### PR TITLE
add ResolutionFolder=__SOURCE_DIRECTORY__ to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Although this project is hosted in the [fsharp](https://github.com/fsharp) repos
 
  [1]: https://github.com/fsharp/FSharp.Data/blob/master/LICENSE.md
  [2]: https://github.com/fsharp/FSharp.Data/tree/master/docs/content
- [3]: http://fsharp.github.io/FSharp.Data/
+ [3]: http://fsprojects.github.io/FSharp.Data/

--- a/docs/content/ja/library/CsvProvider.fsx
+++ b/docs/content/ja/library/CsvProvider.fsx
@@ -41,7 +41,7 @@ Yahoo FinanceのWebサイトでは以下のような構造のCSV形式で
 静的に型付けされた方法でファイルの内容を参照できるようになります：
 *)
 
-type Stocks = CsvProvider<"../../data/MSFT.csv">
+type Stocks = CsvProvider<"../../data/MSFT.csv", ResolutionFolder=__SOURCE_DIRECTORY__>
 
 (**
 生成された型にはデータをロードするための2つのstaticメソッドがあります。
@@ -142,7 +142,7 @@ Chart.Candlestick(recent).WithYAxis(Min = 40.0, Max = 50.0)
 `GetSample` メソッドを使っていることに注意してください。
 *)
 
-let small = CsvProvider<"../../data/SmallTest.csv">.GetSample()
+let small = CsvProvider<"../../data/SmallTest.csv", ResolutionFolder=__SOURCE_DIRECTORY__>.GetSample()
 
 (**
 先ほどの例と同じく、行データは値 `small` の `Rows` プロパティで取得できます。
@@ -178,7 +178,7 @@ CSVの列区切り文字には代わりにセミコロン( `;` )が使われま�
 以下では区切り文字として `;` を使っています：
 *)
 
-let airQuality = CsvProvider<"../../data/AirQuality.csv", ";">.GetSample()
+let airQuality = CsvProvider<"../../data/AirQuality.csv", ";", ResolutionFolder=__SOURCE_DIRECTORY__>.GetSample()
 
 for row in airQuality.Rows do
   if row.Month > 6 then 
@@ -201,7 +201,7 @@ for row in airQuality.Rows do
 末尾に構造化されていないデータが追加されています)：
 *)
 
-let mortalityNy = CsvProvider<"../../data/MortalityNY.tsv", IgnoreErrors=true>.GetSample()
+let mortalityNy = CsvProvider<"../../data/MortalityNY.tsv", IgnoreErrors=true, ResolutionFolder=__SOURCE_DIRECTORY__>.GetSample()
 
 // 原因名をコードで検索
 // (事故で負傷した自転車走者)
@@ -220,7 +220,7 @@ for r in mortalityNy.Rows do
 これはたとえばファイルが不正で、セミコロンかコロンのどちらかで
 行が区切られているような場合に有効です。
 具体的には
-`CsvProvider<"../../data/AirQuality.csv", Separator=";,">`
+`CsvProvider<"../../data/AirQuality.csv", Separator=";,", ResolutionFolder=__SOURCE_DIRECTORY__>`
 というようにします。
 
 ## 値無し
@@ -350,7 +350,7 @@ for row in csv.Rows do
 
 *)
 
-let titanic1 = CsvProvider<"../../data/Titanic.csv", Schema=",,Passenger Class,,,float">.GetSample()
+let titanic1 = CsvProvider<"../../data/Titanic.csv", Schema=",,Passenger Class,,,float", ResolutionFolder=__SOURCE_DIRECTORY__>.GetSample()
 for row in titanic1.Rows do
   printfn "%s Class = %d Fare = %g" row.Name row.``Passenger Class`` row.Fare
 
@@ -360,7 +360,7 @@ for row in titanic1.Rows do
 
 *)
 
-let titanic2 = CsvProvider<"../../data/Titanic.csv", Schema="Fare=float,PClass->Passenger Class">.GetSample()
+let titanic2 = CsvProvider<"../../data/Titanic.csv", Schema="Fare=float,PClass->Passenger Class", ResolutionFolder=__SOURCE_DIRECTORY__>.GetSample()
 for row in titanic2.Rows do
   printfn "%s Class = %d Fare = %g" row.Name row.``Passenger Class`` row.Fare
 

