### PR TITLE
Remove restrictions for getting innerText

### DIFF
--- a/src/Html/HtmlOperations.fs
+++ b/src/Html/HtmlOperations.fs
@@ -234,32 +234,23 @@ module HtmlNode =
         let classesToLookFor = cssClass.Split [|' '|]
         classesToLookFor |> Array.forall (fun cssClass -> presentClasses |> Array.exists ((=) cssClass))
 
-    let private innerTextExcluding' recurse exclusions n = 
-        let exclusions = "style" :: "script" :: exclusions
-        let isAriaHidden (n:HtmlNode) = 
-            match tryGetAttribute "aria-hidden" n with
-            | Some a -> 
-                match bool.TryParse(a.Value()) with
-                | true, v -> v
-                | false, _ -> false 
-            | None -> false
-        let rec innerText' inRoot n =
-            let exclusions = if inRoot then ["style"; "script"] else exclusions
+    let private innerTextExcluding' recurse exclusions n =
+        let rec innerText' n =
             match n with
-            | HtmlElement(name, _, content) when List.forall ((<>) name) exclusions && not (isAriaHidden n) ->
+            | HtmlElement(name, _, content) when List.forall ((<>) name) exclusions ->
                 seq { for e in content do
                         match e with
                         | HtmlText(text) -> yield text
                         | HtmlComment(_) -> yield ""
-                        | elem -> 
+                        | elem ->
                             if recurse then
-                                yield innerText' false elem 
+                                yield innerText' elem
                             else
                                 yield "" }
                 |> String.Concat
             | HtmlText(text) -> text
             | _ -> ""
-        innerText' true n
+        innerText' n
 
     let innerTextExcluding exclusions n =
         innerTextExcluding' true exclusions n

--- a/tests/FSharp.Data.Tests/HtmlOperations.fs
+++ b/tests/FSharp.Data.Tests/HtmlOperations.fs
@@ -142,13 +142,3 @@ let ``Can get direct inner text``() =
 let ``Inner text on a comment should be String.Empty``() =
     let comment = HtmlNode.NewComment "Hello World"
     HtmlNode.innerText comment |> should equal String.Empty
-
-[<Test>]
-let ``Inner text on a style should be String.Empty``() =
-    let comment = HtmlNode.NewElement("style", [HtmlNode.NewText "Hello World"])
-    HtmlNode.innerText comment |> should equal String.Empty
-
-[<Test>]
-let ``Inner text on a script should be String.Empty``() =
-    let comment = HtmlNode.NewElement("script", [HtmlNode.NewText "Hello World"])
-    HtmlNode.innerText comment |> should equal String.Empty


### PR DESCRIPTION
This pull request addresses #1292. It seems like the current version of `innerTextExcluding'` was tightly coupled to some of the implementation details of the Html type provider. In order to avoid breaking the `Validate signature didn't change` tests, I moved the existing logic to private functions inside `HtmlRuntime.fs`. Then I added a new simpler implementation to `HtmlOperations.fs` which doesn't modify the exclusion list or filter on the `aria-hidden` attribute.