### PR TITLE
update docs

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,4 +2,4 @@
 
 dotnet tool restore
 dotnet paket restore
-dotnet fake build -t Build
+dotnet fake build  %*

--- a/build.fsx
+++ b/build.fsx
@@ -32,9 +32,9 @@ let project = "FSharp.Data"
 let authors = "Tomas Petricek;Gustavo Guerra;Colin Bull;fsprojects contributors"
 let summary = "Library of F# type providers and data access tools"
 let description = """
-  The FSharp.Data library (FSharp.Data.dll) contains type providers and utilities to access
-  common data formats in your F# applications and scripts. It contains F# type providers for working with
-  structured file formats (CSV, HTML, JSON and XML) and helpers for parsing CSV, HTML and JSON files and for sending HTTP requests."""
+  The FSharp.Data package contains type providers and utilities to access
+  common data formats (CSV, HTML, JSON and XML in your F# applications and scripts. It also
+  contains  helpers for parsing CSV, HTML and JSON files and for sending HTTP requests."""
 let tags = "F# fsharp data typeprovider WorldBank CSV HTML CSS JSON XML HTTP linqpad-samples"
 
 let gitOwner = "fsprojects"

--- a/docs/ja/library/CsvFile.fsx
+++ b/docs/ja/library/CsvFile.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/ja/library/CsvProvider.fsx
+++ b/docs/ja/library/CsvProvider.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/ja/library/Http.fsx
+++ b/docs/ja/library/Http.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/ja/library/JsonProvider.fsx
+++ b/docs/ja/library/JsonProvider.fsx
@@ -1,5 +1,5 @@
 ﻿(*** condition: prepare ***)
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/ja/library/JsonValue.fsx
+++ b/docs/ja/library/JsonValue.fsx
@@ -1,5 +1,5 @@
 ﻿(*** condition: prepare ***)
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/ja/library/WorldBank.fsx
+++ b/docs/ja/library/WorldBank.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/ja/library/XmlProvider.fsx
+++ b/docs/ja/library/XmlProvider.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/ja/tutorials/JsonAnonymizer.fsx
+++ b/docs/ja/tutorials/JsonAnonymizer.fsx
@@ -21,7 +21,7 @@ JSON匿名化機能をコード内で利用したい場合には、
 
 *)
 
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 open System
 open System.Globalization
 open FSharp.Data

--- a/docs/ja/tutorials/JsonToXml.fsx
+++ b/docs/ja/tutorials/JsonToXml.fsx
@@ -25,7 +25,7 @@ JSONとXML間の変換を自身のコードで使いたい場合には
 *)
 
 #r "System.Xml.Linq.dll"
-#r "../../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 open System.Xml.Linq
 open FSharp.Data
 

--- a/docs/library/CsvFile.fsx
+++ b/docs/library/CsvFile.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/library/CsvProvider.fsx
+++ b/docs/library/CsvProvider.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/library/HtmlCssSelectors.fsx
+++ b/docs/library/HtmlCssSelectors.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/library/HtmlParser.fsx
+++ b/docs/library/HtmlParser.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/library/HtmlProvider.fsx
+++ b/docs/library/HtmlProvider.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/library/HtmlProvider.fsx
+++ b/docs/library/HtmlProvider.fsx
@@ -142,7 +142,7 @@ let doctorWho = new HtmlProvider<DrWho>()
 
 // Get the average number of viewers for each doctor's series run
 let viewersByDoctor = 
-  doctorWho.Tables.``Season 13 (1975-1976)``.Rows
+  doctorWho.Tables.``Season 1 (1963-1964) Edit``.Rows
   |> Seq.groupBy (fun season -> season.``Directed by``)
   |> Seq.map (fun (doctor, seasons) -> 
       let averaged = 

--- a/docs/library/Http.fsx
+++ b/docs/library/Http.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/library/JsonProvider.fsx
+++ b/docs/library/JsonProvider.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/library/JsonValue.fsx
+++ b/docs/library/JsonValue.fsx
@@ -17,7 +17,7 @@ To load a sample JSON document, we first need to reference the `FSharp.Data.dll`
 (when using F# Interactive) or to add reference to a project. 
 *)
 
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 open FSharp.Data
 
 (**

--- a/docs/library/WorldBank.fsx
+++ b/docs/library/WorldBank.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/library/XmlProvider.fsx
+++ b/docs/library/XmlProvider.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/tutorials/JsonAnonymizer.fsx
+++ b/docs/tutorials/JsonAnonymizer.fsx
@@ -1,5 +1,5 @@
 (*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/docs/tutorials/JsonToXml.fsx
+++ b/docs/tutorials/JsonToXml.fsx
@@ -1,5 +1,5 @@
 ﻿(*** condition: prepare ***)
-#r "../../bin/lib/netstandard2.0/FSharp.Data.dll"
+#r "../../src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: FSharp.Data,{{fsdocs-package-version}}"

--- a/src/CommonProviderImplementation/Helpers.fs
+++ b/src/CommonProviderImplementation/Helpers.fs
@@ -180,19 +180,25 @@ module internal ProviderHelpers =
             | _ -> None
         | _ -> None
 
+    /// <summary>
     /// Reads a sample parameter for a type provider, detecting if it is a uri and fetching it if needed
-    /// Samples from the web are cached for 30 minutes
+    /// </summary>
+    /// <remarks>
+    /// Samples from the web are cached for 30 minutes. 
     /// Samples from the filesystem are read using shared read, so it works when the file is locked by Excel or similar tools,
+    /// </remarks>
     /// 
-    /// Parameters:
-    /// * valueToBeParsedOrItsUri - the text which can be a sample or an uri for a sample
-    /// * parseFunc - receives the file/url extension (or ""  if not applicable) and the text value 
-    /// * formatName - the description of what is being parsed (for the error message)
-    /// * tp - the type provider
-    /// * cfg - the type provider config
-    /// * resource - when specified, we first try to treat read the sample from an embedded resource
-    ///     (the value specified assembly and resource name e.g. "MyCompany.MyAssembly, some_resource.json")
-    /// * resolutionFolder - if the type provider allows to override the resolutionFolder pass it here
+    /// <param name="valueToBeParsedOrItsUri">the text which can be a sample or an uri for a sample</param>
+    /// <param name="parseFunc">receives the file/url extension (or ""  if not applicable) and the text value </param>
+    /// <param name="formatName">the description of what is being parsed (for the error message)</param>
+    /// <param name="tp">the type provider</param>
+    /// <param name="cfg">the type provider config</param>
+    /// <param name="resource">when specified, we first try to treat read the sample from an embedded resource
+    ///     (the value specified assembly and resource name e.g. "MyCompany.MyAssembly, some_resource.json")</param>
+    /// <param name="resolutionFolder">if the type provider allows to override the resolutionFolder pass it here</param>
+    /// <param name="encodingStr"></param>
+    /// <param name="fullTypeName"></param>
+    /// <param name="maxNumberOfRows"></param>
     let private parseTextAtDesignTime valueToBeParsedOrItsUri parseFunc formatName (tp:DisposableTypeProviderForNamespaces) 
                                       (cfg:TypeProviderConfig) encodingStr resolutionFolder resource fullTypeName maxNumberOfRows =
     
@@ -358,16 +364,16 @@ module internal ProviderHelpers =
     | Schema of string
 
     /// Creates all the constructors for a type provider: (Async)Parse, (Async)Load, (Async)GetSample(s), and default constructor
-    /// * source - the sample/sample list/schema from which the types will be generated
-    /// * getSpec - receives the file/url extension (or ""  if not applicable) and the text value of the sample or schema
-    /// * tp - the type provider
-    /// * cfg - the type provider config
-    /// * encodingStr - the encoding to be used when reading the sample or schema
-    /// * resolutionFolder -> if the type provider allows to override the resolutionFolder pass it here
-    /// * resource - when specified, we first try to treat read the sample from an embedded resource
-    ///     (the value specifies assembly and resource name e.g. "MyCompany.MyAssembly, some_resource.json")
-    /// * fullTypeName - the full name of the type provider, this will be used as the caching key
-    /// * maxNumberOfRows - the max number of rows to read from the sample or schema
+    /// <param name="source">the sample/sample list/schema from which the types will be generated</param>
+    /// <param name="getSpec">receives the file/url extension (or ""  if not applicable) and the text value of the sample or schema</param>
+    /// <param name="tp">the type provider</param>
+    /// <param name="cfg">the type provider config</param>
+    /// <param name="encodingStr">the encoding to be used when reading the sample or schema</param>
+    /// <param name="resolutionFolder -> if the type provider allows to override the resolutionFolder pass it here</param>
+    /// <param name="resource">when specified, we first try to treat read the sample from an embedded resource</param>
+    ///     (the value specifies assembly and resource name e.g. "MyCompany.MyAssembly, some_resource.json")</param>
+    /// <param name="fullTypeName">the full name of the type provider, this will be used as the caching key</param>
+    /// <param name="maxNumberOfRows">the max number of rows to read from the sample or schema</param>
     let generateType formatName source getSpec
                      (tp:DisposableTypeProviderForNamespaces) (cfg:TypeProviderConfig) 
                      encodingStr resolutionFolder resource fullTypeName maxNumberOfRows  =

--- a/src/CommonRuntime/NameUtils.fs
+++ b/src/CommonRuntime/NameUtils.fs
@@ -1,4 +1,4 @@
-﻿/// Tools for generating nice member names that follow F# & .NET naming conventions
+/// Tools for generating nice member names that follow F# & .NET naming conventions
 module FSharp.Data.Runtime.NameUtils
 
 open System
@@ -62,7 +62,7 @@ let niceCamelName (s:string) =
     name.[0].ToString().ToLowerInvariant() + name.Substring(1)
   else name
 
-/// Given a function to format names (such as `niceCamelName` or `nicePascalName`)
+/// Given a function to format names (such as 'niceCamelName' or 'nicePascalName')
 /// returns a name generator that never returns duplicate name (by appending an
 /// index to already used names)
 /// 

--- a/src/Csv/CsvFile.fs
+++ b/src/Csv/CsvFile.fs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------
 // Untyped CSV api
 // --------------------------------------------------------------------------------------
 
@@ -29,13 +29,15 @@ type CsvRow(parent:CsvFile, columns:string[]) =
   /// Gets a column by name
   member __.Item with get columnName = columns.[parent.GetColumnIndex columnName]
 
-/// Represents a CSV file. The lines are read on demand from `reader`.
-/// Columns are delimited by one of the chars passed by `separators` (defaults to just `,`), and
-/// to escape the separator chars, the `quote` character will be used (defaults to `"`).
-/// If `hasHeaders` is true (the default), the first line read by `reader` will not be considered part of data.
-/// If `ignoreErrors` is true (the default is false), rows with a different number of columns from the header row
+/// <summary>
+/// Represents a CSV file. The lines are read on demand from <c>reader</c>.
+/// Columns are delimited by one of the chars passed by <c>separators</c> (defaults to just <c>,</c>), and
+/// to escape the separator chars, the <c>quote</c> character will be used (defaults to <c>"</c>).
+/// If <c>hasHeaders</c> is true (the default), the first line read by <c>reader</c> will not be considered part of data.
+/// If <c>ignoreErrors</c> is true (the default is false), rows with a different number of columns from the header row
 /// (or the first row if headers are not present) will be ignored.
-/// The first `skipRows` lines will be skipped.
+/// The first <c>skipRows</c> lines will be skipped.
+/// </summary>
 and CsvFile private (readerFunc:Func<TextReader>, [<Optional>] ?separators, [<Optional>] ?quote, [<Optional>] ?hasHeaders, [<Optional>] ?ignoreErrors, [<Optional>] ?skipRows) as this =
   inherit CsvFile<CsvRow>(
     Func<_,_,_>(fun this columns -> CsvRow(this :?> CsvFile, columns)),

--- a/src/Csv/CsvInference.fs
+++ b/src/Csv/CsvInference.fs
@@ -1,4 +1,4 @@
-﻿/// Structural inference for CSV
+/// Structural inference for CSV
 module FSharp.Data.Runtime.CsvInference
 
 open System
@@ -58,8 +58,10 @@ type private SchemaParseResult =
 
 let private asOption = function true, x -> Some x | false, _ -> None
 
+/// <summary>
 /// Parses type specification in the schema for a single column. 
-/// This can be of the form: type|measure|type<measure>
+/// This can be of the form: <c>type|measure|type&lt;measure&gt;</c>
+/// </summary>
 let private parseTypeAndUnit unitsOfMeasureProvider str = 
   let m = typeAndUnitRegex.Value.Match(str)
   if m.Success then
@@ -323,15 +325,16 @@ let internal inferColumnTypes headerNamesAndUnits schema rows inferRows missingV
     ||> getFields preferOptionals
 
 type CsvFile with
+    /// <summary>
     /// Infers the types of the columns of a CSV file
-    /// Parameters:
-    /// * inferRows - Number of rows to use for inference. If this is zero, all rows are used
-    /// * missingValues - The set of strings recogized as missing values
-    /// * cultureInfo - The culture used for parsing numbers and dates
-    /// * schema - Optional column types, in a comma separated list. Valid types are "int", "int64", "bool", "float", "decimal", "date", "timespan", "guid", "string", "int?", "int64?", "bool?", "float?", "decimal?", "date?", "guid?", "int option", "int64 option", "bool option", "float option", "decimal option", "date option", "guid option" and "string option". You can also specify a unit and the name of the column like this: Name (type&lt;unit&gt;). You can also override only the name. If you don't want to specify all the columns, you can specify by name like this: 'ColumnName=type'
-    /// * assumeMissingValues - Assumes all columns can have missing values
-    /// * preferOptionals - when set to true, inference will prefer to use the option type instead of nullable types, double.NaN or "" for missing values
-    /// * unitsOfMeasureProvider - optional function to resolve Units of Measure
+    /// </summary>
+    /// <param name="inferRows"> - Number of rows to use for inference. If this is zero, all rows are used</param>
+    /// <param name="missingValues"> - The set of strings recogized as missing values</param>
+    /// <param name="cultureInfo"> - The culture used for parsing numbers and dates</param>
+    /// <param name="schema"> - Optional column types, in a comma separated list. Valid types are "int", "int64", "bool", "float", "decimal", "date", "timespan", "guid", "string", "int?", "int64?", "bool?", "float?", "decimal?", "date?", "guid?", "int option", "int64 option", "bool option", "float option", "decimal option", "date option", "guid option" and "string option". You can also specify a unit and the name of the column like this: Name (type&lt;unit&gt;). You can also override only the name. If you don't want to specify all the columns, you can specify by name like this: 'ColumnName=type'</param>
+    /// <param name="assumeMissingValues"> - Assumes all columns can have missing values</param>
+    /// <param name="preferOptionals"> - when set to true, inference will prefer to use the option type instead of nullable types, double.NaN or "" for missing values</param>
+    /// <param name="unitsOfMeasureProvider"> - optional function to resolve Units of Measure</param>
     member x.InferColumnTypes(inferRows, missingValues, cultureInfo, schema, assumeMissingValues, preferOptionals, [<Optional>] ?unitsOfMeasureProvider) =
         let unitsOfMeasureProvider = defaultArg unitsOfMeasureProvider defaultUnitsOfMeasureProvider
         let headerNamesAndUnits, schema = parseHeaders x.Headers x.NumberOfColumns schema unitsOfMeasureProvider

--- a/src/Html/HtmlOperations.fs
+++ b/src/Html/HtmlOperations.fs
@@ -60,10 +60,11 @@ module HtmlNode =
         | HtmlElement(elements = elements) -> elements
         | _ -> []
 
+    /// <summary>
     /// Finds all of the elements nodes of this node that match the given set of names
-    /// Parameters:
-    ///  * names - The set of names to match
-    ///  * n - The given node
+    /// </summary>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="n">The given node</param>
     let inline elementsNamed names n = 
         let nameSet = getNameSet names
         n |> elements |> List.filter (name >> nameSet.Contains)
@@ -81,38 +82,42 @@ module HtmlNode =
         }
         descendantsBy includeSelf n
 
+    /// <summary>
     /// Gets all of the descendants of this node that statisfy the given predicate
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * predicate - The predicate by which to match the nodes to return
-    /// * n - The given node
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
+    /// <param name="n">The given node</param>
     let descendants recurseOnMatch predicate n =
         descendantsBy false recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of this node that statisfy the given predicate
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * predicate - The predicate by which to match the nodes to return
-    /// * n - The given node
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
+    /// <param name="n">The given node</param>
     let descendantsAndSelf recurseOnMatch predicate n =
         descendantsBy true recurseOnMatch predicate n
     
+    /// <summary>
     /// Finds all of the descendant nodes of this nodes that match the given set of names
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * names - The set of names to match
-    /// * n - The given node
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="n">The given node</param>
     let inline descendantsNamed recurseOnMatch names n = 
         let nameSet = getNameSet names
         n |> descendants recurseOnMatch (name >> nameSet.Contains)
 
+    /// <summary>
     /// Finds all of the descendant nodes of this nodes that match the given set of names
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * names - The set of names to match
-    /// * n - The given node
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="n">The given node</param>
     let inline descendantsAndSelfNamed recurseOnMatch names n = 
         let nameSet = getNameSet names
         n |> descendantsAndSelf recurseOnMatch (name >> nameSet.Contains)
@@ -130,38 +135,42 @@ module HtmlNode =
         }
         descendantsByWithPath includeSelf [] n
     
+    /// <summary>
     /// Gets all of the descendants of this node that statisfy the given predicate
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * predicate - The predicate by which to match the nodes to return
-    /// * n - The given node
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
+    /// <param name="n">The given node</param>
     let descendantsWithPath recurseOnMatch predicate n = 
         descendantsByWithPath false recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of this node that statisfy the given predicate
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * predicate - The predicate by which to match the nodes to return
-    /// * n - The given node
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
+    /// <param name="n">The given node</param>
     let descendantsAndSelfWithPath recurseOnMatch predicate n = 
         descendantsByWithPath true recurseOnMatch predicate n
 
+    /// <summary>
     /// Finds all of the descendant nodes of this nodes that match the given set of names
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * names - The set of names to match
-    /// * n - The given node
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="n">The given node</param>
     let inline descendantsNamedWithPath recurseOnMatch names n = 
         let nameSet = getNameSet names
         n |> descendantsWithPath recurseOnMatch (name >> nameSet.Contains)
 
+    /// <summary>
     /// Finds all of the descendant nodes of this nodes that match the given set of names
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * names - The set of names to match
-    /// * n - The given node
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="n">The given node</param>
     let inline descendantsAndSelfNamedWithPath recurseOnMatch names n = 
         let nameSet = getNameSet names
         n |> descendantsAndSelfWithPath recurseOnMatch (name >> nameSet.Contains)
@@ -172,35 +181,40 @@ module HtmlNode =
         | HtmlElement(attributes = attributes) -> attributes
         | _ -> []
 
+    /// <summary>
     /// Tries to return an attribute that exists on the current node
-    /// Parameters:
-    /// * name - The name of the attribute to return.
+    /// </summary>
+    /// <param name="name">The name of the attribute to return.</param>
+    /// <param name="n">The given node</param>
     let inline tryGetAttribute name n =
         n |> attributes |> List.tryFind (HtmlAttribute.name >> ((=) (toLower name)))
     
+    /// <summary>
     /// Returns the attribute with the given name. If the
     /// attribute does not exist then this will throw an exception
-    /// Parameters:
-    /// * name - The name of the attribute to select
-    /// * n - The given node
+    /// </summary>
+    /// <param name="name">The name of the attribute to select</param>
+    /// <param name="n">The given node</param>
     let inline attribute name n = 
         match tryGetAttribute name n with
         | Some v -> v
         | None -> failwithf "Unable to find attribute (%s)" name
 
+    /// <summary>
     /// Return the value of the named attribute, or an empty string if not found.
-    /// Parameters:
-    /// * name - The name of the attribute to get the value from
-    /// * n - The given node
+    /// </summary>
+    /// <param name="name">The name of the attribute to get the value from</param>
+    /// <param name="n">The given node</param>
     let inline attributeValue name n = 
         defaultArg (n |> tryGetAttribute name |> Option.map HtmlAttribute.value) ""
 
+    /// <summary>
     /// Returns true if the current node has an attribute that
     /// matches both the name and the value
-    /// Parameters:
-    /// * name - The name of the attribute
-    /// * value - The value of the attribute
-    /// * x - The given html node
+    /// </summary>
+    /// <param name="name">The name of the attribute</param>
+    /// <param name="value">The value of the attribute</param>
+    /// <param name="n">The given html node</param>
     let inline hasAttribute name value n = 
         match tryGetAttribute name n with
         | Some attr -> toLower (HtmlAttribute.value attr) = toLower value
@@ -250,15 +264,17 @@ module HtmlNode =
     let innerTextExcluding exclusions n =
         innerTextExcluding' true exclusions n
 
+    /// <summary>
     /// Returns the inner text of the current node
-    /// Parameters:
-    /// * n - The given node
+    /// </summary>
+    /// <param name="n">The given node</param>
     let inline innerText n = 
         innerTextExcluding [] n
 
+    /// <summary>
     /// Returns the direct inner text of the current node
-    /// Parameters:
-    /// * n - The given node
+    /// </summary>
+    /// <param name="n">The given node</param>
     let directInnerText n = 
         innerTextExcluding' false [] n
 
@@ -454,51 +470,63 @@ type HtmlNodeExtensions =
     static member Elements(n:HtmlNode) = 
         HtmlNode.elements n
 
+    /// <summary>
     /// Gets all of the elements of the current node, which match the given set of names
-    /// Parameters:
-    /// * names - The set of names by which to map the elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the elements</param>
     [<Extension>]
     static member Elements(n:HtmlNode, names:seq<string>) = 
         HtmlNode.elementsNamed names n
 
+    /// <summary>
     /// Gets all of the elements of the current node, which match the given name
-    /// Parameters:
-    /// * names - The name by which to map the elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name by which to map the elements</param>
     [<Extension>]
     static member Elements(n:HtmlNode, name:string) = 
         HtmlNode.elementsNamed [name] n
         
+    /// <summary>
     /// Gets all of the descendants of the current node that satisfy the predicate
-    /// Parameters:
-    /// * predicate - The predicate for which descendants to return
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="predicate">The predicate for which descendants to return</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member Descendants(n:HtmlNode, predicate, recurseOnMatch) = 
         HtmlNode.descendants recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of the current node that satisfy the predicate
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * predicate - The predicate for which descendants to return
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="predicate">The predicate for which descendants to return</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsAndSelf(n:HtmlNode, predicate, recurseOnMatch) = 
         HtmlNode.descendantsAndSelf recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of the current node that satisfy the predicate
     /// Recurses on match
-    /// Parameters:
-    /// * predicate - The predicate for which descendants to return
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="predicate">The predicate for which descendants to return</param>
     [<Extension>]
     static member Descendants(n:HtmlNode, predicate) = 
         let recurseOnMatch = true
         HtmlNode.descendants recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of the current node that satisfy the predicate
     /// The current node is also considered in the comparison
     /// Recurses on match
-    /// Parameters:
-    /// * predicate - The predicate for which descendants to return
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="predicate">The predicate for which descendants to return</param>
     [<Extension>]
     static member DescendantsAndSelf(n:HtmlNode, predicate) = 
         let recurseOnMatch = true
@@ -521,109 +549,133 @@ type HtmlNodeExtensions =
         let predicate = fun _ -> true
         HtmlNode.descendantsAndSelf recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given set of names
-    /// Parameters:
-    /// * names - The set of names by which to map the descendants
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the descendants</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member Descendants(n:HtmlNode, names:seq<string>, recurseOnMatch) = 
         HtmlNode.descendantsNamed recurseOnMatch names n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given set of names
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * names - The set of names by which to map the descendants
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the descendants</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsAndSelf(n:HtmlNode, names:seq<string>, recurseOnMatch) = 
         HtmlNode.descendantsAndSelfNamed recurseOnMatch names n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given set of names
     /// Recurses on match
-    /// Parameters:
-    /// * names - The set of names by which to map the descendants
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the descendants</param>
     [<Extension>]
     static member Descendants(n:HtmlNode, names:seq<string>) = 
         let recurseOnMatch = true
         HtmlNode.descendantsNamed recurseOnMatch names n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given set of names
     /// The current node is also considered in the comparison
     /// Recurses on match
-    /// Parameters:
-    /// * names - The set of names by which to map the descendants
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the descendants</param>
     [<Extension>]
     static member DescendantsAndSelf(n:HtmlNode, names:seq<string>) = 
         let recurseOnMatch = true
         HtmlNode.descendantsAndSelfNamed recurseOnMatch names n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given name
-    /// Parameters:
-    /// * name - The name by which to map the descendants
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name by which to map the descendants</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member Descendants(n:HtmlNode, name:string, recurseOnMatch) = 
         HtmlNode.descendantsNamed recurseOnMatch [name] n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given name
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * name - The name by which to map the descendants
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name by which to map the descendants</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsAndSelf(n:HtmlNode, name:string, recurseOnMatch) = 
         HtmlNode.descendantsAndSelfNamed recurseOnMatch [name] n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given name
     /// Recurses on match
-    /// Parameters:
-    /// * name - The name by which to map the descendants
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name by which to map the descendants</param>
     [<Extension>]
     static member Descendants(n:HtmlNode, name:string) = 
         let recurseOnMatch = true
         HtmlNode.descendantsNamed recurseOnMatch [name] n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given name
     /// The current node is also considered in the comparison
     /// Recurses on match
-    /// Parameters:
-    /// * name - The name by which to map the descendants
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name by which to map the descendants</param>
     [<Extension>]
     static member DescendantsAndSelf(n:HtmlNode, name:string) = 
         let recurseOnMatch = true
         HtmlNode.descendantsAndSelfNamed recurseOnMatch [name] n   
 
+    /// <summary>
     /// Gets all of the descendants of the current node that satisfy the predicate
-    /// Parameters:
-    /// * predicate - The predicate for which descendants to return
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="predicate">The predicate for which descendants to return</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsWithPath(n:HtmlNode, predicate, recurseOnMatch) = 
         HtmlNode.descendantsWithPath recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of the current node that satisfy the predicate
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * predicate - The predicate for which descendants to return
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="predicate">The predicate for which descendants to return</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsAndSelfWithPath(n:HtmlNode, predicate, recurseOnMatch) = 
         HtmlNode.descendantsAndSelfWithPath recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of the current node that satisfy the predicate
     /// Recurses on match
-    /// Parameters:
-    /// * predicate - The predicate for which descendants to return
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="predicate">The predicate for which descendants to return</param>
     [<Extension>]
     static member DescendantsWithPath(n:HtmlNode, predicate) = 
         let recurseOnMatch = true
         HtmlNode.descendantsWithPath recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of the current node that satisfy the predicate
     /// The current node is also considered in the comparison
     /// Recurses on match
-    /// Parameters:
-    /// * predicate - The predicate for which descendants to return
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="predicate">The predicate for which descendants to return</param>
     [<Extension>]
     static member DescendantsAndSelfWithPath(n:HtmlNode, predicate) = 
         let recurseOnMatch = true
@@ -646,73 +698,89 @@ type HtmlNodeExtensions =
         let predicate = fun _ -> true
         HtmlNode.descendantsAndSelfWithPath recurseOnMatch predicate n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given set of names
-    /// Parameters:
-    /// * names - The set of names by which to map the descendants
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the descendants</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsWithPath(n:HtmlNode, names:seq<string>, recurseOnMatch) = 
         HtmlNode.descendantsNamedWithPath recurseOnMatch names n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given set of names
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * names - The set of names by which to map the descendants
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the descendants</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsAndSelfWithPath(n:HtmlNode, names:seq<string>, recurseOnMatch) = 
         HtmlNode.descendantsAndSelfNamedWithPath recurseOnMatch names n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given set of names
     /// Recurses on match
-    /// Parameters:
-    /// * names - The set of names by which to map the descendants
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the descendants</param>
     [<Extension>]
     static member DescendantsWithPath(n:HtmlNode, names:seq<string>) = 
         let recurseOnMatch = true
         HtmlNode.descendantsNamedWithPath recurseOnMatch names n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given set of names
     /// The current node is also considered in the comparison
     /// Recurses on match
-    /// Parameters:
-    /// * names - The set of names by which to map the descendants
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="names">The set of names by which to map the descendants</param>
     [<Extension>]
     static member DescendantsAndSelfWithPath(n:HtmlNode, names:seq<string>) = 
         let recurseOnMatch = true
         HtmlNode.descendantsAndSelfNamedWithPath recurseOnMatch names n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given name
-    /// Parameters:
-    /// * name - The name by which to map the descendants
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name by which to map the descendants</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsWithPath(n:HtmlNode, name:string, recurseOnMatch) = 
         HtmlNode.descendantsNamedWithPath recurseOnMatch [name] n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given name
     /// The current node is also considered in the comparison
-    /// Parameters:
-    /// * name - The name by which to map the descendants
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name by which to map the descendants</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsAndSelfWithPath(n:HtmlNode, name:string, recurseOnMatch) = 
         HtmlNode.descendantsAndSelfNamedWithPath recurseOnMatch [name] n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given name
     /// Recurses on match
-    /// Parameters:
-    /// * name - The names by which to map the descendants
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The names by which to map the descendants</param>
     [<Extension>]
     static member DescendantsWithPath(n:HtmlNode, name:string) = 
         let recurseOnMatch = true
         HtmlNode.descendantsNamedWithPath recurseOnMatch [name] n
 
+    /// <summary>
     /// Gets all of the descendants of the current node, which match the given name
     /// The current node is also considered in the comparison
     /// Recurses on match
-    /// Parameters:
-    /// * name - The names by which to map the descendants
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The names by which to map the descendants</param>
     [<Extension>]
     static member DescendantsAndSelfWithPath(n:HtmlNode, name:string) = 
         let recurseOnMatch = true
@@ -723,33 +791,41 @@ type HtmlNodeExtensions =
     static member Attributes(n:HtmlNode) = 
         HtmlNode.attributes n
 
+    /// <summary>
     /// Tries to select an attribute with the given name from the current node.
-    /// Parameters:
-    /// * name - The name of the attribute to select
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name of the attribute to select</param>
     [<Extension>]
     static member TryGetAttribute(n:HtmlNode, name:string) = 
         HtmlNode.tryGetAttribute name n
 
+    /// <summary>
     /// Returns the attribute with the given name. If the
     /// attribute does not exist then this will throw an exception
-    /// Parameters:
-    /// * name - The name of the attribute to select
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name of the attribute to select</param>
     [<Extension>]
     static member Attribute(n:HtmlNode, name) = 
         HtmlNode.attribute name n
 
+    /// <summary>
     /// Return the value of the named attribute, or an empty string if not found.
-    /// Parameters:
-    /// * name - The name of the attribute to get the value from
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name of the attribute to get the value from</param>
     [<Extension>]
     static member AttributeValue(n:HtmlNode, name) =
       HtmlNode.attributeValue name n
 
+    /// <summary>
     /// Returns true if the current node has an attribute that
     /// matches both the name and the value
-    /// Parameters:
-    /// * name - The name of the attribute
-    /// * value - The value of the attribute
+    /// </summary>
+    /// <param name="n">The given node</param>
+    /// <param name="name">The name of the attribute</param>
+    /// <param name="value">The value of the attribute</param>
     [<Extension>]
     static member HasAttribute(n:HtmlNode, name, value) = 
         HtmlNode.hasAttribute name value n
@@ -795,77 +871,86 @@ module HtmlDocument =
         match doc with
         | HtmlDocument(elements = elements) -> elements
                 
+    /// <summary>
     /// Returns all of the root elements of the document that match the set of names
-    /// Parameters:
-    /// * names - The set of names to match
-    /// * doc - The given document
+    /// </summary>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="doc">The given document</param>
     let inline elementsNamed names doc = 
         let nameSet = getNameSet names
         doc |> elements |> List.filter (HtmlNode.name >> nameSet.Contains)
 
+    /// <summary>
     /// Gets all of the descendants of this document that statisfy the given predicate
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * predicate - The predicate by which to match the nodes to return
-    /// * doc - The given document
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
+    /// <param name="doc">The given document</param>
     let inline descendants recurseOnMatch predicate doc =
         doc |> elements |> Seq.collect (HtmlNode.descendantsAndSelf recurseOnMatch predicate)
 
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given set of names
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * names - The set of names to match
-    /// * doc - The given document
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="doc">The given document</param>
     let inline descendantsNamed recurseOnMatch names doc = 
         let nameSet = getNameSet names
         doc |> descendants recurseOnMatch (HtmlNode.name >> nameSet.Contains)
 
+    /// <summary>
     /// Gets all of the descendants of this document that statisfy the given predicate
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * predicate - The predicate by which to match the nodes to return
-    /// * doc - The given document
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
+    /// <param name="doc">The given document</param>
     let inline descendantsWithPath recurseOnMatch predicate doc =
         doc |> elements |> Seq.collect (HtmlNode.descendantsAndSelfWithPath recurseOnMatch predicate)
 
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given set of names
-    /// Parameters:
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
-    /// * names - The set of names to match
-    /// * doc - The given document
+    /// </summary>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="doc">The given document</param>
     let inline descendantsNamedWithPath recurseOnMatch names doc = 
         let nameSet = getNameSet names
         doc |> descendantsWithPath recurseOnMatch (HtmlNode.name >> nameSet.Contains)
 
+    /// <summary>
     /// Finds the body element of the given document,
     /// this throws an exception if no body element exists.
-    /// Parameters:
-    /// * x - The given document
+    /// </summary>
+    /// <param name="x">The given document</param>
     let inline body (x:HtmlDocument) = 
         match List.ofSeq <| descendantsNamed false ["body"] x with
         | [] -> failwith "No element body found!"
         | body:: _ -> body
 
+    /// <summary>
     /// Tries to find the body element of the given document.
-    /// Parameters:
-    /// * x - The given document
+    /// </summary>
+    /// <param name="x">The given document</param>
     let inline tryGetBody (x:HtmlDocument) = 
         match List.ofSeq <| descendantsNamed false ["body"] x with
         | [] -> None
         | body:: _ -> Some body
 
+    /// <summary>
     /// Finds the html element of the given document,
     /// this throws an exception if no html element exists.
-    /// Parameters:
-    /// * x - The given document
+    /// </summary>
+    /// <param name="x">The given document</param>
     let inline html (x:HtmlDocument) = 
         match List.ofSeq <| descendantsNamed false ["html"] x with
         | [] -> failwith "No element html found!"
         | html:: _ -> html
 
+    /// <summary>
     /// Tries to find the html element of the given document.
-    /// Parameters:
-    /// * x - The given document
+    /// </summary>
+    /// <param name="x">The given document</param>
     let inline tryGetHtml (x:HtmlDocument) = 
         match List.ofSeq <| descendantsNamed false ["html"] x with
         | [] -> None
@@ -876,40 +961,48 @@ module HtmlDocument =
 /// Extension methods with operations on HTML documents
 type HtmlDocumentExtensions =
 
+    /// <summary>
     /// Returns all of the root elements of the current document
-    /// that match the given predicate
-    /// Parameters:
-    /// * predicate - The predicate used to match elements
+    /// </summary>
+    /// <param name="doc">The given document</param>
     [<Extension>]
     static member Elements(doc:HtmlDocument) = 
         HtmlDocument.elements doc
 
+    /// <summary>
     /// Returns all of the root elements in the current document that match the set of names
-    /// Parameters:
-    /// * names - The set of names to match
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="names">The set of names to match</param>
     [<Extension>]
     static member Elements(doc:HtmlDocument, names:seq<string>) = 
         HtmlDocument.elementsNamed names doc
 
+    /// <summary>
     /// Returns all of the root elements in the current document that match the name
-    /// Parameters:
-    /// * name - The name to match
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="name">The name to match</param>
     [<Extension>]
     static member Elements(doc:HtmlDocument, name:string) = 
         HtmlDocument.elementsNamed [name] doc
 
+    /// <summary>
     /// Gets all of the descendants of this document that statisfy the given predicate
-    /// Parameters:
-    /// * predicate - The predicate by which to match the nodes to return
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member Descendants(doc:HtmlDocument, predicate, recurseOnMatch) = 
         HtmlDocument.descendants recurseOnMatch predicate doc
 
+    /// <summary>
     /// Gets all of the descendants of this document that statisfy the given predicate
     /// Recurses on match
-    /// Parameters:
-    /// * predicate - The predicate by which to match the nodes to return
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
     [<Extension>]
     static member Descendants(doc:HtmlDocument, predicate) = 
         let recurseOnMatch = true
@@ -923,52 +1016,64 @@ type HtmlDocumentExtensions =
         let predicate = fun _ -> true
         HtmlDocument.descendants recurseOnMatch predicate doc
         
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given set of names
-    /// Parameters:
-    /// * names - The set of names to match
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member Descendants(doc:HtmlDocument, names:seq<string>, recurseOnMatch) =
         HtmlDocument.descendantsNamed recurseOnMatch names doc
 
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given set of names
     /// Recurses on match
-    /// Parameters:
-    /// * names - The set of names to match
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="names">The set of names to match</param>
     [<Extension>]
     static member Descendants(doc:HtmlDocument, names:seq<string>) =
         let recurseOnMatch = true
         HtmlDocument.descendantsNamed recurseOnMatch names doc
 
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given name
-    /// Parameters:
-    /// * name - The name to match
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="name">The name to match</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member Descendants(doc:HtmlDocument, name:string, recurseOnMatch) =
         HtmlDocument.descendantsNamed recurseOnMatch [name] doc
 
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given name
     /// Recurses on match
-    /// Parameters:
-    /// * names - The name to match
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="name">The name to match</param>
     [<Extension>]
     static member Descendants(doc:HtmlDocument, name:string) =
         let recurseOnMatch = true
         HtmlDocument.descendantsNamed recurseOnMatch [name] doc
 
+    /// <summary>
     /// Gets all of the descendants of this document that statisfy the given predicate
-    /// Parameters:
-    /// * predicate - The predicate by which to match the nodes to return
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsWithPath(doc:HtmlDocument, predicate, recurseOnMatch) = 
         HtmlDocument.descendantsWithPath recurseOnMatch predicate doc
 
+    /// <summary>
     /// Gets all of the descendants of this document that statisfy the given predicate
     /// Recurses on match
-    /// Parameters:
-    /// * predicate - The predicate by which to match the nodes to return
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="predicate">The predicate by which to match the nodes to return</param>
     [<Extension>]
     static member DescendantsWithPath(doc:HtmlDocument, predicate) = 
         let recurseOnMatch = true
@@ -982,35 +1087,43 @@ type HtmlDocumentExtensions =
         let predicate = fun _ -> true
         HtmlDocument.descendantsWithPath recurseOnMatch predicate doc
 
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given set of names
-    /// Parameters:
-    /// * names - The set of names to match
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="names">The set of names to match</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsWithPath(doc:HtmlDocument, names:seq<string>, recurseOnMatch) =
         HtmlDocument.descendantsNamedWithPath recurseOnMatch names doc
 
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given set of names
     /// Recurses on match
-    /// Parameters:
-    /// * names - The set of names to match
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="names">The set of names to match</param>
     [<Extension>]
     static member DescendantsWithPath(doc:HtmlDocument, names:seq<string>) =
         let recurseOnMatch = true
         HtmlDocument.descendantsNamedWithPath recurseOnMatch names doc
         
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given name
-    /// Parameters:
-    /// * name - The name to match
-    /// * recurseOnMatch - If a match is found continues down the tree matching child elements
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="name">The name to match</param>
+    /// <param name="recurseOnMatch">If a match is found continues down the tree matching child elements</param>
     [<Extension>]
     static member DescendantsWithPath(doc:HtmlDocument, name:string, recurseOnMatch) =
         HtmlDocument.descendantsNamedWithPath recurseOnMatch [name] doc
 
+    /// <summary>
     /// Finds all of the descendant nodes of this document that match the given name
     /// Recurses on match
-    /// Parameters:
-    /// * name - The name to match
+    /// </summary>
+    /// <param name="doc">The given document</param>
+    /// <param name="name">The name to match</param>
     [<Extension>]
     static member DescendantsWithPath(doc:HtmlDocument, name:string) =
         let recurseOnMatch = true


### PR DESCRIPTION
Fixes the issues in https://github.com/fsprojects/FSharp.Data/issues/1368

Also move some docs from non-standard markdown to standard XML 

Note the fsdocs sidebar has moved the left by default.  I'm also thinking we should change the default fsdocs template to position it more like [DiffSharp](https://diffsharp.github.io/) does than all the way to the left as the default is now doing. (I'd like to keep using the FSharp.Formatting default template so we can keep making improvements there)