### PR TITLE
Fix generated code of the json provider with `PreferDictionaries` when values are arrays

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 * Move common runtime utilities out of `FSharp.Data.Http` and into a new `FSharp.Data.Runtime.Utilities` assembly.
 * Add `aria-label` to the list of html attributes used to infer names of types provided by the HtmlProvider.
 * Enable TLS 1.2 when requesting http(s) samples from the type providers.
+* Fix generated code of the json provider with `PreferDictionaries` when values are arrays.
 
 ### 6.0.1-beta001 - Aug 18 2022
 

--- a/tests/FSharp.Data.DesignTime.Tests/SignatureTestCases.config
+++ b/tests/FSharp.Data.DesignTime.Tests/SignatureTestCases.config
@@ -190,6 +190,14 @@ Json,DictionaryInference.json,false,,,true,true,BackwardCompatible
 Json,DictionaryInference.json,false,,,true,true,ValuesOnly
 Json,DictionaryInference.json,false,,,true,true,ValuesAndInlineSchemasHints
 Json,DictionaryInference.json,false,,,true,true,ValuesAndInlineSchemasOverrides
+Json,DictionaryInference-arrays.json,false,,,true,false,BackwardCompatible
+Json,DictionaryInference-arrays.json,false,,,true,false,ValuesOnly
+Json,DictionaryInference-arrays.json,false,,,true,false,ValuesAndInlineSchemasHints
+Json,DictionaryInference-arrays.json,false,,,true,false,ValuesAndInlineSchemasOverrides
+Json,DictionaryInference-arrays.json,false,,,true,true,BackwardCompatible
+Json,DictionaryInference-arrays.json,false,,,true,true,ValuesOnly
+Json,DictionaryInference-arrays.json,false,,,true,true,ValuesAndInlineSchemasHints
+Json,DictionaryInference-arrays.json,false,,,true,true,ValuesAndInlineSchemasOverrides
 Html,MarketDepth.htm,false,false,
 Html,MarketDepth.htm,true,false,
 Html,SimpleHtmlTablesWithTr.html,false,false,

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,BackwardCompatible.expected
@@ -1,0 +1,108 @@
+class JsonProvider : obj
+    static member AsyncGetSample: () -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json"), f)
+
+    static member AsyncLoad: uri:string -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri), f)
+
+    static member GetSample: () -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json")))
+
+    static member Load: stream:System.IO.Stream -> JsonProvider+Root
+    JsonDocument.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> JsonProvider+Root
+    JsonDocument.Create(reader)
+
+    static member Load: uri:string -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
+
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
+    static member Parse: text:string -> JsonProvider+Root
+    JsonDocument.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseList: text:string -> JsonProvider+JsonProvider+Root[]
+    JsonDocument.CreateList(((new StringReader(text)) :> TextReader))
+
+
+class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
+    new : mappings:JsonProvider+Mappings -> JsonProvider+Root
+    JsonRuntime.CreateRecord([| ("Mappings",
+                                 (mappings :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(jsonValue, "")
+
+    member Mappings: JsonProvider+Mappings with get
+    JsonRuntime.GetPropertyPacked(this, "Mappings")
+
+
+class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
+    new : 123:JsonProvider+JsonProvider+123[] -> 456:JsonProvider+JsonProvider+123[] -> 789:JsonProvider+JsonProvider+789[] -> JsonProvider+Mappings
+    JsonRuntime.CreateRecord([| ("123",
+                                 (123 :> obj))
+                                ("456",
+                                 (456 :> obj))
+                                ("789",
+                                 (789 :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Mappings
+    JsonDocument.Create(jsonValue, "")
+
+    member 123: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "123"), new Func<_,_>(id)))
+
+    member 456: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "456"), new Func<_,_>(id)))
+
+    member 789: JsonProvider+JsonProvider+789[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "789"), new Func<_,_>(id)))
+
+
+class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> JsonProvider+123
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+123
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+
+class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj))
+                                ("ErrorMessage",
+                                 (errorMessage :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+789
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member ErrorMessage: string option with get
+    JsonRuntime.ConvertString("", JsonRuntime.TryGetPropertyUnpacked(this, "ErrorMessage"))
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -1,0 +1,108 @@
+class JsonProvider : obj
+    static member AsyncGetSample: () -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json"), f)
+
+    static member AsyncLoad: uri:string -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri), f)
+
+    static member GetSample: () -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json")))
+
+    static member Load: stream:System.IO.Stream -> JsonProvider+Root
+    JsonDocument.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> JsonProvider+Root
+    JsonDocument.Create(reader)
+
+    static member Load: uri:string -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
+
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
+    static member Parse: text:string -> JsonProvider+Root
+    JsonDocument.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseList: text:string -> JsonProvider+JsonProvider+Root[]
+    JsonDocument.CreateList(((new StringReader(text)) :> TextReader))
+
+
+class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
+    new : mappings:JsonProvider+Mappings -> JsonProvider+Root
+    JsonRuntime.CreateRecord([| ("Mappings",
+                                 (mappings :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(jsonValue, "")
+
+    member Mappings: JsonProvider+Mappings with get
+    JsonRuntime.GetPropertyPacked(this, "Mappings")
+
+
+class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
+    new : 123:JsonProvider+JsonProvider+123[] -> 456:JsonProvider+JsonProvider+123[] -> 789:JsonProvider+JsonProvider+789[] -> JsonProvider+Mappings
+    JsonRuntime.CreateRecord([| ("123",
+                                 (123 :> obj))
+                                ("456",
+                                 (456 :> obj))
+                                ("789",
+                                 (789 :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Mappings
+    JsonDocument.Create(jsonValue, "")
+
+    member 123: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "123"), new Func<_,_>(id)))
+
+    member 456: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "456"), new Func<_,_>(id)))
+
+    member 789: JsonProvider+JsonProvider+789[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "789"), new Func<_,_>(id)))
+
+
+class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> JsonProvider+123
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+123
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+
+class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj))
+                                ("ErrorMessage",
+                                 (errorMessage :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+789
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member ErrorMessage: string option with get
+    JsonRuntime.ConvertString("", JsonRuntime.TryGetPropertyUnpacked(this, "ErrorMessage"))
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -1,0 +1,108 @@
+class JsonProvider : obj
+    static member AsyncGetSample: () -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json"), f)
+
+    static member AsyncLoad: uri:string -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri), f)
+
+    static member GetSample: () -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json")))
+
+    static member Load: stream:System.IO.Stream -> JsonProvider+Root
+    JsonDocument.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> JsonProvider+Root
+    JsonDocument.Create(reader)
+
+    static member Load: uri:string -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
+
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
+    static member Parse: text:string -> JsonProvider+Root
+    JsonDocument.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseList: text:string -> JsonProvider+JsonProvider+Root[]
+    JsonDocument.CreateList(((new StringReader(text)) :> TextReader))
+
+
+class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
+    new : mappings:JsonProvider+Mappings -> JsonProvider+Root
+    JsonRuntime.CreateRecord([| ("Mappings",
+                                 (mappings :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(jsonValue, "")
+
+    member Mappings: JsonProvider+Mappings with get
+    JsonRuntime.GetPropertyPacked(this, "Mappings")
+
+
+class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
+    new : 123:JsonProvider+JsonProvider+123[] -> 456:JsonProvider+JsonProvider+123[] -> 789:JsonProvider+JsonProvider+789[] -> JsonProvider+Mappings
+    JsonRuntime.CreateRecord([| ("123",
+                                 (123 :> obj))
+                                ("456",
+                                 (456 :> obj))
+                                ("789",
+                                 (789 :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Mappings
+    JsonDocument.Create(jsonValue, "")
+
+    member 123: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "123"), new Func<_,_>(id)))
+
+    member 456: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "456"), new Func<_,_>(id)))
+
+    member 789: JsonProvider+JsonProvider+789[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "789"), new Func<_,_>(id)))
+
+
+class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> JsonProvider+123
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+123
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+
+class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj))
+                                ("ErrorMessage",
+                                 (errorMessage :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+789
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member ErrorMessage: string option with get
+    JsonRuntime.ConvertString("", JsonRuntime.TryGetPropertyUnpacked(this, "ErrorMessage"))
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesOnly.expected
@@ -1,0 +1,108 @@
+class JsonProvider : obj
+    static member AsyncGetSample: () -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json"), f)
+
+    static member AsyncLoad: uri:string -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri), f)
+
+    static member GetSample: () -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json")))
+
+    static member Load: stream:System.IO.Stream -> JsonProvider+Root
+    JsonDocument.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> JsonProvider+Root
+    JsonDocument.Create(reader)
+
+    static member Load: uri:string -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
+
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
+    static member Parse: text:string -> JsonProvider+Root
+    JsonDocument.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseList: text:string -> JsonProvider+JsonProvider+Root[]
+    JsonDocument.CreateList(((new StringReader(text)) :> TextReader))
+
+
+class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
+    new : mappings:JsonProvider+Mappings -> JsonProvider+Root
+    JsonRuntime.CreateRecord([| ("Mappings",
+                                 (mappings :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(jsonValue, "")
+
+    member Mappings: JsonProvider+Mappings with get
+    JsonRuntime.GetPropertyPacked(this, "Mappings")
+
+
+class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
+    new : 123:JsonProvider+JsonProvider+123[] -> 456:JsonProvider+JsonProvider+123[] -> 789:JsonProvider+JsonProvider+789[] -> JsonProvider+Mappings
+    JsonRuntime.CreateRecord([| ("123",
+                                 (123 :> obj))
+                                ("456",
+                                 (456 :> obj))
+                                ("789",
+                                 (789 :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Mappings
+    JsonDocument.Create(jsonValue, "")
+
+    member 123: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "123"), new Func<_,_>(id)))
+
+    member 456: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "456"), new Func<_,_>(id)))
+
+    member 789: JsonProvider+JsonProvider+789[] with get
+    JsonRuntime.ConvertArray(JsonRuntime.GetPropertyPackedOrNull(this, "789"), new Func<_,_>(id)))
+
+
+class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> JsonProvider+123
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+123
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+
+class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj))
+                                ("ErrorMessage",
+                                 (errorMessage :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+789
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member ErrorMessage: string option with get
+    JsonRuntime.ConvertString("", JsonRuntime.TryGetPropertyUnpacked(this, "ErrorMessage"))
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,BackwardCompatible.expected
@@ -42,7 +42,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
-    new : items:int * JsonProvider+MappingsValue seq -> JsonProvider+Mappings
+    new : items:int * JsonProvider+JsonProvider+MappingsValue[] seq -> JsonProvider+Mappings
     JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
@@ -57,62 +57,24 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     member IsEmpty: bool with get
     (Operators.op_Equality JsonRuntime.GetRecordProperties(this).Length 0)
 
-    member Item: JsonProvider+MappingsValue with get
-    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+    member Item: JsonProvider+JsonProvider+MappingsValue[] with get
+    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))), key)
 
