### PR TITLE
Some medium refactoring and little fixes

### DIFF
--- a/src/CommonProviderImplementation/ConversionsGenerator.fs
+++ b/src/CommonProviderImplementation/ConversionsGenerator.fs
@@ -1,4 +1,4 @@
-﻿// Copyright 2011-2015, Tomas Petricek (http://tomasp.net), Gustavo Guerra (http://functionalflow.co.uk), and other contributors
+// Copyright 2011-2015, Tomas Petricek (http://tomasp.net), Gustavo Guerra (http://functionalflow.co.uk), and other contributors
 // Licensed under the Apache License, Version 2.0, see LICENSE.md in this project
 //
 // Conversions from string to various primitive types
@@ -68,6 +68,8 @@ let getBackConversionQuotation missingValuesStr cultureStr typ value : Expr<stri
 /// Creates a function that takes Expr<string option> and converts it to
 /// an expression of other type - the type is specified by `field`
 let convertStringValue missingValuesStr cultureStr (field: PrimitiveInferedProperty) =
+    let fieldName = field.Name
+    let field = field.Value
 
     let returnType =
         match field.TypeWrapper with
@@ -92,7 +94,7 @@ let convertStringValue missingValuesStr cultureStr (field: PrimitiveInferedPrope
             let varExpr = Expr.Cast<string option>(Expr.Var var)
 
             let body =
-                typeof<TextRuntime>?GetNonOptionalValue field.RuntimeType (field.Name, convert varExpr, varExpr)
+                typeof<TextRuntime>?GetNonOptionalValue field.RuntimeType (fieldName, convert varExpr, varExpr)
 
             Expr.Let(var, value, body)
         | TypeWrapper.Option -> convert value

--- a/src/CommonProviderImplementation/Helpers.fs
+++ b/src/CommonProviderImplementation/Helpers.fs
@@ -22,9 +22,9 @@ open ProviderImplementation.ProvidedTypes
 // ----------------------------------------------------------------------------------------------
 
 [<AutoOpen>]
-module internal PrimitiveInferedPropertyExtensions =
+module internal PrimitiveInferedValueExtensions =
 
-    type PrimitiveInferedProperty with
+    type PrimitiveInferedValue with
 
         member x.TypeWithMeasure =
             match x.UnitOfMeasure with

--- a/src/CommonRuntime/StructuralTypes.fs
+++ b/src/CommonRuntime/StructuralTypes.fs
@@ -192,6 +192,15 @@ type Bit = Bit
 
 // ------------------------------------------------------------------------------------------------
 
+/// Represents a transformation of a type
+[<RequireQualifiedAccess>]
+type TypeWrapper =
+    /// No transformation will be made to the type
+    | None
+    /// The type T will be converter to type T option
+    | Option
+    /// The type T will be converter to type Nullable<T>
+    | Nullable
 /// Represents type information about a primitive property (used mainly in the CSV provider)
 /// This type captures the type, unit of measure and handling of missing values (if we
 /// infer that the value may be missing, we can generate option<T> or nullable<T>)
@@ -219,12 +228,3 @@ type PrimitiveInferedProperty =
     static member Create(name, typ, optional, unit) =
         PrimitiveInferedProperty.Create(name, typ, (if optional then TypeWrapper.Option else TypeWrapper.None), unit)
 
-/// Represents a transformation of a type
-[<RequireQualifiedAccess>]
-type TypeWrapper =
-    /// No transformation will be made to the type
-    | None
-    /// The type T will be converter to type T option
-    | Option
-    /// The type T will be converter to type Nullable<T>
-    | Nullable

--- a/src/Csv/CsvInference.fs
+++ b/src/Csv/CsvInference.fs
@@ -263,7 +263,8 @@ let internal parseHeaders headers numberOfColumns schema unitsOfMeasureProvider 
                 match parseResult with
                 | SchemaParseResult.Name name -> makeUnique name, None
                 | SchemaParseResult.NameAndUnit (name, unit) ->
-                    // store the original header because the inferred type might not support units of measure
+                    // store the original header because the inferred type might not support units of measure.
+                    // format: schemaDefinition \n schemaName
                     (makeUnique item) + "\n" + (makeUnique name), Some unit
                 | SchemaParseResult.Full prop ->
                     let prop = { prop with Name = makeUnique prop.Name }
@@ -367,6 +368,14 @@ let internal getFields preferOptionals inferedType schema =
             match Array.get schema index with
             | Some prop -> prop
             | None ->
+                let schemaCompleteDefinition, schemaName =
+                    let split = field.Name.Split('\n')
+
+                    if split.Length > 1 then
+                        split.[0], split.[1]
+                    else
+                        field.Name, field.Name
+
                 match field.Type with
                 | InferedType.Primitive (typ, unit, optional) ->
 
@@ -394,15 +403,14 @@ let internal getFields preferOptionals inferedType schema =
                         match unit with
                         | Some unit ->
                             if StructuralInference.supportsUnitsOfMeasure typ then
-                                typ, Some unit, field.Name.Split('\n').[1]
+                                typ, Some unit, schemaName
                             else
-                                typ, None, field.Name.Split('\n').[0]
-                        | _ -> typ, None, field.Name.Split('\n').[0]
+                                typ, None, schemaCompleteDefinition
+                        | _ -> typ, None, schemaCompleteDefinition
 
                     PrimitiveInferedProperty.Create(name, typ, typWrapper, unit)
 
-                | _ ->
-                    PrimitiveInferedProperty.Create(field.Name.Split('\n').[0], typeof<string>, preferOptionals, None))
+                | _ -> PrimitiveInferedProperty.Create(schemaCompleteDefinition, typeof<string>, preferOptionals, None))
 
     | _ -> failwithf "inferFields: Expected record type, got %A" inferedType
 