--- a/docs/content/ja/library/JsonProvider.fsx
+++ b/docs/content/ja/library/JsonProvider.fsx
@@ -172,7 +172,7 @@ for item in Values.GetSamples() do
 型を生成した後、同じファイルを読み込んでいます：
 *)
 
-type WorldBank = JsonProvider<"../../data/WorldBank.json">
+type WorldBank = JsonProvider<"../../data/WorldBank.json", ResolutionFolder=__SOURCE_DIRECTORY__>
 let doc = WorldBank.GetSample()
 
 (**
@@ -226,7 +226,7 @@ for record in doc.Array do
 
 *)
 
-type Tweet = JsonProvider<"../../data/TwitterStream.json", SampleIsList=true>
+type Tweet = JsonProvider<"../../data/TwitterStream.json", SampleIsList=true, ResolutionFolder=__SOURCE_DIRECTORY__>
 let text = (*[omit:(omitted)]*)""" {"in_reply_to_status_id_str":null,"text":"\u5927\u91d1\u6255\u3063\u3066\u904a\u3070\u3057\u3066\u3082\u3089\u3046\u3002\u3082\u3046\u3053\u306e\u4e0a\u306a\u3044\u8d05\u6ca2\u3002\u3067\u3082\uff0c\u5b9f\u969b\u306b\u306f\u305d\u306e\u8d05\u6ca2\u306e\u672c\u8cea\u3092\u6e80\u55ab\u3067\u304d\u308b\u4eba\u306f\u9650\u3089\u308c\u3066\u308b\u3002\u305d\u3053\u306b\u76ee\u306b\u898b\u3048\u306a\u3044\u968e\u5c64\u304c\u3042\u308b\u3068\u304a\u3082\u3046\u3002","in_reply_to_user_id_str":null,"retweet_count":0,"geo":null,"source":"web","retweeted":false,"truncated":false,"id_str":"263290764686155776","entities":{"user_mentions":[],"hashtags":[],"urls":[]},"in_reply_to_user_id":null,"in_reply_to_status_id":null,"place":null,"coordinates":null,"in_reply_to_screen_name":null,"created_at":"Tue Oct 30 14:46:24 +0000 2012","user":{"notifications":null,"contributors_enabled":false,"time_zone":"Tokyo","profile_background_color":"FFFFFF","location":"Kodaira Tokyo Japan","profile_background_tile":false,"profile_image_url_https":"https:\/\/si0.twimg.com\/profile_images\/1172376796\/70768_100000537851636_3599485_q_normal.jpg","default_profile_image":false,"follow_request_sent":null,"profile_sidebar_fill_color":"17451B","description":"KS(Green62)\/WasedaUniv.(Schl Adv Sci\/Eng)\/SynBio\/ChronoBio\/iGEM2010-2012\/Travel\/Airplane\/ \u5bfa\u30fb\u5ead\u3081\u3050\u308a","favourites_count":17,"screen_name":"Merlin_wand","profile_sidebar_border_color":"000000","id_str":"94788486","verified":false,"lang":"ja","statuses_count":8641,"profile_use_background_image":true,"protected":false,"profile_image_url":"http:\/\/a0.twimg.com\/profile_images\/1172376796\/70768_100000537851636_3599485_q_normal.jpg","listed_count":31,"geo_enabled":true,"created_at":"Sat Dec 05 13:07:32 +0000 2009","profile_text_color":"000000","name":"Marin","profile_background_image_url":"http:\/\/a0.twimg.com\/profile_background_images\/612807391\/twitter_free1.br.jpg","friends_count":629,"url":null,"id":94788486,"is_translator":false,"default_profile":false,"following":null,"profile_background_image_url_https":"https:\/\/si0.twimg.com\/profile_background_images\/612807391\/twitter_free1.br.jpg","utc_offset":32400,"profile_link_color":"ADADAD","followers_count":426},"id":263290764686155776,"contributors":null,"favorited":false} """(*[/omit]*)
 let tweet = Tweet.Parse(text)
 
@@ -252,7 +252,7 @@ printfn "%s (%d 回リツイートされました)\n:%s"
 *)
 
 // GitHub.json downloaded from https://api.github.com/repos/fsharp/FSharp.Data/issues to prevent rate limit when generating these docs