-    member Items: int * JsonProvider+MappingsValue seq with get
-    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)))
+    member Items: int * JsonProvider+JsonProvider+MappingsValue[] seq with get
+    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))))
 
     member Keys: int[] with get
     JsonRuntime.GetKeysFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)))
 
-    member TryFind: key:int -> JsonProvider+MappingsValue option
-    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+    member TryFind: key:int -> JsonProvider+JsonProvider+MappingsValue[] option
+    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))), key)
 
-    member Values: JsonProvider+JsonProvider+MappingsValue[] with get
-    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(id)))
+    member Values: JsonProvider+JsonProvider+JsonProvider+MappingsValue[][] with get
+    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))))
 
 
 class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
-    new : 123s:JsonProvider+JsonProvider+123[] -> record:JsonProvider+123 option -> 789s:JsonProvider+JsonProvider+789[] -> JsonProvider+MappingsValue
-    JsonRuntime.CreateArray([| (123s :> obj)
-                               (record :> obj)
-                               (789s :> obj) |], "")
-
-    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
-    JsonDocument.Create(jsonValue, "")
-
-    member 123s: JsonProvider+JsonProvider+123[] with get
-    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@123", new Func<_,_>(id)))
-
-    member 789s: JsonProvider+JsonProvider+789[] with get
-    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@789", new Func<_,_>(id)))
-
-    member Record: JsonProvider+123 option with get
-    JsonRuntime.TryGetArrayChildByTypeTag(this, "", "Record@456", new Func<_,_>(id)))
-
-
-class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
-    new : groupId:int -> canDelete:bool -> JsonProvider+123
-    JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
-                                ("CanDelete",
-                                 (canDelete :> obj)) |], "")
-
-    new : jsonValue:JsonValue -> JsonProvider+123
-    JsonDocument.Create(jsonValue, "")
-
-    member CanDelete: bool with get
-    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
-    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
-
-    member GroupId: int with get
-    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
-    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
-
-
-class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
-    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+MappingsValue
     JsonRuntime.CreateRecord([| ("GroupId",
                                  (groupId :> obj))
                                 ("CanDelete",
@@ -120,7 +82,7 @@ class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
                                 ("ErrorMessage",
                                  (errorMessage :> obj)) |], "")
 
-    new : jsonValue:JsonValue -> JsonProvider+789
+    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
     JsonDocument.Create(jsonValue, "")
 
     member CanDelete: bool with get

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,BackwardCompatible.expected
@@ -1,0 +1,137 @@
+class JsonProvider : obj
+    static member AsyncGetSample: () -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json"), f)
+
+    static member AsyncLoad: uri:string -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri), f)
+
+    static member GetSample: () -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json")))
+
+    static member Load: stream:System.IO.Stream -> JsonProvider+Root
+    JsonDocument.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> JsonProvider+Root
+    JsonDocument.Create(reader)
+
+    static member Load: uri:string -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
+
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
+    static member Parse: text:string -> JsonProvider+Root
+    JsonDocument.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseList: text:string -> JsonProvider+JsonProvider+Root[]
+    JsonDocument.CreateList(((new StringReader(text)) :> TextReader))
+
+
+class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
+    new : mappings:JsonProvider+Mappings -> JsonProvider+Root
+    JsonRuntime.CreateRecord([| ("Mappings",
+                                 (mappings :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(jsonValue, "")
+
+    member Mappings: JsonProvider+Mappings with get
+    JsonRuntime.GetPropertyPacked(this, "Mappings")
+
+
+class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
+    new : items:int * JsonProvider+MappingsValue seq -> JsonProvider+Mappings
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
+
+    new : jsonValue:JsonValue -> JsonProvider+Mappings
+    JsonDocument.Create(jsonValue, "")
+
+    member ContainsKey: key:int -> bool
+    JsonRuntime.InferedDictionaryContainsKey(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), key)
+
+    member Count: int with get
+    JsonRuntime.GetRecordProperties(this).Length
+
+    member IsEmpty: bool with get
+    (Operators.op_Equality JsonRuntime.GetRecordProperties(this).Length 0)
+
+    member Item: JsonProvider+MappingsValue with get
+    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+
+    member Items: int * JsonProvider+MappingsValue seq with get
+    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)))
+
+    member Keys: int[] with get
+    JsonRuntime.GetKeysFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)))
+
+    member TryFind: key:int -> JsonProvider+MappingsValue option
+    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+
+    member Values: JsonProvider+JsonProvider+MappingsValue[] with get
+    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(id)))
+
+
+class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
+    new : 123s:JsonProvider+JsonProvider+123[] -> record:JsonProvider+123 option -> 789s:JsonProvider+JsonProvider+789[] -> JsonProvider+MappingsValue
+    JsonRuntime.CreateArray([| (123s :> obj)
+                               (record :> obj)
+                               (789s :> obj) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
+    JsonDocument.Create(jsonValue, "")
+
+    member 123s: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@123", new Func<_,_>(id)))
+
+    member 789s: JsonProvider+JsonProvider+789[] with get
+    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@789", new Func<_,_>(id)))
+
+    member Record: JsonProvider+123 option with get
+    JsonRuntime.TryGetArrayChildByTypeTag(this, "", "Record@456", new Func<_,_>(id)))
+
+
+class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> JsonProvider+123
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+123
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+
+class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj))
+                                ("ErrorMessage",
+                                 (errorMessage :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+789
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member ErrorMessage: string option with get
+    JsonRuntime.ConvertString("", JsonRuntime.TryGetPropertyUnpacked(this, "ErrorMessage"))
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasHints.expected
@@ -42,7 +42,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
-    new : items:int * JsonProvider+MappingsValue seq -> JsonProvider+Mappings
+    new : items:int * JsonProvider+JsonProvider+MappingsValue[] seq -> JsonProvider+Mappings
     JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
@@ -57,62 +57,24 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     member IsEmpty: bool with get
     (Operators.op_Equality JsonRuntime.GetRecordProperties(this).Length 0)
 
-    member Item: JsonProvider+MappingsValue with get
-    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+    member Item: JsonProvider+JsonProvider+MappingsValue[] with get
+    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))), key)
 
