### PR TITLE
Remove explicit PackageReference in projects + include paket.references

### DIFF
--- a/FSharp.Data.sln
+++ b/FSharp.Data.sln
@@ -3,74 +3,20 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.32814.64
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{7E48C05A-8C42-4871-A618-180BEEF696AA}"
-	ProjectSection(SolutionItems) = preProject
-		docs\index.md = docs\index.md
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "data", "data", "{78CB4667-C0B2-487E-8D48-84FFD8DBF9AA}"
-	ProjectSection(SolutionItems) = preProject
-		docs\data\AirQuality.csv = docs\data\AirQuality.csv
-		docs\data\MSFT.csv = docs\data\MSFT.csv
-		docs\data\SmallTest.csv = docs\data\SmallTest.csv
-		docs\data\Titanic.csv = docs\data\Titanic.csv
-		docs\data\TwitterStream.json = docs\data\TwitterStream.json
-		docs\data\WorldBank.json = docs\data\WorldBank.json
-		docs\data\Writers.xml = docs\data\Writers.xml
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{EF9F7922-4570-4D6D-8034-C3582756239B}"
-	ProjectSection(SolutionItems) = preProject
-		docs\tools\generate.fsx = docs\tools\generate.fsx
-		performanceAnalysis.fsx = performanceAnalysis.fsx
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "templates", "templates", "{839C977B-55D4-4EFC-8B81-290357C836D3}"
-	ProjectSection(SolutionItems) = preProject
-		docs\tools\templates\template.cshtml = docs\tools\templates\template.cshtml
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "library", "library", "{5F82EB06-4E8B-4733-A0C7-F210925DDD04}"
-	ProjectSection(SolutionItems) = preProject
-		docs\library\CsvFile.fsx = docs\library\CsvFile.fsx
-		docs\library\CsvProvider.fsx = docs\library\CsvProvider.fsx
-		docs\library\HtmlCssSelectors.fsx = docs\library\HtmlCssSelectors.fsx
-		docs\library\HtmlParser.fsx = docs\library\HtmlParser.fsx
-		docs\library\HtmlProvider.fsx = docs\library\HtmlProvider.fsx
-		docs\library\Http.fsx = docs\library\Http.fsx
-		docs\library\JsonProvider.fsx = docs\library\JsonProvider.fsx
-		docs\library\JsonValue.fsx = docs\library\JsonValue.fsx
-		docs\library\WorldBank.fsx = docs\library\WorldBank.fsx
-		docs\library\XmlProvider.fsx = docs\library\XmlProvider.fsx
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tutorials", "tutorials", "{D90D3EC4-8C1E-48B1-988A-95217B2BBDB8}"
 	ProjectSection(SolutionItems) = preProject
 		docs\tutorials\JsonAnonymizer.fsx = docs\tutorials\JsonAnonymizer.fsx
 		docs\tutorials\JsonToXml.fsx = docs\tutorials\JsonToXml.fsx
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ja", "ja", "{CA5C64CE-E68C-4320-A00A-E67CA883B9D2}"
-	ProjectSection(SolutionItems) = preProject
-		docs\ja\contributing.md = docs\ja\contributing.md
-		docs\ja\library\CsvFile.fsx = docs\ja\library\CsvFile.fsx
-		docs\ja\library\CsvProvider.fsx = docs\ja\library\CsvProvider.fsx
-		docs\ja\fsharpdata.md = docs\ja\fsharpdata.md
-		docs\ja\library\Http.fsx = docs\ja\library\Http.fsx
-		docs\ja\index.md = docs\ja\index.md
-		docs\ja\library\JsonProvider.fsx = docs\ja\library\JsonProvider.fsx
-		docs\ja\tutorials\JsonToXml.fsx = docs\ja\tutorials\JsonToXml.fsx
-		docs\ja\library\JsonValue.fsx = docs\ja\library\JsonValue.fsx
-		docs\tools\templates\ja\template.cshtml = docs\tools\templates\ja\template.cshtml
-		docs\ja\library\WorldBank.fsx = docs\ja\library\WorldBank.fsx
-		docs\ja\library\XmlProvider.fsx = docs\ja\library\XmlProvider.fsx
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{36E72EB1-5847-4B38-8993-B951648CB0D9}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.fantomasignore = .fantomasignore
 		build.fsx = build.fsx
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE.md = LICENSE.md
+		paket.dependencies = paket.dependencies
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
 		src\SetupTesting.fsx = src\SetupTesting.fsx
