### PR TITLE
fix docs output lengths

### DIFF
--- a/docs/library/CsvFile.fsx
+++ b/docs/library/CsvFile.fsx
@@ -51,7 +51,7 @@ points to a live CSV file on the Yahoo finance web site:
 let msft = CsvFile.Load(__SOURCE_DIRECTORY__ + "/../data/MSFT.csv").Cache()
 
 // Print the prices in the HLOC format
-for row in msft.Rows do
+for row in msft.Rows |> Seq.truncate 10 do
   printfn "HLOC: (%s, %s, %s)"
     (row.GetColumn "High") (row.GetColumn "Low") (row.GetColumn "Date")
 
@@ -91,7 +91,7 @@ The following example shows how to process the sample previous CSV sample using 
 
 open FSharp.Data.CsvExtensions
 
-for row in msft.Rows do
+for row in msft.Rows |> Seq.truncate 10 do
   printfn "HLOC: (%f, %M, %O)"
     (row.["High"].AsFloat()) (row?Low.AsDecimal()) (row?Date.AsDateTime())
 

--- a/docs/library/CsvProvider.fsx
+++ b/docs/library/CsvProvider.fsx
@@ -92,8 +92,8 @@ let firstRow = msft.Rows |> Seq.head
 let lastDate = firstRow.Date
 let lastOpen = firstRow.Open
 
-// Print the prices in the HLOC format
-for row in msft.Rows do
+// Print the first 10 prices in the HLOC format
+for row in msft.Rows |> Seq.truncate 10 do
   printfn "HLOC: (%A, %A, %A, %A)" row.High row.Low row.Open row.Close
 
 (*** include-fsi-merged-output ***)
@@ -177,7 +177,7 @@ type AirQuality = CsvProvider<"../data/AirQuality.csv", ";", ResolutionFolder=Re
 
 let airQuality = new AirQuality()
 
-for row in airQuality.Rows do
+for row in airQuality.Rows |> Seq.truncate 10 do
   if row.Month > 6 then
     printfn "Temp: %i Ozone: %f " row.Temp row.Ozone
 
@@ -347,7 +347,7 @@ type Titanic1 =
               ResolutionFolder=ResolutionFolder>
 
 let titanic1 = Titanic1.GetSample()
-for row in titanic1.Rows do
+for row in titanic1.Rows |> Seq.truncate 10 do
   printfn "%s Class = %d Fare = %g"
     row.Name row.``Passenger Class`` row.Fare
 
@@ -364,7 +364,7 @@ type Titanic2 =
               ResolutionFolder=ResolutionFolder>
 
 let titanic2 = Titanic2.GetSample()
-for row in titanic2.Rows do
+for row in titanic2.Rows |> Seq.truncate 10 do
   printfn "%s Class = %d Fare = %g"
     row.Name row.``Passenger Class`` row.Fare
 

--- a/docs/library/HtmlParser.fsx
+++ b/docs/library/HtmlParser.fsx
@@ -62,6 +62,7 @@ let links =
            x.TryGetAttribute("href")
            |> Option.map (fun a -> x.InnerText(), a.Value())
     )
+    |> Seq.truncate 10
     |> Seq.toList
 
 (*** include-fsi-merged-output ***)

--- a/docs/library/XmlProvider.fsx
+++ b/docs/library/XmlProvider.fsx
@@ -271,8 +271,10 @@ type Census = XmlProvider<"../data/Census.xml", ResolutionFolder=ResolutionFolde
 
 let data = Census.Load("https://api.census.gov/data.xml")
 
-let apiLinks = data.Datasets
-               |> Array.map (fun ds -> ds.Title,ds.Distribution.AccessUrl)
+let apiLinks =
+    data.Datasets
+    |> Array.map (fun ds -> ds.Title,ds.Distribution.AccessUrl)
+    |> Array.truncate 10
 
 (*** include-fsi-merged-output ***)
 


### PR DESCRIPTION
The docs are now showing F# Interactive processing outputs 

These reduces the amount of information shown