### PR TITLE
HtmlState: restore FormattedMode if still in pre after char ref

### DIFF
--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -334,7 +334,10 @@ module internal HtmlParser =
             x.Tokens := result :: !x.Tokens
 
         member x.IsFormattedTag
-            with get() = x.CurrentTagName().ToLower() = "pre"
+            with get() =
+                match x.CurrentTagName().ToLower() with
+                | "pre" | "code" -> true
+                | _ -> false
 
         member x.IsScriptTag
             with get() =

--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -334,14 +334,11 @@ module internal HtmlParser =
             x.Tokens := result :: !x.Tokens
 
         member x.IsFormattedTag
-            with get() =
-               match x.CurrentTagName() with
-               | "pre" | "code" -> true
-               | _ -> false
+            with get() = x.CurrentTagName().ToLower() = "pre"
 
         member x.IsScriptTag
             with get() =
-               match x.CurrentTagName().Trim().ToLower() with
+               match x.CurrentTagName().ToLower() with
                | "script" | "style" -> true
                | _ -> false
 
@@ -386,7 +383,9 @@ module internal HtmlParser =
                 | DocTypeMode -> DocType content
                 | CDATAMode -> CData (content.Replace("<![CDATA[", "").Replace("]]>", ""))
             x.Content := CharList.Empty
-            x.InsertionMode := DefaultMode
+            x.InsertionMode :=
+                if x.IsFormattedTag then FormattedMode
+                else DefaultMode
             match result with
             | Text t when String.IsNullOrEmpty(t) -> ()
             | _ -> x.Tokens := result :: !x.Tokens

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -1,5 +1,6 @@
 module FSharp.Data.Tests.HtmlParser
 
+open System
 open System.Globalization
 open NUnit.Framework
 open FsUnit
@@ -838,7 +839,8 @@ let ``Drops whitespace outside pre``() =
         |> Seq.head
         |> string
     // default indentation is 2 spaces
-    let expected = "<div>\n  foo <pre>    bar    </pre> baz\n</div>"
+    let nl = Environment.NewLine
+    let expected = $"<div>%s{nl}  foo <pre>    bar    </pre> baz%s{nl}</div>"
     result |> should equal expected
 
 [<Test>]

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -805,8 +805,8 @@ let ``Can parse pre blocks``() =
     result |> should equal [ "\r\n        This code should be indented and\r\n        have line feeds in it" ]
 
 [<Test>]
-let ``Can parse code blocks``() =
-    let html = "<code>\r\n        let f a b = a * b\r\n        f 5 6 |> should equal 30</code>"
+let ``Can parse pre containing code blocks``() =
+    let html = "<pre><code>\r\n        let f a b = a * b\r\n        f 5 6 |> should equal 30</code></pre>"
 
     let result =
         (HtmlDocument.Parse html)
@@ -825,6 +825,20 @@ let ``Can parse pre blocks with char refs``() =
         |> Seq.head
         |> HtmlNode.innerText
     let expected = "let hello =\r\n    fun who ->\r\n        \"hello\" + who"
+    result |> should equal expected
+
+[<Test>]
+let ``Drops whitespace outside pre``() =
+    let html =
+        "<div>foo    <pre>    bar    </pre>    baz</div>"
+
+    let result =
+        (HtmlDocument.Parse html)
+        |> HtmlDocument.descendantsNamed false [ "div" ]
+        |> Seq.head
+        |> string
+    // default indentation is 2 spaces
+    let expected = "<div>\n  foo <pre>    bar    </pre> baz\n</div>"
     result |> should equal expected
 
 [<Test>]

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -805,15 +805,26 @@ let ``Can parse pre blocks``() =
     result |> should equal [ "\r\n        This code should be indented and\r\n        have line feeds in it" ]
 
 [<Test>]
+let ``Can parse code blocks``() =
+    let html = "<code>\r\n        let f a b = a * b\r\n        f 5 6 |> should equal 30</code>"
+
+    let result =
+        (HtmlDocument.Parse html)
+        |> HtmlDocument.descendantsNamed true [ "code" ]
+        |> Seq.map (HtmlNode.innerText)
+        |> Seq.toList
+    result |> should equal [ "\r\n        let f a b = a * b\r\n        f 5 6 |> should equal 30" ]
+
+[<Test>]
 let ``Can parse pre blocks with char refs``() =
-    let html = "<pre>let hello who =\r\n    &quot;hello&quot; + who</pre>"
+    let html = "<pre>let hello =\r\n    fun who -&gt;\r\n        &quot;hello&quot; + who</pre>"
 
     let result =
         (HtmlDocument.Parse html)
         |> HtmlDocument.descendantsNamed true [ "pre" ]
         |> Seq.head
         |> HtmlNode.innerText
-    let expected = "let hello who =\r\n    \"hello\" + who"
+    let expected = "let hello =\r\n    fun who ->\r\n        \"hello\" + who"
     result |> should equal expected
 
 [<Test>]

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -805,15 +805,16 @@ let ``Can parse pre blocks``() =
     result |> should equal [ "\r\n        This code should be indented and\r\n        have line feeds in it" ]
 
 [<Test>]
-let ``Can parse code blocks``() =
-    let html = "<code>\r\n        let f a b = a * b\r\n        f 5 6 |> should equal 30</code>"
+let ``Can parse pre blocks with char refs``() =
+    let html = "<pre>let hello who =\r\n    &quot;hello&quot; + who</pre>"
 
     let result =
         (HtmlDocument.Parse html)
-        |> HtmlDocument.descendantsNamed true [ "code" ]
-        |> Seq.map (HtmlNode.innerText)
-        |> Seq.toList
-    result |> should equal [ "\r\n        let f a b = a * b\r\n        f 5 6 |> should equal 30" ]
+        |> HtmlDocument.descendantsNamed true [ "pre" ]
+        |> Seq.head
+        |> HtmlNode.innerText
+    let expected = "let hello who =\r\n    \"hello\" + who"
+    result |> should equal expected
 
 [<Test>]
 let ``Can parse national rail mobile site correctly``() =
@@ -911,7 +912,7 @@ let ``Parsing non-html content doesn't cause an infinite loop - Github-1264``() 
 [<Test; Timeout(2000)>]
 let ``Can handle incomplete tags at end of file without creating an infinite loop``() =
     let result = HtmlDocument.Parse """<html><head></head></html"""
-    let expected = 
+    let expected =
         HtmlDocument.New
             [ HtmlNode.NewElement
                 ("html",


### PR DESCRIPTION
At the same time the assumption that the code element is formatted is not correct. They are often used at the same time though and with that comes another issue: keeping FormattedMode in elements nested into pre.

I'm not sure how to approach this, I've never worked with refs like here before. Would it be ok to drop the FormattedMode and add an IsFormatted: bool ref instead? And update that when entering/exiting pre elements.