### PR TITLE
Fix reading CSV from non seekable network stream

### DIFF
--- a/src/Csv/CsvRuntime.fs
+++ b/src/Csv/CsvRuntime.fs
@@ -65,15 +65,14 @@ module internal CsvReader =
         /// Reads multiple lines from the input, skipping newline characters
         let rec readLines lineNumber =
             seq {
-                match reader.Peek() with
+                match reader.Read() with
                 | -1 -> ()
                 | Char '\r'
                 | Char '\n' ->
-                    reader.Read() |> ignore
                     yield! readLines lineNumber
-                | _ ->
+                | Char c ->
                     yield
-                        readLine [] (StringBuilder())
+                        readLine [] (StringBuilder(string c))
                         |> List.rev
                         |> Array.ofList,
                         lineNumber

--- a/src/Csv/CsvRuntime.fs
+++ b/src/Csv/CsvRuntime.fs
@@ -50,7 +50,10 @@ module internal CsvReader =
         /// Reads a line with data that are separated using specified separators
         /// and may be quoted. Ends with newline or end of input.
         let rec readLine data (chars: StringBuilder) =
-            match reader.Read() with
+            reader.Read() |> readLineWithChar data chars
+
+        and readLineWithChar data (chars: StringBuilder) i =
+            match i with
             | -1
             | Char '\r'
             | Char '\n' ->
@@ -70,9 +73,9 @@ module internal CsvReader =
                 | Char '\r'
                 | Char '\n' ->
                     yield! readLines lineNumber
-                | Char c ->
+                | i ->
                     yield
-                        readLine [] (StringBuilder(string c))
+                        readLineWithChar [] (StringBuilder()) i
                         |> List.rev
                         |> Array.ofList,
                         lineNumber

--- a/src/Csv/CsvRuntime.fs
+++ b/src/Csv/CsvRuntime.fs
@@ -68,8 +68,7 @@ module internal CsvReader =
                 match reader.Read() with
                 | -1 -> ()
                 | Char '\r'
-                | Char '\n' ->
-                    yield! readLines lineNumber
+                | Char '\n' -> yield! readLines lineNumber
                 | current ->
                     yield
                         readLine [] (StringBuilder()) current

--- a/tests/FSharp.Data.Core.Tests/CsvReader.fs
+++ b/tests/FSharp.Data.Core.Tests/CsvReader.fs
@@ -76,9 +76,11 @@ let ``Quoted strings parsed correctly`` () =
 [<Test>]
 let ``Read all rows from non seekable slow network stream`` () =
 
-  let data = """ABC
-DEF
-GHI"""
+  let data = """ABC;1
+DEF;2
+GHI;3
+"QUOTED";4
+;5"""
 
   let encoding = System.Text.Encoding.UTF8
   let bytes = data |> encoding.GetBytes 
@@ -105,6 +107,11 @@ GHI"""
   let reader = new StreamReader(fakeNetworkStream, encoding)
 
   let actual = readCsvFile reader ";" '"' |> Seq.map fst |> Array.ofSeq
-  let expected = [| [| "ABC" |]; [| "DEF" |]; [| "GHI" |] |]
+  let expected = 
+    [| [| "ABC"; "1" |]
+       [| "DEF"; "2" |]
+       [| "GHI"; "3" |]
+       [| "QUOTED"; "4" |]
+       [| ""; "5" |] |]
 
   actual |> should equal expected

--- a/tests/FSharp.Data.Core.Tests/CsvReader.fs
+++ b/tests/FSharp.Data.Core.Tests/CsvReader.fs
@@ -72,3 +72,39 @@ let ``Quoted strings parsed correctly`` () =
   let expected = [|[|"12"; "a\n\rb"|]; [|"123"; "\"hello\" world"|]|]
   actual |> should equal expected
 
+
+[<Test>]
+let ``Read all rows from non seekable slow network stream`` () =
+
+  let data = """ABC
+DEF
+GHI"""
+
+  let encoding = System.Text.Encoding.UTF8
+  let bytes = data |> encoding.GetBytes 
+  use memoryStream = new MemoryStream(bytes)
+
+  use fakeNetworkStream =
+    { new System.IO.Stream () with
+        override _.CanRead: bool = memoryStream.CanRead
+        override _.CanSeek: bool = false
+        override _.CanWrite: bool = false
+        override _.Flush (): unit = memoryStream.Flush( )
+        override _.Length: int64 = raise (System.NotSupportedException())
+        override _.Position
+            with get (): int64 = memoryStream.Position
+            and set (v: int64): unit = raise (System.NotSupportedException ())
+        override _.Read(buffer: byte[], offset: int, _: int): int = 
+          memoryStream.Read (buffer, offset, 1 (* Ignores the count parameter and reads one byte only to simulate a slow network stream *))
+        override _.ReadByte(): int = memoryStream.ReadByte ()
+        override _.Seek(offset: int64, origin: SeekOrigin): int64 = raise (System.NotSupportedException ())
+        override _.SetLength(value: int64): unit = raise (System.NotSupportedException ())
+        override _.Write(buffer: byte[], offset: int, count: int): unit = raise (System.NotSupportedException ())
+        override _.WriteByte(value: byte): unit = raise (System.NotSupportedException ()) }
+
+  let reader = new StreamReader(fakeNetworkStream, encoding)
+
+  let actual = readCsvFile reader ";" '"' |> Seq.map fst |> Array.ofSeq
+  let expected = [| [| "ABC" |]; [| "DEF" |]; [| "GHI" |] |]
+
+  actual |> should equal expected


### PR DESCRIPTION
When using the `FSharp.Data.Csv.Core` package to read massive CSV data from an AWS S3 bucket we had some issues because sometimes many rows got lost.

The problem seems to be related to the `StreamReader.Peek()` method that is used. When `StreamReader.Peek()` returns `-1` the whole reading stops with the current implementation. The [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.streamreader.peek?view=net-7.0) states that `-1` is not only returned in case of the end of the stream, but also if the stream is not seekable and the stream doesn't read all data that was requested.

> An integer representing the next character to be read, or -1 if there are no characters to be read or if the stream does not support seeking.

This can be fixed by using `StreamReader.Read()` instead, because this method is blocking. I have also tried to add a unit test to simulate the problem with a non seekable stream that always reads just 1 byte when calling `Stream.Read(buffer, offset, count)`.

