### PR TITLE
Proposed fix to #1420 on extra newline before endBoundaryStream

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1388,7 +1388,8 @@ module internal HttpHelpers =
             let bytes = e.GetBytes text
             new MemoryStream(bytes) :> Stream
 
-        let wholePayload = Seq.append segments [newlineStream(); endBoundaryStream; ]
+        /// per spec, close-delimiter := "--" boundary "--" CRLF ; no need extra newline
+        let wholePayload = Seq.append segments [ endBoundaryStream; ]
         let wholePayloadLength = wholePayload |> trySumLength
         new CombinedStream(wholePayloadLength, wholePayload) :> Stream
 

--- a/tests/FSharp.Data.Tests/Http.fs
+++ b/tests/FSharp.Data.Tests/Http.fs
@@ -205,7 +205,8 @@ let ``correct multipart content format`` () =
     let str = Encoding.UTF8.GetString(ms.ToArray())
     Console.WriteLine(str)
     let singleMultipartFormat file = sprintf "--%s\r\nContent-Disposition: form-data; name=\"%i\"; filename=\"%i\"\r\nContent-Type: application/octet-stream\r\n\r\n%s\r\n" boundary file file content
-    let finalFormat = [sprintf "\r\n--%s--" boundary] |> Seq.append (seq {for i in [0..numFiles] -> singleMultipartFormat i }) |>  String.concat ""
+     // No need extra newline /r/n before closing delimiter
+    let finalFormat = [sprintf "--%s--" boundary] |> Seq.append (seq {for i in [0..numFiles] -> singleMultipartFormat i }) |>  String.concat ""
     str |> should equal finalFormat
 
 [<Test>]
@@ -244,7 +245,7 @@ let ``Non-seekable streams create non-seekable CombinedStream`` () =
 [<Test>]
 let ``Seekable streams create Seekable CombinedStream`` () =
     let byteLen = 10L
-    let result = byteLen + 110L //110 is headers
+    let result = byteLen + 108L // As no extra /r/n, 2 bytes removed, 108 is headers
     use ms = new IO.MemoryStream(Array.zeroCreate (int byteLen))
     let multiparts = [MultipartItem("","", ms)]
     let combinedStream = HttpHelpers.writeMultipart "-" multiparts Encoding.UTF8


### PR DESCRIPTION
As reported in #1420 , two extra bytes of newline is appended to the last Multipart Item, this PR aims to fix it.

Since extra newline removed, two existing test cases shall be revised to reflect this change:

- ``correct multipart content format``
- ``Seekable streams create Seekable CombinedStream``

I have tested several scenarios on number of files,  format, size etc. upon the built FSharp.Data.dll and looks good.