### PR TITLE
relative path is broken on linux

### DIFF
--- a/docs/content/library/CsvProvider.fsx
+++ b/docs/content/library/CsvProvider.fsx
@@ -37,7 +37,7 @@ and the next rows define the data. We can pass reference to the file to `CsvProv
 get a strongly typed view of the file:
 *)
 
-type Stocks = CsvProvider<"../data/MSFT.csv">
+type Stocks = CsvProvider< const(__SOURCE_DIRECTORY__ + "/../data/MSFT.csv") >
 
 (**
 The generated type provides two static methods for loading data. The `Parse` method can be


### PR DESCRIPTION
While running script with fsharpi on linux, the relative path resolution is broken.

use **SOURCE_DIRECTORY** to get correct location.
