### PR TITLE
add GithubActionsTestLogger and use it in CI builds

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -55,6 +55,8 @@ let license = "Apache-2.0"
 // Read release notes & version info from RELEASE_NOTES.md
 let release = ReleaseNotes.load "RELEASE_NOTES.md"
 
+let isCI = Environment.GetEnvironmentVariable("CI") <> null
+
 // --------------------------------------------------------------------------------------
 // Generate assembly info files with the right version & up-to-date information
 
@@ -106,8 +108,16 @@ Target.create "Build" (fun _ ->
     |> DotNet.build (fun o -> { o with Configuration = DotNet.BuildConfiguration.Release }))
 
 Target.create "RunTests" (fun _ ->
-    "FSharp.Data.sln"
-    |> DotNet.test (fun o -> { o with Configuration = DotNet.BuildConfiguration.Release }))
+    let setParams (o: DotNet.TestOptions) =
+        { o with
+            Configuration = DotNet.BuildConfiguration.Release
+            Logger =
+                if isCI then
+                    Some "GitHubActions"
+                else
+                    None }
+
+    "FSharp.Data.sln" |> DotNet.test setParams)
 
 // --------------------------------------------------------------------------------------
 // Build a NuGet package

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -55,3 +55,4 @@ group Test
     nuget NUnit3TestAdapter
     nuget FsUnit  4.0.4
     nuget FsCheck 2.15.1
+    nuget GitHubActionsTestLogger

--- a/paket.lock
+++ b/paket.lock
@@ -345,6 +345,8 @@ NUGET
       FSharp.Core (>= 4.3.4)
       NETStandard.Library (>= 2.0.3)
       NUnit (>= 3.13 < 4.0)
+    GitHubActionsTestLogger (2.0)
+      Microsoft.TestPlatform.ObjectModel (>= 17.2)
     Microsoft.CodeCoverage (17.2)
     Microsoft.NET.Test.Sdk (17.2)
       Microsoft.CodeCoverage (>= 17.2)

--- a/tests/FSharp.Data.DesignTime.Tests/paket.references
+++ b/tests/FSharp.Data.DesignTime.Tests/paket.references
@@ -4,4 +4,4 @@ group Test
     NUnit
     NUnit3TestAdapter
     FsUnit
-    
+    GitHubActionsTestLogger

--- a/tests/FSharp.Data.Reference.Tests/paket.references
+++ b/tests/FSharp.Data.Reference.Tests/paket.references
@@ -5,3 +5,4 @@ group Test
     NUnit3TestAdapter
     FsUnit
     FsCheck
+    GitHubActionsTestLogger

--- a/tests/FSharp.Data.Tests.CSharp/paket.references
+++ b/tests/FSharp.Data.Tests.CSharp/paket.references
@@ -3,3 +3,4 @@ group Test
     Microsoft.NET.Test.Sdk
     NUnit
     NUnit3TestAdapter
+    GitHubActionsTestLogger

--- a/tests/FSharp.Data.Tests/paket.references
+++ b/tests/FSharp.Data.Tests/paket.references
@@ -5,3 +5,4 @@ group Test
     NUnit3TestAdapter
     FsUnit
     FsCheck
+    GitHubActionsTestLogger


### PR DESCRIPTION
This adds [Tyrrrz/GitHubActionsTestLogger](https://github.com/Tyrrrz/GitHubActionsTestLogger) so that it's easier for test results to be viewed for a particular CI run.  This test logger will only be used if you're on a CI run.