### PR TITLE
Change the namespace of the public "InferenceMode" enum

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 6.0.1-beta002 - Jan 6 2023
+
+* Change the namespace of the `InferenceMode` enum from `FSharp.Data.Runtime.StructuralInference` to `FSharp.Data`.
+
 ### 6.0.1-beta001 - Aug 18 2022
 
 * There are now multiple packages

--- a/src/CommonRuntime/StructuralInference.fs
+++ b/src/CommonRuntime/StructuralInference.fs
@@ -12,21 +12,6 @@ open FSharp.Data.Runtime
 open FSharp.Data.Runtime.StructuralTypes
 open System.Text.RegularExpressions
 
-/// This is the public inference mode enum with backward compatibility.
-type InferenceMode =
-    /// Used as a default value for backward compatibility with the legacy InferTypesFromValues boolean static parameter.
-    /// The actual behaviour will depend on whether InferTypesFromValues is set to true (default) or false.
-    | BackwardCompatible = 0
-    /// Type everything as strings
-    /// (or the most basic type possible for the value when it's not string, e.g. for json numbers or booleans).
-    | NoInference = 1
-    /// Infer types from values only. Inline schemas are disabled.
-    | ValuesOnly = 2
-    /// Inline schemas types have the same weight as value infered types.
-    | ValuesAndInlineSchemasHints = 3
-    /// Inline schemas types override value infered types. (Value infered types are ignored if an inline schema is present)
-    | ValuesAndInlineSchemasOverrides = 4
-
 /// This is the internal DU representing all the valid cases we support, mapped from the public InferenceMode.
 [<Obsolete("This API will be made internal in a future release. Please file an issue at https://github.com/fsprojects/FSharp.Data/issues/1458 if you need this public.")>]
 type InferenceMode' =

--- a/src/FSharp.Data.Http/FSharp.Data.Http.fsproj
+++ b/src/FSharp.Data.Http/FSharp.Data.Http.fsproj
@@ -11,6 +11,7 @@
     <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="PublicApi.fs" />
     <Compile Include="..\Net\Http.fs" />
     <Compile Include="..\CommonRuntime\IO.fs" />
     <Compile Include="..\CommonRuntime\TextConversions.fs" />

--- a/src/FSharp.Data.Http/PublicApi.fs
+++ b/src/FSharp.Data.Http/PublicApi.fs
@@ -1,0 +1,17 @@
+namespace FSharp.Data
+
+/// This is the public inference mode enum used when initializing a type provider,
+/// with backward compatibility.
+type InferenceMode =
+    /// Used as a default value for backward compatibility with the legacy InferTypesFromValues boolean static parameter.
+    /// The actual behaviour will depend on whether InferTypesFromValues is set to true (default) or false.
+    | BackwardCompatible = 0
+    /// Type everything as strings
+    /// (or the most basic type possible for the value when it's not string, e.g. for json numbers or booleans).
+    | NoInference = 1
+    /// Infer types from values only. Inline schemas are disabled.
+    | ValuesOnly = 2
+    /// Inline schemas types have the same weight as value infered types.
+    | ValuesAndInlineSchemasHints = 3
+    /// Inline schemas types override value infered types. (Value infered types are ignored if an inline schema is present)
+    | ValuesAndInlineSchemasOverrides = 4

--- a/src/Xml/XmlProvider.fs
+++ b/src/Xml/XmlProvider.fs
@@ -7,6 +7,7 @@ open FSharp.Core.CompilerServices
 open ProviderImplementation
 open ProviderImplementation.ProvidedTypes
 open ProviderImplementation.ProviderHelpers
+open FSharp.Data
 open FSharp.Data.Runtime
 open FSharp.Data.Runtime.BaseTypes
 open FSharp.Data.Runtime.StructuralTypes

--- a/tests/FSharp.Data.DesignTime.Tests/TypeProviderInstantiation.fs
+++ b/tests/FSharp.Data.DesignTime.Tests/TypeProviderInstantiation.fs
@@ -5,6 +5,7 @@ open System.IO
 open ProviderImplementation
 open ProviderImplementation.ProvidedTypes
 open ProviderImplementation.ProvidedTypesTesting
+open FSharp.Data
 open FSharp.Data.Runtime
 open FSharp.Data.Runtime.StructuralInference
 


### PR DESCRIPTION
This is a breaking change, but I feel like it's needed...

Using `FSharp.Data.Runtime.StructuralInference` was a mistake (sorry, my bad). It should not be necessary to reference that namespace just to initialize a type provider...

I moved the enum to the `FSharp.Data` namespace instead, the same as the providers so it's readily available:
- Nothing has to be explicitly `open`ed to use the enum with a type provider.
- This will hopefully make the breaking change less painful since it is likely to still compile after the update.

I have no idea how much this new-ish enum is used in the wild, but since it's optional and a bit obscure, it might not impact too many users...

Since the next version will be the new major version 6.x and it's still currently in beta, I think this is a good opportunity to do this kind of thing now.