-    member Items: int * JsonProvider+MappingsValue seq with get
-    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)))
+    member Items: int * JsonProvider+JsonProvider+MappingsValue[] seq with get
+    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))))
 
     member Keys: int[] with get
     JsonRuntime.GetKeysFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)))
 
-    member TryFind: key:int -> JsonProvider+MappingsValue option
-    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+    member TryFind: key:int -> JsonProvider+JsonProvider+MappingsValue[] option
+    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))), key)
 
-    member Values: JsonProvider+JsonProvider+MappingsValue[] with get
-    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(id)))
+    member Values: JsonProvider+JsonProvider+JsonProvider+MappingsValue[][] with get
+    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))))
 
 
 class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
-    new : 123s:JsonProvider+JsonProvider+123[] -> record:JsonProvider+123 option -> 789s:JsonProvider+JsonProvider+789[] -> JsonProvider+MappingsValue
-    JsonRuntime.CreateArray([| (123s :> obj)
-                               (record :> obj)
-                               (789s :> obj) |], "")
-
-    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
-    JsonDocument.Create(jsonValue, "")
-
-    member 123s: JsonProvider+JsonProvider+123[] with get
-    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@123", new Func<_,_>(id)))
-
-    member 789s: JsonProvider+JsonProvider+789[] with get
-    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@789", new Func<_,_>(id)))
-
-    member Record: JsonProvider+123 option with get
-    JsonRuntime.TryGetArrayChildByTypeTag(this, "", "Record@456", new Func<_,_>(id)))
-
-
-class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
-    new : groupId:int -> canDelete:bool -> JsonProvider+123
-    JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
-                                ("CanDelete",
-                                 (canDelete :> obj)) |], "")
-
-    new : jsonValue:JsonValue -> JsonProvider+123
-    JsonDocument.Create(jsonValue, "")
-
-    member CanDelete: bool with get
-    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
-    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
-
-    member GroupId: int with get
-    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
-    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
-
-
-class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
-    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+MappingsValue
     JsonRuntime.CreateRecord([| ("GroupId",
                                  (groupId :> obj))
                                 ("CanDelete",
@@ -120,7 +82,7 @@ class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
                                 ("ErrorMessage",
                                  (errorMessage :> obj)) |], "")
 
-    new : jsonValue:JsonValue -> JsonProvider+789
+    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
     JsonDocument.Create(jsonValue, "")
 
     member CanDelete: bool with get

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasHints.expected
@@ -1,0 +1,137 @@
+class JsonProvider : obj
+    static member AsyncGetSample: () -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json"), f)
+
+    static member AsyncLoad: uri:string -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri), f)
+
+    static member GetSample: () -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json")))
+
+    static member Load: stream:System.IO.Stream -> JsonProvider+Root
+    JsonDocument.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> JsonProvider+Root
+    JsonDocument.Create(reader)
+
+    static member Load: uri:string -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
+
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
+    static member Parse: text:string -> JsonProvider+Root
+    JsonDocument.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseList: text:string -> JsonProvider+JsonProvider+Root[]
+    JsonDocument.CreateList(((new StringReader(text)) :> TextReader))
+
+
+class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
+    new : mappings:JsonProvider+Mappings -> JsonProvider+Root
+    JsonRuntime.CreateRecord([| ("Mappings",
+                                 (mappings :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(jsonValue, "")
+
+    member Mappings: JsonProvider+Mappings with get
+    JsonRuntime.GetPropertyPacked(this, "Mappings")
+
+
+class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
+    new : items:int * JsonProvider+MappingsValue seq -> JsonProvider+Mappings
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
+
+    new : jsonValue:JsonValue -> JsonProvider+Mappings
+    JsonDocument.Create(jsonValue, "")
+
+    member ContainsKey: key:int -> bool
+    JsonRuntime.InferedDictionaryContainsKey(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), key)
+
+    member Count: int with get
+    JsonRuntime.GetRecordProperties(this).Length
+
+    member IsEmpty: bool with get
+    (Operators.op_Equality JsonRuntime.GetRecordProperties(this).Length 0)
+
+    member Item: JsonProvider+MappingsValue with get
+    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+
+    member Items: int * JsonProvider+MappingsValue seq with get
+    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)))
+
+    member Keys: int[] with get
+    JsonRuntime.GetKeysFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)))
+
+    member TryFind: key:int -> JsonProvider+MappingsValue option
+    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+
+    member Values: JsonProvider+JsonProvider+MappingsValue[] with get
+    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(id)))
+
+
+class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
+    new : 123s:JsonProvider+JsonProvider+123[] -> record:JsonProvider+123 option -> 789s:JsonProvider+JsonProvider+789[] -> JsonProvider+MappingsValue
+    JsonRuntime.CreateArray([| (123s :> obj)
+                               (record :> obj)
+                               (789s :> obj) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
+    JsonDocument.Create(jsonValue, "")
+
+    member 123s: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@123", new Func<_,_>(id)))
+
+    member 789s: JsonProvider+JsonProvider+789[] with get
+    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@789", new Func<_,_>(id)))
+
+    member Record: JsonProvider+123 option with get
+    JsonRuntime.TryGetArrayChildByTypeTag(this, "", "Record@456", new Func<_,_>(id)))
+
+
+class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> JsonProvider+123
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+123
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+
+class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj))
+                                ("ErrorMessage",
+                                 (errorMessage :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+789
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member ErrorMessage: string option with get
+    JsonRuntime.ConvertString("", JsonRuntime.TryGetPropertyUnpacked(this, "ErrorMessage"))
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasOverrides.expected
@@ -42,7 +42,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
-    new : items:int * JsonProvider+MappingsValue seq -> JsonProvider+Mappings
+    new : items:int * JsonProvider+JsonProvider+MappingsValue[] seq -> JsonProvider+Mappings
     JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
@@ -57,62 +57,24 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     member IsEmpty: bool with get
     (Operators.op_Equality JsonRuntime.GetRecordProperties(this).Length 0)
 
-    member Item: JsonProvider+MappingsValue with get
-    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+    member Item: JsonProvider+JsonProvider+MappingsValue[] with get
+    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))), key)
 
