### PR TITLE
JsonProvider.Load(value: JsonValue)

### DIFF
--- a/src/Csv/CsvProvider.fs
+++ b/src/Csv/CsvProvider.fs
@@ -117,8 +117,10 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
                                                separators, quote, hasHeaders, ignoreErrors, skipRows, cacheRows)
                   Expr.Let(stringArrayToRowVar, stringArrayToRow, Expr.Let(rowToStringArrayVar, rowToStringArray, body))
               CreateListFromTextReader = None
-              CreateFromTextReaderForSampleList = fun _ -> failwith "Not Applicable" }
-        
+              CreateFromTextReaderForSampleList = fun _ -> failwith "Not Applicable"
+              CreateFromValue = None
+               }
+
         let maxNumberOfRows = if inferRows > 0 then Some inferRows else None
         
         // On the CsvProvider the schema might be partial and we will still infer from the sample

--- a/src/Html/HtmlProvider.fs
+++ b/src/Html/HtmlProvider.fs
@@ -55,7 +55,9 @@ type public HtmlProvider(cfg:TypeProviderConfig) as this =
               RepresentationType = htmlType
               CreateFromTextReader = fun reader -> <@@ HtmlDocument.Create(includeLayoutTables, %reader) @@>                    
               CreateListFromTextReader = None
-              CreateFromTextReaderForSampleList = fun _ -> failwith "Not Applicable" }
+              CreateFromTextReaderForSampleList = fun _ -> failwith "Not Applicable"
+              CreateFromValue = None
+               }
 
         generateType "HTML" (Sample sample) getSpec this cfg encodingStr resolutionFolder resource typeName (*maxNumberOfRows*)None
 

--- a/src/Json/JsonProvider.fs
+++ b/src/Json/JsonProvider.fs
@@ -67,13 +67,15 @@ type public JsonProvider(cfg:TypeProviderConfig) as this =
                       result.Convert <@@ JsonDocument.Create(%reader) @@>
                   CreateListFromTextReader = Some (fun reader ->
                       result.Convert <@@ JsonDocument.CreateList(%reader) @@>)
-                  CreateFromTextReaderForSampleList = fun reader -> 
-                      result.Convert <@@ JsonDocument.CreateList(%reader) @@> }
-            
-        let source = 
-            if sampleIsList then 
-                SampleList sample 
-            else 
+                  CreateFromTextReaderForSampleList = fun reader ->
+                      result.Convert <@@ JsonDocument.CreateList(%reader) @@>
+                  CreateFromValue = Some (typeof<JsonValue>, fun value -> result.Convert <@@ JsonDocument.Create(%value, "") @@>)
+                       }
+
+        let source =
+            if sampleIsList then
+                SampleList sample
+            else
                 Sample sample
 
         generateType "JSON" source getSpec this cfg encodingStr resolutionFolder resource typeName (*maxNumberOfRows*)None

--- a/src/Xml/XmlProvider.fs
+++ b/src/Xml/XmlProvider.fs
@@ -71,7 +71,9 @@ type public XmlProvider(cfg:TypeProviderConfig) as this =
                               result.Converter <@@ XmlElement.Create(%reader) @@>
                       CreateListFromTextReader = None
                       CreateFromTextReaderForSampleList = fun reader -> // hack: this will actually parse the schema
-                          <@@ XmlSchema.parseSchemaFromTextReader resolutionFolder %reader @@> }
+                          <@@ XmlSchema.parseSchemaFromTextReader resolutionFolder %reader @@>
+                      CreateFromValue = None
+                           }
 
 
                 else
@@ -100,10 +102,12 @@ type public XmlProvider(cfg:TypeProviderConfig) as this =
                           CreateFromTextReader = fun reader -> 
                               result.Converter <@@ XmlElement.Create(%reader) @@>
                           CreateListFromTextReader = None
-                          CreateFromTextReaderForSampleList = fun reader -> 
-                              result.Converter <@@ XmlElement.CreateList(%reader) @@> }
-       
-        let source = 
+                          CreateFromTextReaderForSampleList = fun reader ->
+                              result.Converter <@@ XmlElement.CreateList(%reader) @@>
+                          CreateFromValue = None
+                               }
+
+        let source =
             if schema <> "" then
                 Schema schema
             elif sampleIsList then

