### PR TITLE
NameUtils/Pluralizer: Fix unusual singularizations for some common words (choices; releases)

### DIFF
--- a/src/CommonRuntime/Pluralizer.fs
+++ b/src/CommonRuntime/Pluralizer.fs
@@ -98,6 +98,7 @@ let private tables = lazy(
          "child",            "children",         ""
          "chassis",          "",                 ""
          "chinese",          "",                 ""
+         "choice",           "choices",          ""
          "clippers",         "",                 ""
          "cod",              "",                 ""
          "codex",            "codices",          ""

--- a/src/CommonRuntime/Pluralizer.fs
+++ b/src/CommonRuntime/Pluralizer.fs
@@ -154,6 +154,7 @@ let private tables = lazy(
          "pro",              "pros",             ""
          "rabies",           "",                 ""
          "radius",           "radiuses",         "radii"
+         "release",          "releases",         ""
          "rhino",            "rhinos",           ""
          "salmon",           "",                 ""
          "scissors",         "",                 ""

--- a/tests/FSharp.Data.Tests/NameUtils.fs
+++ b/tests/FSharp.Data.Tests/NameUtils.fs
@@ -123,6 +123,7 @@ let ``Can pluralize names``() =
    check "index" "indices"
    check "status" "statuses"
    check "release" "releases"
+   check "choice" "choices"
 
 [<Test>]
 let ``Can singularize names``() =
@@ -148,3 +149,4 @@ let ``Can singularize names``() =
    check "indexes" "index"
    check "statuses" "status"
    check "releases" "release"
+   check "choices" "choice"

--- a/tests/FSharp.Data.Tests/NameUtils.fs
+++ b/tests/FSharp.Data.Tests/NameUtils.fs
@@ -122,6 +122,7 @@ let ``Can pluralize names``() =
    check "woman" "women"
    check "index" "indices"
    check "status" "statuses"
+   check "release" "releases"
 
 [<Test>]
 let ``Can singularize names``() =
@@ -146,3 +147,4 @@ let ``Can singularize names``() =
    check "indices" "index"
    check "indexes" "index"
    check "statuses" "status"
+   check "releases" "release"


### PR DESCRIPTION
Currently, "releases" takes the "sis" <-> "ses" suffix rule, and therefore becomes "releasis" when converted from plural to singular.

This patch fixes the problem by adding "release" as a special word, so that `toSingular` correctly resolves the singular form.