-    member Items: int * JsonProvider+MappingsValue seq with get
-    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)))
+    member Items: int * JsonProvider+JsonProvider+MappingsValue[] seq with get
+    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))))
 
     member Keys: int[] with get
     JsonRuntime.GetKeysFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)))
 
-    member TryFind: key:int -> JsonProvider+MappingsValue option
-    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+    member TryFind: key:int -> JsonProvider+JsonProvider+MappingsValue[] option
+    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))), key)
 
-    member Values: JsonProvider+JsonProvider+MappingsValue[] with get
-    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(id)))
+    member Values: JsonProvider+JsonProvider+JsonProvider+MappingsValue[][] with get
+    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))))
 
 
 class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
-    new : 123s:JsonProvider+JsonProvider+123[] -> record:JsonProvider+123 option -> 789s:JsonProvider+JsonProvider+789[] -> JsonProvider+MappingsValue
-    JsonRuntime.CreateArray([| (123s :> obj)
-                               (record :> obj)
-                               (789s :> obj) |], "")
-
-    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
-    JsonDocument.Create(jsonValue, "")
-
-    member 123s: JsonProvider+JsonProvider+123[] with get
-    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@123", new Func<_,_>(id)))
-
-    member 789s: JsonProvider+JsonProvider+789[] with get
-    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@789", new Func<_,_>(id)))
-
-    member Record: JsonProvider+123 option with get
-    JsonRuntime.TryGetArrayChildByTypeTag(this, "", "Record@456", new Func<_,_>(id)))
-
-
-class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
-    new : groupId:int -> canDelete:bool -> JsonProvider+123
-    JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
-                                ("CanDelete",
-                                 (canDelete :> obj)) |], "")
-
-    new : jsonValue:JsonValue -> JsonProvider+123
-    JsonDocument.Create(jsonValue, "")
-
-    member CanDelete: bool with get
-    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
-    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
-
-    member GroupId: int with get
-    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
-    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
-
-
-class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
-    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+MappingsValue
     JsonRuntime.CreateRecord([| ("GroupId",
                                  (groupId :> obj))
                                 ("CanDelete",
@@ -120,7 +82,7 @@ class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
                                 ("ErrorMessage",
                                  (errorMessage :> obj)) |], "")
 
-    new : jsonValue:JsonValue -> JsonProvider+789
+    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
     JsonDocument.Create(jsonValue, "")
 
     member CanDelete: bool with get

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasOverrides.expected
@@ -1,0 +1,137 @@
+class JsonProvider : obj
+    static member AsyncGetSample: () -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json"), f)
+
+    static member AsyncLoad: uri:string -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri), f)
+
+    static member GetSample: () -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json")))
+
+    static member Load: stream:System.IO.Stream -> JsonProvider+Root
+    JsonDocument.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> JsonProvider+Root
+    JsonDocument.Create(reader)
+
+    static member Load: uri:string -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
+
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
+    static member Parse: text:string -> JsonProvider+Root
+    JsonDocument.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseList: text:string -> JsonProvider+JsonProvider+Root[]
+    JsonDocument.CreateList(((new StringReader(text)) :> TextReader))
+
+
+class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
+    new : mappings:JsonProvider+Mappings -> JsonProvider+Root
+    JsonRuntime.CreateRecord([| ("Mappings",
+                                 (mappings :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(jsonValue, "")
+
+    member Mappings: JsonProvider+Mappings with get
+    JsonRuntime.GetPropertyPacked(this, "Mappings")
+
+
+class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
+    new : items:int * JsonProvider+MappingsValue seq -> JsonProvider+Mappings
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
+
+    new : jsonValue:JsonValue -> JsonProvider+Mappings
+    JsonDocument.Create(jsonValue, "")
+
+    member ContainsKey: key:int -> bool
+    JsonRuntime.InferedDictionaryContainsKey(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), key)
+
+    member Count: int with get
+    JsonRuntime.GetRecordProperties(this).Length
+
+    member IsEmpty: bool with get
+    (Operators.op_Equality JsonRuntime.GetRecordProperties(this).Length 0)
+
+    member Item: JsonProvider+MappingsValue with get
+    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+
+    member Items: int * JsonProvider+MappingsValue seq with get
+    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)))
+
+    member Keys: int[] with get
+    JsonRuntime.GetKeysFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)))
+
+    member TryFind: key:int -> JsonProvider+MappingsValue option
+    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+
+    member Values: JsonProvider+JsonProvider+MappingsValue[] with get
+    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(id)))
+
+
+class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
+    new : 123s:JsonProvider+JsonProvider+123[] -> record:JsonProvider+123 option -> 789s:JsonProvider+JsonProvider+789[] -> JsonProvider+MappingsValue
+    JsonRuntime.CreateArray([| (123s :> obj)
+                               (record :> obj)
+                               (789s :> obj) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
+    JsonDocument.Create(jsonValue, "")
+
+    member 123s: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@123", new Func<_,_>(id)))
+
+    member 789s: JsonProvider+JsonProvider+789[] with get
+    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@789", new Func<_,_>(id)))
+
+    member Record: JsonProvider+123 option with get
+    JsonRuntime.TryGetArrayChildByTypeTag(this, "", "Record@456", new Func<_,_>(id)))
+
+
+class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> JsonProvider+123
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+123
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+
+class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj))
+                                ("ErrorMessage",
+                                 (errorMessage :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+789
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member ErrorMessage: string option with get
+    JsonRuntime.ConvertString("", JsonRuntime.TryGetPropertyUnpacked(this, "ErrorMessage"))
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesOnly.expected
@@ -42,7 +42,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
-    new : items:int * JsonProvider+MappingsValue seq -> JsonProvider+Mappings
+    new : items:int * JsonProvider+JsonProvider+MappingsValue[] seq -> JsonProvider+Mappings
     JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
@@ -57,62 +57,24 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     member IsEmpty: bool with get
     (Operators.op_Equality JsonRuntime.GetRecordProperties(this).Length 0)
 
-    member Item: JsonProvider+MappingsValue with get
-    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+    member Item: JsonProvider+JsonProvider+MappingsValue[] with get
+    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))), key)
 
