### PR TITLE
Update .gitattributes to fix file type attributions in GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,6 @@
 
 *.png binary
 *.exe binary
+
+# correct file type displays in gitlab to not be so overwhelmingly HTML
+tests/FSharp.Data.Tests/Data/**.htm* -linguist-detectable


### PR DESCRIPTION
Fixes #1380 by performing the suggested action from that issue.