### PR TITLE
Correction to positioning of boundary delimiter with multiple multipart/form-data files

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1367,7 +1367,8 @@ module private HttpHelpers =
                 [ headerStream
                   newlineStream()
                   newlineStream()
-                  fileStream ]
+                  fileStream 
+                  newlineStream()]
             let partLength = partSubstreams |> Seq.sumBy (fun s -> s.Length)
             new CombinedStream(partLength, partSubstreams) :> Stream
         )


### PR DESCRIPTION
newline required before writing next boundary and header of subsequent files, otherwise server will only decode first file.