-    member Items: int * JsonProvider+MappingsValue seq with get
-    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)))
+    member Items: int * JsonProvider+JsonProvider+MappingsValue[] seq with get
+    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))))
 
     member Keys: int[] with get
     JsonRuntime.GetKeysFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)))
 
-    member TryFind: key:int -> JsonProvider+MappingsValue option
-    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+    member TryFind: key:int -> JsonProvider+JsonProvider+MappingsValue[] option
+    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))), key)
 
-    member Values: JsonProvider+JsonProvider+MappingsValue[] with get
-    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(id)))
+    member Values: JsonProvider+JsonProvider+JsonProvider+MappingsValue[][] with get
+    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.ConvertArray(t, new Func<_,_>(id)))))
 
 
 class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
-    new : 123s:JsonProvider+JsonProvider+123[] -> record:JsonProvider+123 option -> 789s:JsonProvider+JsonProvider+789[] -> JsonProvider+MappingsValue
-    JsonRuntime.CreateArray([| (123s :> obj)
-                               (record :> obj)
-                               (789s :> obj) |], "")
-
-    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
-    JsonDocument.Create(jsonValue, "")
-
-    member 123s: JsonProvider+JsonProvider+123[] with get
-    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@123", new Func<_,_>(id)))
-
-    member 789s: JsonProvider+JsonProvider+789[] with get
-    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@789", new Func<_,_>(id)))
-
-    member Record: JsonProvider+123 option with get
-    JsonRuntime.TryGetArrayChildByTypeTag(this, "", "Record@456", new Func<_,_>(id)))
-
-
-class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
-    new : groupId:int -> canDelete:bool -> JsonProvider+123
-    JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
-                                ("CanDelete",
-                                 (canDelete :> obj)) |], "")
-
-    new : jsonValue:JsonValue -> JsonProvider+123
-    JsonDocument.Create(jsonValue, "")
-
-    member CanDelete: bool with get
-    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
-    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
-
-    member GroupId: int with get
-    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
-    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
-
-
-class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
-    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+MappingsValue
     JsonRuntime.CreateRecord([| ("GroupId",
                                  (groupId :> obj))
                                 ("CanDelete",
@@ -120,7 +82,7 @@ class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
                                 ("ErrorMessage",
                                  (errorMessage :> obj)) |], "")
 
-    new : jsonValue:JsonValue -> JsonProvider+789
+    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
     JsonDocument.Create(jsonValue, "")
 
     member CanDelete: bool with get

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesOnly.expected
@@ -1,0 +1,137 @@
+class JsonProvider : obj
+    static member AsyncGetSample: () -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json"), f)
+
+    static member AsyncLoad: uri:string -> JsonProvider+Root async
+    let f = new Func<_,_>(fun (t:TextReader) -> JsonDocument.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri), f)
+
+    static member GetSample: () -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "JSON" "" "DictionaryInference-arrays.json")))
+
+    static member Load: stream:System.IO.Stream -> JsonProvider+Root
+    JsonDocument.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> JsonProvider+Root
+    JsonDocument.Create(reader)
+
+    static member Load: uri:string -> JsonProvider+Root
+    JsonDocument.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "JSON" "" uri)))
+
+    static member Load: value:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(value, "")
+
+    static member Parse: text:string -> JsonProvider+Root
+    JsonDocument.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseList: text:string -> JsonProvider+JsonProvider+Root[]
+    JsonDocument.CreateList(((new StringReader(text)) :> TextReader))
+
+
+class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
+    new : mappings:JsonProvider+Mappings -> JsonProvider+Root
+    JsonRuntime.CreateRecord([| ("Mappings",
+                                 (mappings :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+Root
+    JsonDocument.Create(jsonValue, "")
+
+    member Mappings: JsonProvider+Mappings with get
+    JsonRuntime.GetPropertyPacked(this, "Mappings")
+
+
+class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
+    new : items:int * JsonProvider+MappingsValue seq -> JsonProvider+Mappings
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
+
+    new : jsonValue:JsonValue -> JsonProvider+Mappings
+    JsonDocument.Create(jsonValue, "")
+
+    member ContainsKey: key:int -> bool
+    JsonRuntime.InferedDictionaryContainsKey(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), key)
+
+    member Count: int with get
+    JsonRuntime.GetRecordProperties(this).Length
+
+    member IsEmpty: bool with get
+    (Operators.op_Equality JsonRuntime.GetRecordProperties(this).Length 0)
+
+    member Item: JsonProvider+MappingsValue with get
+    JsonRuntime.GetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+
+    member Items: int * JsonProvider+MappingsValue seq with get
+    JsonRuntime.ConvertRecordToDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)))
+
+    member Keys: int[] with get
+    JsonRuntime.GetKeysFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)))
+
+    member TryFind: key:int -> JsonProvider+MappingsValue option
+    JsonRuntime.TryGetValueByKeyFromInferedDictionary(this, new Func<_,_>(fun (t:IJsonDocument) -> JsonRuntime.GetNonOptionalValue(t.Path(), JsonRuntime.ConvertInteger("", Some t.JsonValue), Some t.JsonValue)), new Func<_,_>(id)), key)
+
+    member Values: JsonProvider+JsonProvider+MappingsValue[] with get
+    JsonRuntime.GetValuesFromInferedDictionary(this, new Func<_,_>(id)))
+
+
+class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
+    new : 123s:JsonProvider+JsonProvider+123[] -> record:JsonProvider+123 option -> 789s:JsonProvider+JsonProvider+789[] -> JsonProvider+MappingsValue
+    JsonRuntime.CreateArray([| (123s :> obj)
+                               (record :> obj)
+                               (789s :> obj) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+MappingsValue
+    JsonDocument.Create(jsonValue, "")
+
+    member 123s: JsonProvider+JsonProvider+123[] with get
+    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@123", new Func<_,_>(id)))
+
+    member 789s: JsonProvider+JsonProvider+789[] with get
+    JsonRuntime.GetArrayChildrenByTypeTag(this, "", "Record@789", new Func<_,_>(id)))
+
+    member Record: JsonProvider+123 option with get
+    JsonRuntime.TryGetArrayChildByTypeTag(this, "", "Record@456", new Func<_,_>(id)))
+
+
+class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> JsonProvider+123
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+123
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+
+class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
+    new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
+    JsonRuntime.CreateRecord([| ("GroupId",
+                                 (groupId :> obj))
+                                ("CanDelete",
+                                 (canDelete :> obj))
+                                ("ErrorMessage",
+                                 (errorMessage :> obj)) |], "")
+
+    new : jsonValue:JsonValue -> JsonProvider+789
+    JsonDocument.Create(jsonValue, "")
+
+    member CanDelete: bool with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "CanDelete")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertBoolean(value.JsonOpt), value.JsonOpt)
+
+    member ErrorMessage: string option with get
+    JsonRuntime.ConvertString("", JsonRuntime.TryGetPropertyUnpacked(this, "ErrorMessage"))
+
+    member GroupId: int with get
+    let value = JsonRuntime.TryGetPropertyUnpackedWithPath(this, "GroupId")
+    JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertInteger("", value.JsonOpt), value.JsonOpt)
+
+