@@ -103,6 +49,48 @@ EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Data.Csv.Core", "src\FSharp.Data.Csv.Core\FSharp.Data.Csv.Core.fsproj", "{0A1B8B61-268D-4061-B567-A47141C608E4}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Data.WorldBank.Core", "src\FSharp.Data.WorldBank.Core\FSharp.Data.WorldBank.Core.fsproj", "{A69D007B-EAF0-4866-A8B4-A2EDF2614E56}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{8C038DD5-FB03-4E6D-B8F2-D66AE2E6DCC9}"
+	ProjectSection(SolutionItems) = preProject
+		docs\index.md = docs\index.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "library", "library", "{660DBCC8-F7F2-4301-A611-A2F2C97E369D}"
+	ProjectSection(SolutionItems) = preProject
+		docs\library\CsvFile.fsx = docs\library\CsvFile.fsx
+		docs\library\CsvProvider.fsx = docs\library\CsvProvider.fsx
+		docs\library\HtmlCssSelectors.fsx = docs\library\HtmlCssSelectors.fsx
+		docs\library\HtmlParser.fsx = docs\library\HtmlParser.fsx
+		docs\library\HtmlProvider.fsx = docs\library\HtmlProvider.fsx
+		docs\library\Http.fsx = docs\library\Http.fsx
+		docs\library\JsonProvider.fsx = docs\library\JsonProvider.fsx
+		docs\library\JsonValue.fsx = docs\library\JsonValue.fsx
+		docs\library\WorldBank.fsx = docs\library\WorldBank.fsx
+		docs\library\XmlProvider.fsx = docs\library\XmlProvider.fsx
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "data", "data", "{E399369F-268F-4411-84CD-B868F9FE52EF}"
+	ProjectSection(SolutionItems) = preProject
+		docs\data\2017_F1.htm = docs\data\2017_F1.htm
+		docs\data\AirQuality.csv = docs\data\AirQuality.csv
+		docs\data\Census.xml = docs\data\Census.xml
+		docs\data\GitHub.json = docs\data\GitHub.json
+		docs\data\HtmlBody.xml = docs\data\HtmlBody.xml
+		docs\data\MortalityNY.tsv = docs\data\MortalityNY.tsv
+		docs\data\MSFT.csv = docs\data\MSFT.csv
+		docs\data\po.xsd = docs\data\po.xsd
+		docs\data\SmallTest.csv = docs\data\SmallTest.csv
+		docs\data\Titanic.csv = docs\data\Titanic.csv
+		docs\data\TwitterStream.json = docs\data\TwitterStream.json
+		docs\data\WorldBank.json = docs\data\WorldBank.json
+		docs\data\Writers.xml = docs\data\Writers.xml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tutorials", "tutorials", "{0203D290-11AA-48DB-B1E6-156DFDCEEF80}"
+	ProjectSection(SolutionItems) = preProject
+		docs\tutorials\JsonAnonymizer.fsx = docs\tutorials\JsonAnonymizer.fsx
+		docs\tutorials\JsonToXml.fsx = docs\tutorials\JsonToXml.fsx
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -172,6 +160,9 @@ Global
 		{A5B31ACC-56FB-4EC2-917F-BEB3754EF9AC} = {1F33D53A-C007-408C-AF6C-B7D62288F941}
 		{290FED0C-D7C8-486F-AACF-3D7A1304C863} = {1F33D53A-C007-408C-AF6C-B7D62288F941}
 		{750148EC-6A05-421D-96A4-E5AC9D18AF58} = {1F33D53A-C007-408C-AF6C-B7D62288F941}
