### PR TITLE
Removing snk file from fsproj references

### DIFF
--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -61,9 +61,6 @@
     <Compile Include="..\Html\HtmlGenerator.fs" />
     <Compile Include="..\Html\HtmlProvider.fs" />
     <Compile Include="..\AssemblyInfo.DesignTime.fs" />
-    <None Include="..\keyfile.snk">
-      <Link>keyfile.snk</Link>
-    </None>
     <None Include="..\Test.fsx" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -63,10 +63,5 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\keyfile.snk">
-      <Link>keyfile.snk</Link>
-    </Content>
-  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
I accidentally included the snk file in the fsproj, which caused nuget to include the reference when building the nupkg and subsequently deploying it along with the DLL. This led to the snk file being installed in all projects that referenced FSharp.Data. 

My apologies.