--- a/tests/FSharp.Data.Tests/Data/DictionaryInference-arrays.json
+++ b/tests/FSharp.Data.Tests/Data/DictionaryInference-arrays.json
@@ -1,0 +1,31 @@
+﻿{
+    "Mappings": {
+        "123": [
+            {
+            "GroupId": 1001,
+            "CanDelete": true
+            },
+            {
+            "GroupId": 6562,
+            "CanDelete": false
+            }
+        ],
+        "456": [
+            {
+            "GroupId": 1003,
+            "CanDelete": false
+            }
+        ],
+        "789": [
+            {
+            "GroupId": 1002,
+            "CanDelete": false,
+            "ErrorMessage": "Error."
+            },
+            {
+            "GroupId": 6562,
+            "CanDelete": true
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Before this PR, the generation is wrong:

![image](https://user-images.githubusercontent.com/1535823/222081749-4078a7d5-1638-4125-a0ee-ce0837cbdfe9.png)

![image](https://user-images.githubusercontent.com/1535823/222081999-0fde99c1-81f9-42df-a805-89b80811a62b.png)

This is because the records inferred originally in the arrays are normally supposed to have the name of the property declaring them (`123` and `789` in the screenshots), and two similar records with a different name are not merged.

This problem was taken care of by the original `PreferDictionaries` implementation when values are records (by dropping the record's name), but not when the values are arrays of records!

After this PR, the names of records nested in an array are also dropped, which yields the expected result, with records properly merged in a single type:

![image](https://user-images.githubusercontent.com/1535823/222082978-3a5e2470-514e-4bdb-9c0d-8475843600fa.png)

(PR of the original implementation for reference: https://github.com/fsprojects/FSharp.Data/pull/1430)

---

_Note: This PR contains only 2 commits, but is currently on top of the `rearrange-project-files` branch, from https://github.com/fsprojects/FSharp.Data/pull/1475 — I will rebase it on `master` when https://github.com/fsprojects/FSharp.Data/pull/1475 is merged._

EDIT: rebased and ready!

