### PR TITLE
Fix http tests

### DIFF
--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -11,6 +11,9 @@
     <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Data/**/*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/tests/FSharp.Data.Tests/Http.fs
+++ b/tests/FSharp.Data.Tests/Http.fs
@@ -194,7 +194,7 @@ let ``Web request's timeout is used`` () =
     let exc = Assert.Throws<WebException> (fun () ->
         Http.Request(localServer.BaseAddress + "/200?sleep=1000", customizeHttpRequest = (fun req -> req.Timeout <- 1; req)) |> ignore)
 
-    Assert.AreEqual(typeof<TimeoutException>, exc.InnerException.GetType())
+    exc.Status |> should equal WebExceptionStatus.Timeout
 
 [<Test>]
 let ``Timeout argument is used`` () =
@@ -202,7 +202,7 @@ let ``Timeout argument is used`` () =
     let exc = Assert.Throws<WebException> (fun () ->
         Http.Request(localServer.BaseAddress + "/200?sleep=1000", timeout = 1) |> ignore)
 
-    Assert.AreEqual(typeof<TimeoutException>, exc.InnerException.GetType())
+    exc.Status |> should equal WebExceptionStatus.Timeout
 
 [<Test>]
 let ``Setting timeout in customizeHttpRequest overrides timeout argument`` () =


### PR DESCRIPTION
The CI for #1447 already failed two times, so let's see if this PR improves the situation...

I initially thought the problem was simply that using an external (internet) endpoint for the tests was unreliable, but the tests were still failing a bit randomly after replacing the remote endpoints with a local http test server.

After investigation, I believe there is a race condition between the http stack timeout and the `Async.StartChild` timeout. (in `getResponse` in `Http.fs`)  
If the http stack timeout is triggered first, the inner exception is null. Since the tests were asserting that the inner exception should be a `TimeoutException`, they were failing in this case.

In all cases, the `WebException` status should indicate a timeout, so I changed the assertion accordingly...