### PR TITLE
fix stack overflow when building debug code

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -19,8 +19,10 @@ jobs:
       run: dotnet tool restore
     - name: Restore packages
       run: dotnet paket restore
-    - name: Build and test
+    - name: Build and test (Release)
       run: dotnet fake build -t All
+    - name: Build (Debug)
+      run: dotnet build -c Debug
 
   build-ubuntu:
 
@@ -37,3 +39,5 @@ jobs:
       run: dotnet paket restore
     - name: Build and test
       run: dotnet fake build -t RunTests
+    - name: Build (Debug)
+      run: dotnet build -c Debug

--- a/src/AssemblyInfo.DesignTime.fs
+++ b/src/AssemblyInfo.DesignTime.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FSharp.Data.DesignTime")>]
 [<assembly: AssemblyProductAttribute("FSharp.Data")>]
 [<assembly: AssemblyDescriptionAttribute("Library of F# type providers and data access tools")>]
-[<assembly: AssemblyVersionAttribute("4.2.2.0")>]
-[<assembly: AssemblyFileVersionAttribute("4.2.2.0")>]
+[<assembly: AssemblyVersionAttribute("4.2.5.0")>]
+[<assembly: AssemblyFileVersionAttribute("4.2.5.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharp.Data.DesignTime"
     let [<Literal>] AssemblyProduct = "FSharp.Data"
     let [<Literal>] AssemblyDescription = "Library of F# type providers and data access tools"
-    let [<Literal>] AssemblyVersion = "4.2.2.0"
-    let [<Literal>] AssemblyFileVersion = "4.2.2.0"
+    let [<Literal>] AssemblyVersion = "4.2.5.0"
+    let [<Literal>] AssemblyFileVersion = "4.2.5.0"

--- a/src/AssemblyInfo.fs
+++ b/src/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FSharp.Data")>]
 [<assembly: AssemblyProductAttribute("FSharp.Data")>]
 [<assembly: AssemblyDescriptionAttribute("Library of F# type providers and data access tools")>]
-[<assembly: AssemblyVersionAttribute("4.2.2.0")>]
-[<assembly: AssemblyFileVersionAttribute("4.2.2.0")>]
+[<assembly: AssemblyVersionAttribute("4.2.5.0")>]
+[<assembly: AssemblyFileVersionAttribute("4.2.5.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharp.Data"
     let [<Literal>] AssemblyProduct = "FSharp.Data"
     let [<Literal>] AssemblyDescription = "Library of F# type providers and data access tools"
-    let [<Literal>] AssemblyVersion = "4.2.2.0"
-    let [<Literal>] AssemblyFileVersion = "4.2.2.0"
+    let [<Literal>] AssemblyVersion = "4.2.5.0"
+    let [<Literal>] AssemblyFileVersion = "4.2.5.0"

--- a/src/Csv/CsvRuntime.fs
+++ b/src/Csv/CsvRuntime.fs
@@ -250,16 +250,16 @@ type CsvFile<'RowType> private (rowToStringArray:Func<'RowType,string[]>, dispos
 
     // Track created Readers so that we can dispose of all of them
     let disposeFuncs = new ResizeArray<_>()
-    let disposed = ref false
+    let mutable disposed = false
     let disposer = 
       { new IDisposable with
           member x.Dispose() = 
-            if not !disposed then
+            if not disposed then
                 Seq.iter (fun f -> f()) disposeFuncs
-                disposed := true }
+                disposed <- true }
 
     let newReader() =
-        if !disposed then
+        if disposed then
             raise <| ObjectDisposedException(this.GetType().Name)
         let reader = readerFunc.Invoke()
         disposeFuncs.Add reader.Dispose

--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -9,6 +9,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\keyfile.snk</AssemblyOriginatorKeyFile>
     <PublicSign>false</PublicSign>
+    <!-- always have tailcalls on for design time compiler add-in to allow repo to compile in DEBUG, see https://github.com/fsprojects/FSharp.Data/issues/1410 -->
+    <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\Http.fs" />

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -12,8 +12,7 @@
     <PublicSign>false</PublicSign>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\keyfile.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <!-- always have tailcalls on for design time compiler add-in to allow repo to compile in DEBUG, see https://github.com/fsprojects/FSharp.Data/issues/1410 -->
     <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
@@ -46,19 +45,13 @@
     <Compile Include="..\Html\HtmlActivePatterns.fs" />
     <Compile Include="..\AssemblyInfo.fs" />
     <Compile Include="..\Runtime.fs" />
+      <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.DesignTime\FSharp.Data.DesignTime.fsproj">
       <IsFSharpDesignTimeProvider>true</IsFSharpDesignTimeProvider>
       <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
-    <None Include="..\keyfile.snk">
-      <Link>keyfile.snk</Link>
-    </None>
-    <None Include="keyfile.snk" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.7.2" />

--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1441,7 +1441,7 @@ module internal HttpHelpers =
             checkForRepeatedHeaders (header::visitedHeaders) remainingHeaders
 
     let setHeaders headers (req:HttpWebRequest) =
-        let hasContentType = ref false
+        let mutable hasContentType = false
         checkForRepeatedHeaders [] headers
         headers |> List.iter (fun (header:string, value) ->
             match header.ToLowerInvariant() with
@@ -1461,7 +1461,7 @@ module internal HttpHelpers =
             | "content-range" -> req.Headers.[HeaderEnum.ContentRange] <- value
             | "content-type" ->
                 req.ContentType <- value
-                hasContentType := true
+                hasContentType <- true
             | "date" -> req.Date <- DateTime.SpecifyKind(DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture), DateTimeKind.Utc)
             | "expect" -> req.Expect <- value
             | "expires" -> req.Headers.[HeaderEnum.Expires] <- value
@@ -1493,7 +1493,7 @@ module internal HttpHelpers =
             | "warning" -> req.Headers.[HeaderEnum.Warning] <- value
             | _ -> req.Headers.[header] <- value
         )
-        hasContentType.Value
+        hasContentType
 
     let getResponse (req:HttpWebRequest) silentHttpErrors =
 

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -7,6 +7,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <!-- always have tailcalls on for design time compiler add-in to allow repo to compile in DEBUG, see https://github.com/fsprojects/FSharp.Data/issues/1410 -->
+    <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data/**/*.*">

--- a/tests/FSharp.Data.Tests/JsonProvider.fs
+++ b/tests/FSharp.Data.Tests/JsonProvider.fs
@@ -411,12 +411,12 @@ let ``Can parse wiki sample``() =
 [<Test>]
 let ``Can load empty json file and fails on property access``() = 
     let document = WikiSample.Load("Data/Empty.json")
-    let failed = ref false
+    let mutable failed = false
     try
         document.Age |> ignore
     with
-    | _ -> failed := true
-    !failed |> should be True
+    | _ -> failed <- true
+    failed |> should be True
 
 let newJson = 
     """{  

--- a/tests/FSharp.Data.Tests/Program.fs
+++ b/tests/FSharp.Data.Tests/Program.fs
@@ -1,4 +1,4 @@
-﻿open System
+open System
 
 [<EntryPoint>]
 let main argv = 


### PR DESCRIPTION
Fixes https://github.com/fsprojects/FSharp.Data/issues/1410, a problem building the debug version of this repo with F# 6.

1. It turns out Debug build of FSharp.Data.Tests was busted for a while with F# 5 because tailcalls weren't being taken during JSON parsing.  
2. When turning on explicit tailcalls for debug code, the problem went away with F# 5 but remains for F# 6 because of https://github.com/dotnet/fsharp/issues/12413.  
3. The code changes workaround this

Also adds a debug build to the PRs