### PR TITLE
HtmlNode.ToString(): fix self-closing tags on empty non-void elements

### DIFF
--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -93,14 +93,18 @@ type HtmlNode =
     static member NewCData content = HtmlCData(content)
 
     override x.ToString() =
+        let isVoidElement =
+            let set =
+                [| "area"; "base"; "br"; "col"; "command"; "embed"; "hr"; "img"; "input"
+                   "keygen"; "link"; "meta"; "param"; "source"; "track"; "wbr" |]
+                |> Set.ofArray
+            fun name -> Set.contains name set
         let rec serialize (sb:StringBuilder) indentation canAddNewLine html =
             let append (str:string) = sb.Append str |> ignore
             let appendEndTag name =
                 append "</"
                 append name
                 append ">"
-            let shouldAppendEndTag name =
-                name = "textarea"
             let newLine plus =
                 sb.AppendLine() |> ignore
                 String(' ', indentation + plus) |> append
@@ -117,12 +121,11 @@ type HtmlNode =
                     append "=\""
                     append value
                     append "\""
-                if elements.IsEmpty then
-                    if shouldAppendEndTag name then
-                        append ">"
-                        appendEndTag name
-                    else
-                        append " />"
+                if isVoidElement name then
+                    append " />"
+                elif elements.IsEmpty then
+                    append ">"
+                    appendEndTag name
                 else
                     append ">"
                     if not onlyText then

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -648,6 +648,19 @@ let ``Renders textarea closing tag``() =
     result |> should equal """<textarea cols="40" rows="2"></textarea>"""
 
 [<Test>]
+let ``Renders self-closing tag for void elements``() =
+    [ "area"; "base"; "br"; "col"; "command"; "embed"; "hr"; "img"; "input"
+      "keygen"; "link"; "meta"; "param"; "source"; "track"; "wbr" ]
+    |> List.iter (fun name ->
+        let html = HtmlNode.NewElement name |> string
+        html |> should equal $"<%s{name} />")
+
+[<Test>]
+let ``Renders no self-closing tag for non-void elements``() =
+    let html = HtmlNode.NewElement "foo" |> string
+    html |> should equal "<foo></foo>"
+
+[<Test>]
 let ``Can handle CDATA blocks``() =
     let cData = """
       Trying to provoke the CDATA parser with almost complete CDATA end tags
@@ -911,7 +924,7 @@ let ``Parsing non-html content doesn't cause an infinite loop - Github-1264``() 
 [<Test; Timeout(2000)>]
 let ``Can handle incomplete tags at end of file without creating an infinite loop``() =
     let result = HtmlDocument.Parse """<html><head></head></html"""
-    let expected = 
+    let expected =
         HtmlDocument.New
             [ HtmlNode.NewElement
                 ("html",


### PR DESCRIPTION
Quoting from
https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element

> The following is a complete list of the void elements in HTML:
> area, base, br, col, command, embed, hr, img, input, keygen, link,
> meta, param, source, track, wbr

[...]

> Void elements only have a start tag; end tags must not be specified
> for void elements.
> A non-void element must have an end tag, unless the subsection for
> that element in the HTML elements section of this reference indicates
> that its end tag can be omitted.