### PR TITLE
set sourcelink to be a private asset so that it doesn't get added to package dependencies

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -12,7 +12,7 @@ github fsprojects/FSharp.TypeProviders.SDK src/ProvidedTypes.fs
 github fsprojects/FSharp.TypeProviders.SDK tests/ProvidedTypesTesting.fs
 
 nuget FSharp.Core >= 4.7.2
-nuget Microsoft.SourceLink.GitHub
+nuget Microsoft.SourceLink.GitHub copy_local: true
 
 group Fake
     source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ RESTRICTION: || (== net50) (== netstandard2.0)
 NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (5.0.1)
-    Microsoft.Build.Tasks.Git (1.0)
+    Microsoft.Build.Tasks.Git (1.0) - copy_local: true
     Microsoft.NETCore.App (2.2.8)
       Microsoft.NETCore.DotNetHostPolicy (>= 2.2.8) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp2.2))
       Microsoft.NETCore.Platforms (>= 2.2.4) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp2.2))
@@ -15,8 +15,8 @@ NUGET
       Microsoft.NETCore.DotNetAppHost (>= 5.0.3)
     Microsoft.NETCore.Platforms (5.0.1) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp2.2))
     Microsoft.NETCore.Targets (5.0) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp2.2))
-    Microsoft.SourceLink.Common (1.0)
-    Microsoft.SourceLink.GitHub (1.0)
+    Microsoft.SourceLink.Common (1.0) - copy_local: true
+    Microsoft.SourceLink.GitHub (1.0) - copy_local: true
       Microsoft.Build.Tasks.Git (>= 1.0)
       Microsoft.SourceLink.Common (>= 1.0)
     NETStandard.Library (2.0.3) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp2.2))


### PR DESCRIPTION
Fixes #1376 to remove the errant sourcelink dependency.

After this change, the nuspec contains the following dependency groups:

```xml
<dependencies>
  <group targetFramework=".NETStandard2.0">
    <dependency id="FSharp.Core" version="4.7.2" exclude="Build,Analyzers" />
  </group>
</dependencies>
```