-type GitHub = JsonProvider<"../../data/GitHub.json">
+type GitHub = JsonProvider<"../../data/GitHub.json", ResolutionFolder=__SOURCE_DIRECTORY__>
 
 let topRecentlyUpdatedIssues = 
     GitHub.GetSamples()

--- a/docs/content/ja/library/XmlProvider.fsx
+++ b/docs/content/ja/library/XmlProvider.fsx
@@ -145,7 +145,7 @@ let authors = """
 データ内の情報を表示することができます：
 *)
 
-type Authors = XmlProvider<"../../data/Writers.xml">
+type Authors = XmlProvider<"../../data/Writers.xml", ResolutionFolder=__SOURCE_DIRECTORY__>
 let topic = Authors.Parse(authors)
 
 printfn "%s" topic.Topic
@@ -190,7 +190,7 @@ for author in topic.Authors do
 このような場合には引数 `Global` に `true` を指定します：
 *)
 
-type Html = XmlProvider<"../../data/HtmlBody.xml", Global=true>
+type Html = XmlProvider<"../../data/HtmlBody.xml", Global=true, ResolutionFolder=__SOURCE_DIRECTORY__>
 let html = Html.GetSample()
 
 (**

--- a/docs/content/library/CsvProvider.fsx
+++ b/docs/content/library/CsvProvider.fsx
@@ -36,7 +36,7 @@ and the next rows define the data. We can pass reference to the file to `CsvProv
 get a strongly typed view of the file:
 *)
 
-type Stocks = CsvProvider<"../data/MSFT.csv">
+type Stocks = CsvProvider<"../data/MSFT.csv", ResolutionFolder=__SOURCE_DIRECTORY__>
 
 (**
 The generated type provides two static methods for loading data. The `Parse` method can be
@@ -127,13 +127,13 @@ a static argument. Also note that in this case we're using the same data at runt
 so we use the `GetSample` method instead of calling `Load` and passing the same parameter again.
 *)
 
-let small = CsvProvider<"../data/SmallTest.csv">.GetSample()
+let small = CsvProvider<"../data/SmallTest.csv", ResolutionFolder=__SOURCE_DIRECTORY__>.GetSample()
 
 (**
 We can also use the default constructor instead of the `GetSample` static method:
 *)
 
-let small2 = new CsvProvider<"../data/SmallTest.csv">()
+let small2 = new CsvProvider<"../data/SmallTest.csv", ResolutionFolder=__SOURCE_DIRECTORY__>()
 
 (**
 but the VisualStudio IntelliSense for the type provider parameters doesn't work when we use a default
@@ -167,7 +167,7 @@ where you can specify what to use as separator. This means that you can consume
 any textual tabular format. Here is an example using `;` as a separator:
 *)
 
-type AirQuality = CsvProvider<"../data/AirQuality.csv", ";">
+type AirQuality = CsvProvider<"../data/AirQuality.csv", ResolutionFolder=__SOURCE_DIRECTORY__, ";">
 
 let airQuality = new AirQuality()
 
@@ -187,7 +187,7 @@ we also set `IgnoreErrors` static parameter to `true` so that lines with incorre
 are automatically skipped (the sample file ([`data/MortalityNY.csv`](../data/MortalityNY.tsv)) contains additional unstructured data at the end):
 *)
 
-let mortalityNy = CsvProvider<"../data/MortalityNY.tsv", IgnoreErrors=true>.GetSample()
+let mortalityNy = CsvProvider<"../data/MortalityNY.tsv", IgnoreErrors=true, ResolutionFolder=__SOURCE_DIRECTORY__>.GetSample()
 
 // Find the name of a cause based on code
 // (Pedal cyclist injured in an accident)
@@ -205,7 +205,7 @@ for r in mortalityNy.Rows do
 Finally, note that it is also possible to specify multiple different separators
 for the `CsvProvider`. This might be useful if a file is irregular and contains
 rows separated by either semicolon or a colon. You can use:
-`CsvProvider<"../data/AirQuality.csv", Separator=";,">`.
+`CsvProvider<"../data/AirQuality.csv", Separator=";,", ResolutionFolder=__SOURCE_DIRECTORY__>`.
 
 ## Missing values
 
@@ -319,7 +319,8 @@ the other columns blank in the schema (you also don't need to add all the traili
 *)
 type Titanic1 =
   CsvProvider<"../data/Titanic.csv",
-    Schema=",,Passenger Class,,,float">
+    Schema=",,Passenger Class,,,float",
+    ResolutionFolder=__SOURCE_DIRECTORY__>
 
 let titanic1 = Titanic1.GetSample()
 for row in titanic1.Rows do
@@ -333,7 +334,8 @@ Alternatively, you can rename and override the type of any column by name instea
 *)
 type Titanic2 =
   CsvProvider<"../data/Titanic.csv",
-    Schema="Fare=float,PClass->Passenger Class">
+    Schema="Fare=float,PClass->Passenger Class",
+    ResolutionFolder=__SOURCE_DIRECTORY__>
 
 let titanic2 = Titanic2.GetSample()
 for row in titanic2.Rows do

--- a/docs/content/library/HtmlProvider.fsx
+++ b/docs/content/library/HtmlProvider.fsx
@@ -35,7 +35,7 @@ Usually with HTML files headers are demarked by using the <th> tag, however in t
 first row is headers. (This behaviour is likely to get smarter in later releases). But it highlights a general problem about HTML's strictness. 
 *)
 
-type F1_2017 = HtmlProvider<"../data/2017_F1.htm">
+type F1_2017 = HtmlProvider<"../data/2017_F1.htm", ResolutionFolder=__SOURCE_DIRECTORY__>
 
 (**
 The generated type provides a type space of tables that it has managed to parse out of the given HTML Document.

--- a/docs/content/library/JsonProvider.fsx
+++ b/docs/content/library/JsonProvider.fsx
@@ -163,7 +163,7 @@ The following sample generates type based on the [`data/WorldBank.json`](../data
 file and loads it:
 *)
 
-type WorldBank = JsonProvider<"../data/WorldBank.json">
+type WorldBank = JsonProvider<"../data/WorldBank.json", ResolutionFolder=__SOURCE_DIRECTORY__>
 let doc = WorldBank.GetSample()
 
 (** Note that we can also load the data directly from the web both in the `Load` method and in
@@ -208,7 +208,7 @@ provider that the sample is actually a _list of samples_:
 
 *)
 
-type Tweet = JsonProvider<"../data/TwitterStream.json", SampleIsList=true>
+type Tweet = JsonProvider<"../data/TwitterStream.json", SampleIsList=true, ResolutionFolder=__SOURCE_DIRECTORY__>
 let text = (*[omit:(omitted)]*)""" {"in_reply_to_status_id_str":null,"text":"\u5927\u91d1\u6255\u3063\u3066\u904a\u3070\u3057\u3066\u3082\u3089\u3046\u3002\u3082\u3046\u3053\u306e\u4e0a\u306a\u3044\u8d05\u6ca2\u3002\u3067\u3082\uff0c\u5b9f\u969b\u306b\u306f\u305d\u306e\u8d05\u6ca2\u306e\u672c\u8cea\u3092\u6e80\u55ab\u3067\u304d\u308b\u4eba\u306f\u9650\u3089\u308c\u3066\u308b\u3002\u305d\u3053\u306b\u76ee\u306b\u898b\u3048\u306a\u3044\u968e\u5c64\u304c\u3042\u308b\u3068\u304a\u3082\u3046\u3002","in_reply_to_user_id_str":null,"retweet_count":0,"geo":null,"source":"web","retweeted":false,"truncated":false,"id_str":"263290764686155776","entities":{"user_mentions":[],"hashtags":[],"urls":[]},"in_reply_to_user_id":null,"in_reply_to_status_id":null,"place":null,"coordinates":null,"in_reply_to_screen_name":null,"created_at":"Tue Oct 30 14:46:24 +0000 2012","user":{"notifications":null,"contributors_enabled":false,"time_zone":"Tokyo","profile_background_color":"FFFFFF","location":"Kodaira Tokyo Japan","profile_background_tile":false,"profile_image_url_https":"https:\/\/si0.twimg.com\/profile_images\/1172376796\/70768_100000537851636_3599485_q_normal.jpg","default_profile_image":false,"follow_request_sent":null,"profile_sidebar_fill_color":"17451B","description":"KS(Green62)\/WasedaUniv.(Schl Adv Sci\/Eng)\/SynBio\/ChronoBio\/iGEM2010-2012\/Travel\/Airplane\/ \u5bfa\u30fb\u5ead\u3081\u3050\u308a","favourites_count":17,"screen_name":"Merlin_wand","profile_sidebar_border_color":"000000","id_str":"94788486","verified":false,"lang":"ja","statuses_count":8641,"profile_use_background_image":true,"protected":false,"profile_image_url":"http:\/\/a0.twimg.com\/profile_images\/1172376796\/70768_100000537851636_3599485_q_normal.jpg","listed_count":31,"geo_enabled":true,"created_at":"Sat Dec 05 13:07:32 +0000 2009","profile_text_color":"000000","name":"Marin","profile_background_image_url":"http:\/\/a0.twimg.com\/profile_background_images\/612807391\/twitter_free1.br.jpg","friends_count":629,"url":null,"id":94788486,"is_translator":false,"default_profile":false,"following":null,"profile_background_image_url_https":"https:\/\/si0.twimg.com\/profile_background_images\/612807391\/twitter_free1.br.jpg","utc_offset":32400,"profile_link_color":"ADADAD","followers_count":426},"id":263290764686155776,"contributors":null,"favorited":false} """(*[/omit]*)
 let tweet = Tweet.Parse(text)
 
@@ -231,7 +231,7 @@ Let's start by listing the 5 most recently updated open issues in the FSharp.Dat
 // GitHub.json downloaded from 
 // https://api.github.com/repos/fsharp/FSharp.Data/issues 
 // to prevent rate limit when generating these docs
-type GitHub = JsonProvider<"../data/GitHub.json">
+type GitHub = JsonProvider<"../data/GitHub.json", ResolutionFolder=__SOURCE_DIRECTORY__>
 
 let topRecentlyUpdatedIssues = 
     GitHub.GetSamples()
@@ -300,7 +300,8 @@ project file). If you are building a library `MyLib.dll`, you can write:
 
 *)
 type WB = JsonProvider<"../data/WorldBank.json", 
-  EmbeddedResource="MyLib, MyLib.data.worldbank.json">
+  EmbeddedResource="MyLib, MyLib.data.worldbank.json",
+  ResolutionFolder=__SOURCE_DIRECTORY__>
 
 (**
 You still need to specify the local path, but this is only used when compiling `MyLib.dll`. 

--- a/docs/content/library/WorldBank.fsx
+++ b/docs/content/library/WorldBank.fsx
@@ -72,7 +72,7 @@ a number of static parameters. If the `Asynchronous` parameter is set to `true` 
 type provider generates all operations as asynchronous:
 *)
 
-type WorldBank = WorldBankDataProvider<"World Development Indicators", Asynchronous=true>
+type WorldBank = WorldBankDataProvider<"World Development Indicators", Asynchronous=true, ResolutionFolder=__SOURCE_DIRECTORY__>
 WorldBank.GetDataContext()
 
 (**

--- a/docs/content/library/XmlProvider.fsx
+++ b/docs/content/library/XmlProvider.fsx
@@ -129,7 +129,7 @@ The `Load` and `AsyncLoad` methods allows reading the data from a file or from a
 `Parse` method takes the data as a string, so we can now print the information as follows:
 *)
 
-type Authors = XmlProvider<"../data/Writers.xml">
+type Authors = XmlProvider<"../data/Writers.xml", ResolutionFolder=__SOURCE_DIRECTORY__>
 let topic = Authors.Parse(authors)
 
 printfn "%s" topic.Topic
@@ -170,7 +170,7 @@ that processes `<div>` elements. To make this possible, you need to set an optio
 parameter `Global` to `true`:
 *)
 
-type Html = XmlProvider<"../data/HtmlBody.xml", Global=true>
+type Html = XmlProvider<"../data/HtmlBody.xml", Global=true, ResolutionFolder=__SOURCE_DIRECTORY__>
 let html = Html.GetSample()
 
 (**
@@ -233,7 +233,7 @@ to infer the schema correctly. For example, the first level `<dct:dataset>` elem
 least twice for the provider to infer the `Datasets` array rather than a single `Dataset` object.
 *)
 
-type Census = XmlProvider<"../data/Census.xml">
+type Census = XmlProvider<"../data/Census.xml", ResolutionFolder=__SOURCE_DIRECTORY__>
 
 let data = Census.Load("https://api.census.gov/data.xml")
 

--- a/nuget/FSharp.Data.3.0.1.nuspec
+++ b/nuget/FSharp.Data.3.0.1.nuspec
@@ -7,7 +7,7 @@
     <authors>Tomas Petricek, Gustavo Guerra, Colin Bull</authors>
     <owners>Tomas Petricek, Gustavo Guerra, Colin Bull</owners>
     <licenseUrl>http://github.com/fsharp/FSharp.Data/blob/master/LICENSE.md</licenseUrl>
-    <projectUrl>http://fsharp.github.io/FSharp.Data</projectUrl>
+    <projectUrl>http://fsprojects.github.io/FSharp.Data</projectUrl>
     <iconUrl>https://raw.github.com/fsharp/FSharp.Data/master/misc/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Library of F# type providers and data access tools</summary>

--- a/nuget/FSharp.Data.nuspec
+++ b/nuget/FSharp.Data.nuspec
@@ -7,7 +7,7 @@
     <authors>@authors@</authors>
     <owners>@authors@</owners>
     <license type="expression">Apache-2.0</license>
-    <projectUrl>http://fsharp.github.io/FSharp.Data</projectUrl>
+    <projectUrl>http://fsprojects.github.io/FSharp.Data</projectUrl>
     <iconUrl>https://raw.github.com/fsharp/FSharp.Data/master/misc/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>@summary@</summary>

--- a/performanceAnalysis.fsx
+++ b/performanceAnalysis.fsx
@@ -4,7 +4,7 @@
 open FSharp.Data
 open FSharp.Charting
 
-type Times = CsvProvider<"log.csv",Separators="|",IgnoreErrors=true,Schema="category,instance,time",HasHeaders=false>
+type Times = CsvProvider<"log.csv",Separators="|",IgnoreErrors=true,Schema="category,instance,time",HasHeaders=false, ResolutionFolder=__SOURCE_DIRECTORY__>
 
 let byCategory = 
     Times.GetSample().Rows

--- a/tests/FSharp.Data.Tests/HtmlCharRefs.fs
+++ b/tests/FSharp.Data.Tests/HtmlCharRefs.fs
@@ -27,12 +27,12 @@ let ``Should substitute char references``(ref:string, result:string) =
 
 [<Test>]
 let ``Should substitute char references in attribute``() = 
-    let html = """<a href="/url?q=http://fsharp.github.io/FSharp.Data/&amp;sa=U&amp;ei=sv1jU_3bMMmk0QX33YGQBw&amp;ved=0CB4QFjAA&amp;usg=AFQjCNF_2exXvCWzixA0Uj58KLThvXYUwA"><b>F# Data</b>: Library for Data Access - F# Open Source Group @ GitHub</a>"""
+    let html = """<a href="/url?q=http://fsprojects.github.io/FSharp.Data/&amp;sa=U&amp;ei=sv1jU_3bMMmk0QX33YGQBw&amp;ved=0CB4QFjAA&amp;usg=AFQjCNF_2exXvCWzixA0Uj58KLThvXYUwA"><b>F# Data</b>: Library for Data Access - F# Open Source Group @ GitHub</a>"""
     let parsed = HtmlDocument.Parse html
     let expected = 
         HtmlDocument.New(
          [
-           HtmlNode.NewElement("a", ["href", "/url?q=http://fsharp.github.io/FSharp.Data/&sa=U&ei=sv1jU_3bMMmk0QX33YGQBw&ved=0CB4QFjAA&usg=AFQjCNF_2exXvCWzixA0Uj58KLThvXYUwA"],
+           HtmlNode.NewElement("a", ["href", "/url?q=http://fsprojects.github.io/FSharp.Data/&sa=U&ei=sv1jU_3bMMmk0QX33YGQBw&ved=0CB4QFjAA&usg=AFQjCNF_2exXvCWzixA0Uj58KLThvXYUwA"],
             [
                HtmlNode.NewElement("b", [HtmlNode.NewText "F# Data"])
                HtmlNode.NewText ": Library for Data Access - F# Open Source Group @ GitHub"


### PR DESCRIPTION

Because of https://github.com/fsprojects/FSharp.Data/issues/1340 and https://github.com/fsprojects/FSharp.Data/issues/1306 we should just ask people to add `ResolutionFolder=__SOURCE_DIRECTORY__` to all examples that use relative path names.


