### PR TITLE
Use `nameof` for all dynamically built quotations

### DIFF
--- a/src/CommonProviderImplementation/ConversionsGenerator.fs
+++ b/src/CommonProviderImplementation/ConversionsGenerator.fs
@@ -94,18 +94,22 @@ let internal convertStringValue missingValuesStr cultureStr (field: PrimitiveInf
             let varExpr = Expr.Cast<string option>(Expr.Var var)
 
             let body =
-                typeof<TextRuntime>?GetNonOptionalValue field.RuntimeType (fieldName, convert varExpr, varExpr)
+                typeof<TextRuntime>?(nameof (TextRuntime.GetNonOptionalValue))
+                    field.RuntimeType
+                    (fieldName, convert varExpr, varExpr)
 
             Expr.Let(var, value, body)
         | TypeWrapper.Option -> convert value
-        | TypeWrapper.Nullable -> typeof<TextRuntime>?OptionToNullable field.RuntimeType (convert value)
+        | TypeWrapper.Nullable ->
+            typeof<TextRuntime>?(nameof (TextRuntime.OptionToNullable)) field.RuntimeType (convert value)
 
     let convertBack value =
         let value =
             match field.TypeWrapper with
             | TypeWrapper.None -> ProviderHelpers.some field.RuntimeType value
             | TypeWrapper.Option -> value
-            | TypeWrapper.Nullable -> typeof<TextRuntime>?NullableToOption field.RuntimeType value
+            | TypeWrapper.Nullable ->
+                typeof<TextRuntime>?(nameof (TextRuntime.NullableToOption)) field.RuntimeType value
 
         getBackConversionQuotation missingValuesStr cultureStr field.InferedType value :> Expr
 

--- a/src/CommonProviderImplementation/Helpers.fs
+++ b/src/CommonProviderImplementation/Helpers.fs
@@ -153,7 +153,7 @@ module internal ProviderHelpers =
         let f = Var("f", convFunc.Type)
 
         let body =
-            typeof<TextRuntime>?AsyncMap (typeof<'T>, resultType) (valueAsync, Expr.Var f)
+            typeof<TextRuntime>?(nameof (TextRuntime.AsyncMap)) (typeof<'T>, resultType) (valueAsync, Expr.Var f)
 
         Expr.Let(f, convFunc, body)
 

--- a/src/Csv/CsvProvider.fs
+++ b/src/Csv/CsvProvider.fs
@@ -1,3 +1,5 @@
+#nowarn "10001" // Disable "This method is intended for use in generated code only." triggered by nameof references.
+
 // --------------------------------------------------------------------------------------
 // CSV type provider
 // --------------------------------------------------------------------------------------
@@ -140,7 +142,7 @@ type public CsvProvider(cfg: TypeProviderConfig) as this =
 
             let ctorCode (Singleton paramValue: Expr list) =
                 let body =
-                    csvErasedType?CreateEmpty
+                    csvErasedType?(nameof (CsvFile.CreateEmpty))
                         ()
                         (Expr.Var rowToStringArrayVar, paramValue, headers, sampleCsv.NumberOfColumns, separators, quote)
 
@@ -153,7 +155,9 @@ type public CsvProvider(cfg: TypeProviderConfig) as this =
 
             let parseRowsCode (Singleton text: Expr list) =
                 let body =
-                    csvErasedType?ParseRows () (text, Expr.Var stringArrayToRowVar, separators, quote, ignoreErrors)
+                    csvErasedType?(nameof (CsvFile.ParseRows))
+                        ()
+                        (text, Expr.Var stringArrayToRowVar, separators, quote, ignoreErrors)
 
                 Expr.Let(stringArrayToRowVar, stringArrayToRow, body)
 
@@ -173,7 +177,7 @@ type public CsvProvider(cfg: TypeProviderConfig) as this =
               CreateFromTextReader =
                 fun reader ->
                     let body =
-                        csvErasedType?Create
+                        csvErasedType?(nameof (CsvFile.Create))
                             ()
                             (Expr.Var stringArrayToRowVar,
                              Expr.Var rowToStringArrayVar,

--- a/src/Html/HtmlGenerator.fs
+++ b/src/Html/HtmlGenerator.fs
@@ -1,3 +1,5 @@
+#nowarn "10001" // Disable "This method is intended for use in generated code only." triggered by nameof references.
+
 // --------------------------------------------------------------------------------------
 // HTML type provider - generate code for accessing inferred elements
 // --------------------------------------------------------------------------------------
@@ -108,7 +110,7 @@ module internal HtmlGenerator =
             let rowConverterVar = Var("rowConverter", rowConverter.Type)
 
             let body =
-                tableErasedWithRowErasedType?Create
+                tableErasedWithRowErasedType?(nameof (HtmlDocument.Create))
                     ()
                     (Expr.Var rowConverterVar, htmlDoc, table.Name, table.HasHeaders.Value)
 
@@ -166,7 +168,7 @@ module internal HtmlGenerator =
             let rowConverterVar = Var("rowConverter", rowConverter.Type)
 
             let body =
-                listTypeWithErasedType?Create () (Expr.Var rowConverterVar, htmlDoc, list.Name)
+                listTypeWithErasedType?(nameof (HtmlDocument.Create)) () (Expr.Var rowConverterVar, htmlDoc, list.Name)
 
             Expr.Let(rowConverterVar, rowConverter, body)
 
@@ -228,7 +230,9 @@ module internal HtmlGenerator =
                 let rowConverterVar = Var("rowConverter", rowConverter.Type)
 
                 let body =
-                    listTypeWithErasedType?CreateNested () (Expr.Var rowConverterVar, doc, definitionList.Name, index)
+                    listTypeWithErasedType?(nameof (HtmlList.CreateNested))
+                        ()
+                        (Expr.Var rowConverterVar, doc, definitionList.Name, index)
 
                 Expr.Let(rowConverterVar, rowConverter, body)
 

--- a/src/Json/JsonConversionsGenerator.fs
+++ b/src/Json/JsonConversionsGenerator.fs
@@ -79,12 +79,12 @@ let internal convertJsonValue
         match field.TypeWrapper, canPassAllConversionCallingTypes with
         | TypeWrapper.None, true ->
             wrapInLetIfNeeded value (fun (varExpr: Expr<JsonValueOptionAndPath>) ->
-                typeof<JsonRuntime>?GetNonOptionalValue
+                typeof<JsonRuntime>?(nameof (JsonRuntime.GetNonOptionalValue))
                     (field.RuntimeType)
                     (<@ (%varExpr).Path @>, convert <@ (%varExpr).JsonOpt @>, <@ (%varExpr).JsonOpt @>))
         | TypeWrapper.None, false ->
             wrapInLetIfNeeded value (fun (varExpr: Expr<IJsonDocument>) ->
-                typeof<JsonRuntime>?GetNonOptionalValue
+                typeof<JsonRuntime>?(nameof (JsonRuntime.GetNonOptionalValue))
                     (field.RuntimeType)
                     (<@ (%varExpr).Path() @>, convert <@ Some (%varExpr).JsonValue @>, <@ Some (%varExpr).JsonValue @>))
         | TypeWrapper.Option, true -> convert <@ (%%value: JsonValue option) @>
@@ -93,10 +93,12 @@ let internal convertJsonValue
             convert <@ Some (%%value: IJsonDocument).JsonValue @>
         | TypeWrapper.Nullable, true ->
             //TODO: not covered in tests
-            typeof<TextRuntime>?OptionToNullable (field.RuntimeType) (convert <@ (%%value: JsonValue option) @>)
+            typeof<TextRuntime>?(nameof (TextRuntime.OptionToNullable))
+                (field.RuntimeType)
+                (convert <@ (%%value: JsonValue option) @>)
         | TypeWrapper.Nullable, false ->
             //TODO: not covered in tests
-            typeof<TextRuntime>?OptionToNullable
+            typeof<TextRuntime>?(nameof (TextRuntime.OptionToNullable))
                 (field.RuntimeType)
                 (convert <@ Some (%%value: IJsonDocument).JsonValue @>)
 

--- a/src/Json/JsonGenerator.fs
+++ b/src/Json/JsonGenerator.fs
@@ -358,7 +358,7 @@ module JsonTypeBuilder =
 
             let conv =
                 fun (jDoc: Expr) ->
-                    ctx.JsonRuntimeType?ConvertArray
+                    ctx.JsonRuntimeType?(nameof (JsonRuntime.ConvertArray))
                         (elementResult.ConvertedTypeErased ctx)
                         (jDoc, elementResult.ConverterFunc ctx)
 
@@ -444,17 +444,17 @@ module JsonTypeBuilder =
                     let itemsSeqType = typedefof<_ seq>.MakeGenericType ([| tupleType |])
 
                     let itemsGetter (Singleton jDoc) =
-                        ctx.JsonRuntimeType?ConvertRecordToDictionary
+                        ctx.JsonRuntimeType?(nameof (JsonRuntime.ConvertRecordToDictionary))
                             (keyResult.ConvertedType, valueConvertedTypeErased)
                             (jDoc, keyResult.ConverterFunc ctx, valueResult.ConverterFunc ctx)
 
                     let keysGetter (Singleton jDoc) =
-                        ctx.JsonRuntimeType?GetKeysFromInferedDictionary
+                        ctx.JsonRuntimeType?(nameof (JsonRuntime.GetKeysFromInferedDictionary))
                             (keyResult.ConvertedType)
                             (jDoc, keyResult.ConverterFunc ctx)
 
                     let valuesGetter (Singleton jDoc) =
-                        ctx.JsonRuntimeType?GetValuesFromInferedDictionary
+                        ctx.JsonRuntimeType?(nameof (JsonRuntime.GetValuesFromInferedDictionary))
                             (valueConvertedTypeErased)
                             (jDoc, valueResult.ConverterFunc ctx)
 
@@ -464,17 +464,17 @@ module JsonTypeBuilder =
                         | _ -> failwith "Parameter mismatch"
 
                     let itemGetter (Doubleton (jDoc, key)) =
-                        ctx.JsonRuntimeType?GetValueByKeyFromInferedDictionary
+                        ctx.JsonRuntimeType?(nameof (JsonRuntime.GetValueByKeyFromInferedDictionary))
                             (keyResult.ConvertedType, valueConvertedTypeErased)
                             (jDoc, keyResult.ConverterFunc ctx, valueResult.ConverterFunc ctx, key)
 
                     let tryFindCode (Doubleton (jDoc, key)) =
-                        ctx.JsonRuntimeType?TryGetValueByKeyFromInferedDictionary
+                        ctx.JsonRuntimeType?(nameof (JsonRuntime.TryGetValueByKeyFromInferedDictionary))
                             (keyResult.ConvertedType, valueConvertedTypeErased)
                             (jDoc, keyResult.ConverterFunc ctx, valueResult.ConverterFunc ctx, key)
 
                     let containsKeyCode (Doubleton (jDoc, key)) =
-                        ctx.JsonRuntimeType?InferedDictionaryContainsKey
+                        ctx.JsonRuntimeType?(nameof (JsonRuntime.InferedDictionaryContainsKey))
                             (keyResult.ConvertedType)
                             (jDoc, keyResult.ConverterFunc ctx, key)
 
@@ -528,7 +528,7 @@ module JsonTypeBuilder =
 
                             let cultureStr = ctx.CultureStr
 
-                            ctx.JsonRuntimeType?CreateRecordFromDictionary
+                            ctx.JsonRuntimeType?(nameof (JsonRuntime.CreateRecordFromDictionary))
                                 (keyResult.ConvertedType, valueConvertedTypeErased)
                                 (kvSeq, cultureStr, convFunc)
 
@@ -562,7 +562,7 @@ module JsonTypeBuilder =
                                       match propResult.OptionalConverter with
                                       | Some _ ->
                                           //TODO: not covered in tests
-                                          ctx.JsonRuntimeType?ConvertOptionalProperty
+                                          ctx.JsonRuntimeType?(nameof (JsonRuntime.ConvertOptionalProperty))
                                               (propResult.ConvertedTypeErased ctx)
                                               (jDoc, propName, propResult.ConverterFunc ctx)
 
@@ -644,7 +644,7 @@ module JsonTypeBuilder =
                             // from the runtime similarly to options and arrays)
                             let cultureStr = ctx.CultureStr
 
-                            ctx.JsonRuntimeType?GetArrayChildrenByTypeTag
+                            ctx.JsonRuntimeType?(nameof (JsonRuntime.GetArrayChildrenByTypeTag))
                                 (result.ConvertedTypeErased ctx)
                                 (jDoc, cultureStr, tagCode, result.ConverterFunc ctx)
 
@@ -653,7 +653,7 @@ module JsonTypeBuilder =
                             // Similar to the previous case, but call `TryGetArrayChildByTypeTag`
                             let cultureStr = ctx.CultureStr
 
-                            ctx.JsonRuntimeType?TryGetArrayChildByTypeTag
+                            ctx.JsonRuntimeType?(nameof (JsonRuntime.TryGetArrayChildByTypeTag))
                                 (result.ConvertedTypeErased ctx)
                                 (jDoc, cultureStr, tagCode, result.ConverterFunc ctx)))
 
@@ -670,7 +670,7 @@ module JsonTypeBuilder =
                         assert (multiplicity = InferedMultiplicity.OptionalSingle)
                         let cultureStr = ctx.CultureStr
 
-                        ctx.JsonRuntimeType?TryGetValueByTypeTag
+                        ctx.JsonRuntimeType?(nameof (JsonRuntime.TryGetValueByTypeTag))
                             (result.ConvertedTypeErased ctx)
                             (jDoc, cultureStr, tagCode, result.ConverterFunc ctx)))
 


### PR DESCRIPTION
This makes it easier to debug and follow the code since the IDE is able to find the referenced methods and display their signature at the location they are used.

This is only a technical refactoring. Functionally, nothing should have changed.