--- a/src/Json/JsonConversionsGenerator.fs
+++ b/src/Json/JsonConversionsGenerator.fs
@@ -1,4 +1,4 @@
-﻿// ----------------------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------
 // Conversions from string to various primitive types
 // ----------------------------------------------------------------------------------------------
 
@@ -48,10 +48,9 @@ type JsonConversionCallingType =
 
 /// Creates a function that takes Expr<JsonValue option> and converts it to
 /// an expression of other type - the type is specified by `field`
-let convertJsonValue missingValuesStr cultureStr canPassAllConversionCallingTypes (field: PrimitiveInferedProperty) =
+let convertJsonValue missingValuesStr cultureStr canPassAllConversionCallingTypes (field: PrimitiveInferedValue) =
 
     assert (field.TypeWithMeasure = field.RuntimeType)
-    assert (field.Name = "")
 
     let returnType =
         match field.TypeWrapper with

--- a/src/Json/JsonGenerator.fs
+++ b/src/Json/JsonGenerator.fs
@@ -300,7 +300,7 @@ module JsonTypeBuilder =
         | InferedType.Primitive (inferedType, unit, optional) ->
 
             let typ, conv, conversionCallingType =
-                PrimitiveInferedProperty.Create("", inferedType, optional, unit)
+                PrimitiveInferedValue.Create(inferedType, optional, unit)
                 |> convertJsonValue "" ctx.CultureStr canPassAllConversionCallingTypes
 
             { ConvertedType = typ

--- a/tests/FSharp.Data.DesignTime.Tests/InferenceTests.fs
+++ b/tests/FSharp.Data.DesignTime.Tests/InferenceTests.fs
@@ -295,8 +295,8 @@ let ``Infers units of measure correctly``() =
       ||> CsvInference.getFields false
       |> List.map (fun field ->
           field.Name,
-          field.RuntimeType,
-          prettyTypeName field.TypeWithMeasure)
+          field.Value.RuntimeType,
+          prettyTypeName field.Value.TypeWithMeasure)
 
     let propString =  "String(metre)"      , typeof<string>  , "string"
     let propFloat =   "Float"              , typeof<float>   , "float<meter>"
@@ -319,9 +319,9 @@ let ``Inference schema override by column name``() =
     ||> CsvInference.getFields false
     |> List.map (fun field ->
         field.Name,
-        field.RuntimeType,
-        prettyTypeName field.TypeWithMeasure,
-        field.TypeWrapper)
+        field.Value.RuntimeType,
+        prettyTypeName field.Value.TypeWithMeasure,
+        field.Value.TypeWrapper)
 
   let col1 = "A"       , typeof<int>    , "int<second>", TypeWrapper.None
   let col2 = "B"       , typeof<decimal>, "decimal"    , TypeWrapper.Nullable
@@ -342,9 +342,9 @@ let ``Inference schema override by parameter``() =
     ||> CsvInference.getFields false
     |> List.map (fun field ->
         field.Name,
-        field.RuntimeType,
-        prettyTypeName field.TypeWithMeasure,
-        field.TypeWrapper)
+        field.Value.RuntimeType,
+        prettyTypeName field.Value.TypeWithMeasure,
+        field.Value.TypeWrapper)
 
   let col1 = "Column1" , typeof<float>, "float"        , TypeWrapper.None
   let col2 = "Foo"     , typeof<int>  , "int"          , TypeWrapper.None

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -635,5 +635,5 @@ let ``InferColumnTypes shall infer empty string as Double``() =
   let csv = CsvFile.Load(Path.Combine(__SOURCE_DIRECTORY__, "Data/emptyMissingValue.csv"))
   let types = csv.InferColumnTypes(2,[|""|],System.Globalization.CultureInfo.GetCultureInfo(""), null, false, false)
   let expected = "Double"
-  let actual = types.[3].InferedType.Name
+  let actual = types.[3].Value.InferedType.Name
   actual |> should equal expected


### PR DESCRIPTION
This is a series of commits I did while working on #1447 and #1448 that were not strictly necessary for the aforementioned PRs to work, but I think it might be nice to have anyway.

Changes:
- Fix an out of bound exception I saw while debugging the providers. It might not happen when the providers work, but now it will never crash and is better documented.
- We have a `PrimitiveInferedProperty` to represent a type and a name, but there are several cases where we just want a type, so I added a `PrimitiveInferedValue` to do just that. The core or #1447 was initially based on this change, but in the end I did it another way.
- As seen in #1448, there is a test that ensures an xsd is seen as invalid. Unfortunately, this test outputs an error message in the console that is very confusing because the test works. I suppressed this message.

If you feel like some commits are undesirable, I can remove them...  
Oh, and this should merge cleanly with #1447 BTW. Unless the auto-formatting messed something after I checked.