+		{660DBCC8-F7F2-4301-A611-A2F2C97E369D} = {8C038DD5-FB03-4E6D-B8F2-D66AE2E6DCC9}
+		{E399369F-268F-4411-84CD-B868F9FE52EF} = {8C038DD5-FB03-4E6D-B8F2-D66AE2E6DCC9}
+		{0203D290-11AA-48DB-B1E6-156DFDCEEF80} = {8C038DD5-FB03-4E6D-B8F2-D66AE2E6DCC9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {34E4FA16-B344-439D-A789-1E8355E5659F}

--- a/docs/library/WorldBank.fsx
+++ b/docs/library/WorldBank.fsx
@@ -109,7 +109,7 @@ let countries =
        wb.Countries.Brazil
        wb.Countries.Canada
        wb.Countries.Chile
-       wb.Countries.``Czech Republic``
+       wb.Countries.Czechia
        wb.Countries.Denmark
        wb.Countries.France
        wb.Countries.Greece

--- a/src/FSharp.Data.Csv.Core/FSharp.Data.Csv.Core.fsproj
+++ b/src/FSharp.Data.Csv.Core/FSharp.Data.Csv.Core.fsproj
@@ -18,12 +18,10 @@
     <Compile Include="..\AssemblyInfo.Csv.Core.fs" />
     <Compile Include="InternalsVisibleTo.fs" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.Http\FSharp.Data.Http.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -33,9 +33,7 @@
     <Compile Include="..\Html\HtmlProvider.fs" />
     <Compile Include="..\AssemblyInfo.DesignTime.fs" />
     <None Include="..\Test.fsx" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.Json.Core\FSharp.Data.Json.Core.fsproj" />

--- a/src/FSharp.Data.Html.Core/FSharp.Data.Html.Core.fsproj
+++ b/src/FSharp.Data.Html.Core/FSharp.Data.Html.Core.fsproj
@@ -23,13 +23,11 @@
     <Compile Include="..\AssemblyInfo.Html.Core.fs" />
     <Compile Include="InternalsVisibleTo.fs" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.Csv.Core\FSharp.Data.Csv.Core.fsproj" />
     <ProjectReference Include="..\FSharp.Data.Http\FSharp.Data.Http.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/FSharp.Data.Http/FSharp.Data.Http.fsproj
+++ b/src/FSharp.Data.Http/FSharp.Data.Http.fsproj
@@ -23,9 +23,7 @@
     <Compile Include="..\AssemblyInfo.Http.fs" />
     <Compile Include="InternalsVisibleTo.fs" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <None Include="paket.references" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/FSharp.Data.Json.Core/FSharp.Data.Json.Core.fsproj
+++ b/src/FSharp.Data.Json.Core/FSharp.Data.Json.Core.fsproj
@@ -20,12 +20,10 @@
     <Compile Include="..\AssemblyInfo.Json.Core.fs" />
     <Compile Include="InternalsVisibleTo.fs" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.Http\FSharp.Data.Http.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/FSharp.Data.WorldBank.Core/FSharp.Data.WorldBank.Core.fsproj
+++ b/src/FSharp.Data.WorldBank.Core/FSharp.Data.WorldBank.Core.fsproj
@@ -15,13 +15,11 @@
     <Compile Include="..\AssemblyInfo.WorldBank.Core.fs" />
     <Compile Include="InternalsVisibleTo.fs" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.Http\FSharp.Data.Http.fsproj" />
     <ProjectReference Include="..\FSharp.Data.Json.Core\FSharp.Data.Json.Core.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/FSharp.Data.Xml.Core/FSharp.Data.Xml.Core.fsproj
+++ b/src/FSharp.Data.Xml.Core/FSharp.Data.Xml.Core.fsproj
@@ -18,13 +18,11 @@
     <Compile Include="..\AssemblyInfo.Xml.Core.fs" />
     <Compile Include="InternalsVisibleTo.fs" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.Http\FSharp.Data.Http.fsproj" />
     <ProjectReference Include="..\FSharp.Data.Json.Core\FSharp.Data.Json.Core.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="..\AssemblyInfo.fs" />
     <Compile Include="..\Runtime.fs" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.DesignTime\FSharp.Data.DesignTime.fsproj">
@@ -28,9 +29,6 @@
     <ProjectReference Include="..\FSharp.Data.Html.Core\FSharp.Data.Html.Core.fsproj" />
     <ProjectReference Include="..\FSharp.Data.WorldBank.Core\FSharp.Data.WorldBank.Core.fsproj" />
     <ProjectReference Include="..\FSharp.Data.Http\FSharp.Data.Http.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/FSharp.Data.Core.Tests.CSharp/FSharp.Data.Core.Tests.CSharp.csproj
+++ b/tests/FSharp.Data.Core.Tests.CSharp/FSharp.Data.Core.Tests.CSharp.csproj
@@ -15,11 +15,6 @@
     <Compile Include="JsonExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\FSharp.Data.Http\FSharp.Data.Http.fsproj" />
     <ProjectReference Include="..\..\src\FSharp.Data.Json.Core\FSharp.Data.Json.Core.fsproj" />
     <ProjectReference Include="..\..\src\FSharp.Data.Xml.Core\FSharp.Data.Xml.Core.fsproj" />

--- a/tests/FSharp.Data.Core.Tests/FSharp.Data.Core.Tests.fsproj
+++ b/tests/FSharp.Data.Core.Tests/FSharp.Data.Core.Tests.fsproj
@@ -32,6 +32,9 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\FSharp.Data.Http\FSharp.Data.Http.fsproj" />
     <ProjectReference Include="..\..\src\FSharp.Data.Json.Core\FSharp.Data.Json.Core.fsproj" />
     <ProjectReference Include="..\..\src\FSharp.Data.Xml.Core\FSharp.Data.Xml.Core.fsproj" />

--- a/tests/FSharp.Data.DesignTime.Tests/FSharp.Data.DesignTime.Tests.fsproj
+++ b/tests/FSharp.Data.DesignTime.Tests/FSharp.Data.DesignTime.Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="TypeProviderInstantiation.fs" />
     <Compile Include="InferenceTests.fs" />
     <None Include="expected\**\*" />
+    <None Include="paket.references" />
     <None Include="SignatureTestCases.config" />
     <Compile Include="SignatureTests.fs" />
     <Compile Include="Program.fs" />

--- a/tests/FSharp.Data.Reference.Tests/FSharp.Data.Reference.Tests.fsproj
+++ b/tests/FSharp.Data.Reference.Tests/FSharp.Data.Reference.Tests.fsproj
@@ -14,6 +14,9 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\FSharp.Data.Tests\FSharp.Data.Tests.fsproj" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -27,6 +27,9 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\FSharp.Data\FSharp.Data.fsproj" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />


### PR DESCRIPTION
Fixes #1463 and makes it easier to manage paket files since they are now visible in the solution.

I also took the liberty to re-add solution level items missing or with broken paths.