--- a/tests/FSharp.Data.DesignTime.Tests/SignatureTests.fs
+++ b/tests/FSharp.Data.DesignTime.Tests/SignatureTests.fs
@@ -28,7 +28,13 @@ let expectedDirectory = sourceDirectory ++ "expected"
 
 let resolutionFolder = sourceDirectory ++ ".." ++ "FSharp.Data.Tests" ++ "Data"
 let assemblyName = "FSharp.Data.dll"
-let netstandard2RuntimeAssembly = sourceDirectory ++ ".." ++ ".." ++ "src" ++ "FSharp.Data" ++ "bin" ++ "Release" ++ "netstandard2.0" ++ assemblyName
+let netstandard2RuntimeAssembly = sourceDirectory ++ ".." ++ ".." ++ "src" ++ "FSharp.Data" ++ "bin" ++
+                                #if DEBUG
+                                    "Debug"
+                                #else
+                                    "Release"
+                                #endif
+                                ++ "netstandard2.0" ++ assemblyName
 
 let getRuntimeRefs platform = TypeProviderInstantiation.GetRuntimeAssemblyRefs platform
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Empty.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Empty.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+JsonProvider+Root[]
     JsonRuntime.ConvertArray(JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri))), new Func<_,_>(id)))
 
+    static member Load: value:JsonValue -> JsonProvider+JsonProvider+Root[]
+    JsonRuntime.ConvertArray(JsonDocument.Create(value, ""), new Func<_,_>(id)))
+
     static member Parse: text:string -> JsonProvider+JsonProvider+Root[]
     JsonRuntime.ConvertArray(JsonDocument.Create(((new StringReader(text)) :> TextReader)), new Func<_,_>(id)))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,False.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,False.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+JsonProvider+Root[]
     JsonRuntime.ConvertArray(JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri))), new Func<_,_>(id)))
 
+    static member Load: value:JsonValue -> JsonProvider+JsonProvider+Root[]
+    JsonRuntime.ConvertArray(JsonDocument.Create(value, ""), new Func<_,_>(id)))
+
     static member Parse: text:string -> JsonProvider+JsonProvider+Root[]
     JsonRuntime.ConvertArray(JsonDocument.Create(((new StringReader(text)) :> TextReader)), new Func<_,_>(id)))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+JsonProvider+Root[]
     JsonRuntime.ConvertArray(JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri))), new Func<_,_>(id)))
 
+    static member Load: value:JsonValue -> JsonProvider+JsonProvider+Root[]
+    JsonRuntime.ConvertArray(JsonDocument.Create(value, ""), new Func<_,_>(id)))
+
     static member Parse: text:string -> JsonProvider+JsonProvider+Root[]
     JsonRuntime.ConvertArray(JsonDocument.Create(((new StringReader(text)) :> TextReader)), new Func<_,_>(id)))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+WorldBank
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+WorldBank
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+WorldBank
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True.expected
@@ -19,6 +19,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+Root
     JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
 
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
     static member Parse: text:string -> JsonProvider+Root
     JsonDocument.Create(((new StringReader(text)) :> TextReader))
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True.expected
@@ -12,6 +12,9 @@ class JsonProvider : obj
     static member Load: uri:string -> JsonProvider+JsonProvider+Topic[]
     JsonRuntime.ConvertArray(JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri))), new Func<_,_>(id)))
 
+    static member Load: value:JsonValue -> JsonProvider+JsonProvider+Topic[]
+    JsonRuntime.ConvertArray(JsonDocument.Create(value, ""), new Func<_,_>(id)))
+
     static member Parse: text:string -> JsonProvider+JsonProvider+Topic[]
     JsonRuntime.ConvertArray(JsonDocument.Create(((new StringReader(text)) :> TextReader)), new Func<_,_>(id)))
 


### PR DESCRIPTION
Added overload of Load method on JsonProvider to support combining JsonProviders without need for additional conversion to and from string. This should fix #1309