### PR TITLE
Always use the original json primitive type when serializing values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 * Add `aria-label` to the list of html attributes used to infer names of types provided by the HtmlProvider.
 * Enable TLS 1.2 when requesting http(s) samples from the type providers.
 * Fix generated code of the json provider with `PreferDictionaries` when values are arrays.
+* Fix the json provider not using the correct json primitive type when serializing values inferred to another type.
 
 ### 6.0.1-beta001 - Aug 18 2022
 

--- a/docs/tutorials/JsonAnonymizer.fsx
+++ b/docs/tutorials/JsonAnonymizer.fsx
@@ -75,7 +75,7 @@ type JsonAnonymizer(?propertiesToSkip, ?valuesToSkip) =
 
     let isType testType typ =
         match typ with
-        | Runtime.StructuralTypes.InferedType.Primitive (typ, _, _, _) -> typ = testType
+        | Runtime.StructuralTypes.InferedType.Primitive (typ, _, _, _, _) -> typ = testType
         | _ -> false
 
     let rec anonymize json =

--- a/src/FSharp.Data.Csv.Core/CsvInference.fs
+++ b/src/FSharp.Data.Csv.Core/CsvInference.fs
@@ -122,7 +122,7 @@ let internal inferCellType
         if preferOptionals then
             InferedType.Null
         else
-            InferedType.Primitive(typeof<float>, unit, false, false)
+            InferedType.Primitive(typeof<float>, unit, false, false, PrimitiveType.String)
     // If there's only whitespace between commas, treat it as a missing value and not as a string
     elif String.IsNullOrWhiteSpace value then
         InferedType.Null
@@ -341,7 +341,7 @@ let internal getFields preferOptionals inferedType schema =
                         field.Name, field.Name
 
                 match field.Type with
-                | InferedType.Primitive (typ, unit, optional, _) ->
+                | InferedType.Primitive (typ, unit, optional, _, _) ->
 
                     // Transform the types as described above
                     let typ, typWrapper =

--- a/src/FSharp.Data.Csv.Core/CsvInference.fs
+++ b/src/FSharp.Data.Csv.Core/CsvInference.fs
@@ -127,7 +127,7 @@ let internal inferCellType
     elif String.IsNullOrWhiteSpace value then
         InferedType.Null
     else
-        StructuralInference.getInferedTypeFromString unitsOfMeasureProvider inferenceMode cultureInfo value unit
+        StructuralInference.inferPrimitiveType unitsOfMeasureProvider inferenceMode cultureInfo value unit
 
 let internal parseHeaders headers numberOfColumns schema unitsOfMeasureProvider =
 

--- a/src/FSharp.Data.DesignTime/CommonProviderImplementation/QuotationBuilder.fs
+++ b/src/FSharp.Data.DesignTime/CommonProviderImplementation/QuotationBuilder.fs
@@ -1,4 +1,4 @@
-﻿// Copyright 2011-2015, Tomas Petricek (http://tomasp.net), Gustavo Guerra (http://functionalflow.co.uk), and other contributors
+// Copyright 2011-2015, Tomas Petricek (http://tomasp.net), Gustavo Guerra (http://functionalflow.co.uk), and other contributors
 // Licensed under the Apache License, Version 2.0, see LICENSE.md in this project
 //
 // Utilities for building F# quotations without quotation literals
@@ -21,10 +21,10 @@ open UncheckedQuotations
 ///    typ?Name tyArgs args
 ///
 /// tyArgs is a sequence of type arguments for method `Name`.
-/// Actual arguments can be either expression (Expr<'T>) or primitive values, whic
+/// Actual arguments can be either expression (Expr<'T>) or primitive values, which
 /// are automatically wrapped using Expr.Value.
 ///
-let (?) (typ: Type) (operation: string) (args1: 'T) (args2: 'U) : Expr =
+let (?) (typ: Type) (operation: string) (typeArgs: 'T) (argValues: 'U) : Expr =
     // Arguments are either Expr or other type - in the second case,
     // we treat them as Expr.Value (which will only work for primitives)
     let convertValue (arg: obj) =
@@ -86,4 +86,4 @@ let (?) (typ: Type) (operation: string) (args1: 'T) (args2: 'U) : Expr =
                 Expr.PropertyGetUnchecked(List.head args, pi, List.tail args)
         | options -> failwithf "Constructing call of the '%s' operation failed. Got %A" operation options
 
-    invokeOperation (args1, typeof<'T>) (args2, typeof<'U>)
+    invokeOperation (typeArgs, typeof<'T>) (argValues, typeof<'U>)

--- a/src/FSharp.Data.DesignTime/Html/HtmlGenerator.fs
+++ b/src/FSharp.Data.DesignTime/Html/HtmlGenerator.fs
@@ -134,7 +134,7 @@ module internal HtmlGenerator =
 
         let listItemType, conv =
             match columns with
-            | InferedType.Primitive (typ, _, optional, _) ->
+            | InferedType.Primitive (typ, _, optional, _, _) ->
                 let typ, _, conv, _convBack =
                     ConversionsGenerator.convertStringValue
                         missingValuesStr
@@ -196,7 +196,7 @@ module internal HtmlGenerator =
 
             let listItemType, conv =
                 match columns with
-                | StructuralTypes.InferedType.Primitive (typ, _, optional, _) ->
+                | StructuralTypes.InferedType.Primitive (typ, _, optional, _, _) ->
                     let typ, _, conv, _convBack =
                         ConversionsGenerator.convertStringValue
                             missingValuesStr

--- a/src/FSharp.Data.DesignTime/Json/JsonConversionsGenerator.fs
+++ b/src/FSharp.Data.DesignTime/Json/JsonConversionsGenerator.fs
@@ -55,7 +55,6 @@ let internal convertJsonValue
     (field: PrimitiveInferedValue)
     =
 
-
     let returnType =
         match field.TypeWrapper with
         | TypeWrapper.None -> field.TypeWithMeasure

--- a/src/FSharp.Data.DesignTime/Json/JsonGenerator.fs
+++ b/src/FSharp.Data.DesignTime/Json/JsonGenerator.fs
@@ -436,7 +436,7 @@ module JsonTypeBuilder =
                     else
                         let infKeyType =
                             [ for prop in props ->
-                                  StructuralInference.getInferedTypeFromString
+                                  StructuralInference.inferPrimitiveType
                                       ctx.UnitsOfMeasureProvider
                                       ctx.InferenceMode
                                       (TextRuntime.GetCulture ctx.CultureStr)

--- a/src/FSharp.Data.DesignTime/Xml/XmlGenerator.fs
+++ b/src/FSharp.Data.DesignTime/Xml/XmlGenerator.fs
@@ -127,7 +127,7 @@ module internal XmlTypeBuilder =
                       (StructuralInference.typeTag primitive).NiceName
 
               match primitive with
-              | InferedType.Primitive (typ, unit, optional, _) ->
+              | InferedType.Primitive (typ, unit, optional, _, _) ->
 
                   let optional = optional || forceOptional
                   let optionalJustBecauseThereAreMultiple = primitives.Length > 1 && not optional
@@ -356,7 +356,7 @@ module internal XmlTypeBuilder =
                                   failwithf "generateXmlType: Type shouldn't be optional: %A" typ
 
                               match typ with
-                              | InferedType.Primitive (primTyp, unit, false, _) ->
+                              | InferedType.Primitive (primTyp, unit, false, _, _) ->
 
                                   let typ, conv =
                                       ctx.ConvertValue
@@ -396,7 +396,7 @@ module internal XmlTypeBuilder =
 
                           createMember choiceTy (fun x -> x :> Expr)
 
-                      | InferedType.Primitive (typ, unit, optional, _) -> createPrimitiveMember typ unit optional
+                      | InferedType.Primitive (typ, unit, optional, _, _) -> createPrimitiveMember typ unit optional
                       | InferedType.Null -> createPrimitiveMember typeof<string> None false
 
                       | _ -> failwithf "generateXmlType: Expected Primitive or Choice type, got %A" attr.Type ]

--- a/src/FSharp.Data.Html.Core/HtmlInference.fs
+++ b/src/FSharp.Data.Html.Core/HtmlInference.fs
@@ -67,7 +67,7 @@ let internal inferListType parameters (values: string[]) =
                 else
                     InferedType.Primitive(typeof<float>, None, false, false)
             else
-                getInferedTypeFromString
+                inferPrimitiveType
                     parameters.UnitsOfMeasureProvider
                     parameters.InferenceMode
                     parameters.CultureInfo

--- a/src/FSharp.Data.Html.Core/HtmlInference.fs
+++ b/src/FSharp.Data.Html.Core/HtmlInference.fs
@@ -65,7 +65,7 @@ let internal inferListType parameters (values: string[]) =
                 if parameters.PreferOptionals then
                     InferedType.Null
                 else
-                    InferedType.Primitive(typeof<float>, None, false, false)
+                    InferedType.Primitive(typeof<float>, None, false, false, PrimitiveType.String)
             else
                 inferPrimitiveType
                     parameters.UnitsOfMeasureProvider

--- a/src/FSharp.Data.Json.Core/JsonInference.fs
+++ b/src/FSharp.Data.Json.Core/JsonInference.fs
@@ -32,7 +32,7 @@ let rec internal inferType unitsOfMeasureProvider inferenceMode cultureInfo pare
     | JsonValue.Null -> InferedType.Null
     | JsonValue.Boolean _ -> InferedType.Primitive(typeof<bool>, None, false, false)
     | JsonValue.String s ->
-        StructuralInference.getInferedTypeFromString unitsOfMeasureProvider inferenceMode cultureInfo s None
+        StructuralInference.inferPrimitiveType unitsOfMeasureProvider inferenceMode cultureInfo s None
     // For numbers, we test if it is integer and if it fits in smaller range
     | JsonValue.Number 0M when shouldInferNonStringFromValue -> InferedType.Primitive(typeof<Bit0>, None, false, false)
     | JsonValue.Number 1M when shouldInferNonStringFromValue -> InferedType.Primitive(typeof<Bit1>, None, false, false)
@@ -62,11 +62,14 @@ let rec internal inferType unitsOfMeasureProvider inferenceMode cultureInfo pare
         ->
         InferedType.Primitive(typeof<int64>, None, false, false)
     | JsonValue.Float _ -> InferedType.Primitive(typeof<float>, None, false, false)
+
     // More interesting types
+
     | JsonValue.Array ar ->
         StructuralInference.inferCollectionType
             false
             (Seq.map (inferType unitsOfMeasureProvider inferenceMode cultureInfo (NameUtils.singularize parentName)) ar)
+
     | JsonValue.Record properties ->
         let name =
             if String.IsNullOrEmpty parentName then

--- a/src/FSharp.Data.Json.Core/JsonInference.fs
+++ b/src/FSharp.Data.Json.Core/JsonInference.fs
@@ -30,38 +30,40 @@ let rec internal inferType unitsOfMeasureProvider inferenceMode cultureInfo pare
     match json with
     // Null and primitives without subtyping hierarchies
     | JsonValue.Null -> InferedType.Null
-    | JsonValue.Boolean _ -> InferedType.Primitive(typeof<bool>, None, false, false)
+    | JsonValue.Boolean _ -> InferedType.Primitive(typeof<bool>, None, false, false, PrimitiveType.Bool)
     | JsonValue.String s ->
         StructuralInference.inferPrimitiveType unitsOfMeasureProvider inferenceMode cultureInfo s None
     // For numbers, we test if it is integer and if it fits in smaller range
-    | JsonValue.Number 0M when shouldInferNonStringFromValue -> InferedType.Primitive(typeof<Bit0>, None, false, false)
-    | JsonValue.Number 1M when shouldInferNonStringFromValue -> InferedType.Primitive(typeof<Bit1>, None, false, false)
+    | JsonValue.Number 0M when shouldInferNonStringFromValue ->
+        InferedType.Primitive(typeof<Bit0>, None, false, false, PrimitiveType.Number)
+    | JsonValue.Number 1M when shouldInferNonStringFromValue ->
+        InferedType.Primitive(typeof<Bit1>, None, false, false, PrimitiveType.Number)
     | JsonValue.Number n when
         shouldInferNonStringFromValue
         && inRangeDecimal Int32.MinValue Int32.MaxValue n
         && isIntegerDecimal n
         ->
-        InferedType.Primitive(typeof<int>, None, false, false)
+        InferedType.Primitive(typeof<int>, None, false, false, PrimitiveType.Number)
     | JsonValue.Number n when
         shouldInferNonStringFromValue
         && inRangeDecimal Int64.MinValue Int64.MaxValue n
         && isIntegerDecimal n
         ->
-        InferedType.Primitive(typeof<int64>, None, false, false)
-    | JsonValue.Number _ -> InferedType.Primitive(typeof<decimal>, None, false, false)
+        InferedType.Primitive(typeof<int64>, None, false, false, PrimitiveType.Number)
+    | JsonValue.Number _ -> InferedType.Primitive(typeof<decimal>, None, false, false, PrimitiveType.Number)
     | JsonValue.Float f when
         shouldInferNonStringFromValue
         && inRangeFloat Int32.MinValue Int32.MaxValue f
         && isIntegerFloat f
         ->
-        InferedType.Primitive(typeof<int>, None, false, false)
+        InferedType.Primitive(typeof<int>, None, false, false, PrimitiveType.Number)
     | JsonValue.Float f when
         shouldInferNonStringFromValue
         && inRangeFloat Int64.MinValue Int64.MaxValue f
         && isIntegerFloat f
         ->
-        InferedType.Primitive(typeof<int64>, None, false, false)
-    | JsonValue.Float _ -> InferedType.Primitive(typeof<float>, None, false, false)
+        InferedType.Primitive(typeof<int64>, None, false, false, PrimitiveType.Number)
+    | JsonValue.Float _ -> InferedType.Primitive(typeof<float>, None, false, false, PrimitiveType.Number)
 
     // More interesting types
 

--- a/src/FSharp.Data.Runtime.Utilities/StructuralTypes.fs
+++ b/src/FSharp.Data.Runtime.Utilities/StructuralTypes.fs
@@ -66,6 +66,8 @@ type InferedTypeTag =
 [<CustomEquality; NoComparison; RequireQualifiedAccess>]
 [<Obsolete("This API will be made internal in a future release. Please file an issue at https://github.com/fsprojects/FSharp.Data/issues/1458 if you need this public.")>]
 type InferedType =
+    /// When shouldOverrideOnMerge is true, it means this type should win when merged with other primitive types during inference.
+    /// This allows users to control inference by adding manual type hints that take priority.
     | Primitive of typ: Type * unit: option<System.Type> * optional: bool * shouldOverrideOnMerge: bool
     | Record of name: string option * fields: InferedProperty list * optional: bool
     | Json of typ: InferedType * optional: bool

--- a/src/FSharp.Data.Xml.Core/XmlInference.fs
+++ b/src/FSharp.Data.Xml.Core/XmlInference.fs
@@ -30,11 +30,11 @@ let private getAttributes unitsOfMeasureProvider inferenceMode cultureInfo (elem
              && attr.Name.ToString() <> "xmlns" then
               yield
                   { Name = attr.Name.ToString()
-                    Type = getInferedTypeFromString unitsOfMeasureProvider inferenceMode cultureInfo attr.Value None } ]
+                    Type = inferPrimitiveType unitsOfMeasureProvider inferenceMode cultureInfo attr.Value None } ]
 
 let getInferedTypeFromValue unitsOfMeasureProvider inferenceMode cultureInfo (element: XElement) =
     let typ =
-        getInferedTypeFromString unitsOfMeasureProvider inferenceMode cultureInfo (element.Value) None
+        inferPrimitiveType unitsOfMeasureProvider inferenceMode cultureInfo (element.Value) None
 
     match inferenceMode with
     // Embedded json is not parsed when InferenceMode is NoInference

--- a/src/FSharp.Data.Xml.Core/XmlInference.fs
+++ b/src/FSharp.Data.Xml.Core/XmlInference.fs
@@ -41,7 +41,7 @@ let getInferedTypeFromValue unitsOfMeasureProvider inferenceMode cultureInfo (el
     | InferenceMode'.NoInference -> typ
     | _ ->
         match typ with
-        | InferedType.Primitive (t, _, optional, _) when
+        | InferedType.Primitive (t, _, optional, _, _) when
             t = typeof<string>
             && let v = (element.Value).TrimStart() in
                v.StartsWith "{" || v.StartsWith "["

--- a/src/FSharp.Data.Xml.Core/XsdInference.fs
+++ b/src/FSharp.Data.Xml.Core/XsdInference.fs
@@ -255,7 +255,7 @@ module internal XsdInference =
 
     let nil =
         { InferedProperty.Name = "{http://www.w3.org/2001/XMLSchema-instance}nil"
-          Type = InferedType.Primitive(typeof<bool>, None, true, false) }
+          Type = InferedType.Primitive(typeof<bool>, None, true, false, PrimitiveType.String) }
 
     type InferenceContext = System.Collections.Generic.Dictionary<XsdComplexType, InferedProperty>
 
@@ -268,7 +268,9 @@ module internal XsdInference =
         else
             match elm.Type with
             | SimpleType typeCode ->
-                let ty = InferedType.Primitive(getType typeCode, None, elm.IsNillable, false)
+                let ty =
+                    InferedType.Primitive(getType typeCode, None, elm.IsNillable, false, PrimitiveType.String)
+
                 let prop = { InferedProperty.Name = ""; Type = ty }
                 let props = if elm.IsNillable then [ prop; nil ] else [ prop ]
                 InferedType.Record(name, props, optional = false)
@@ -292,13 +294,13 @@ module internal XsdInference =
             cty.Attributes
             |> List.map (fun (name, typeCode, optional) ->
                 { Name = formatName name
-                  Type = InferedType.Primitive(getType typeCode, None, optional, false) })
+                  Type = InferedType.Primitive(getType typeCode, None, optional, false, PrimitiveType.String) })
 
         match cty.Contents with
         | SimpleContent typeCode ->
             let body =
                 { InferedProperty.Name = ""
-                  Type = InferedType.Primitive(getType typeCode, None, false, false) }
+                  Type = InferedType.Primitive(getType typeCode, None, false, false, PrimitiveType.String) }
 
             body :: attrs
         | ComplexContent xsdParticle ->

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True,False,BackwardCompatible.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : birthdate:System.DateTime -> anniversary:System.DateTimeOffset -> noTimeZone:System.DateTime -> utcTime:System.DateTimeOffset -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("birthdate",
-                                 (birthdate :> obj))
+                                 (birthdate :> obj),
+                                 1)
                                 ("anniversary",
-                                 (anniversary :> obj))
+                                 (anniversary :> obj),
+                                 1)
                                 ("NoTimeZone",
-                                 (noTimeZone :> obj))
+                                 (noTimeZone :> obj),
+                                 1)
                                 ("UtcTime",
-                                 (utcTime :> obj)) |], "")
+                                 (utcTime :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : birthdate:System.DateTime -> anniversary:System.DateTimeOffset -> noTimeZone:System.DateTime -> utcTime:System.DateTimeOffset -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("birthdate",
-                                 (birthdate :> obj))
+                                 (birthdate :> obj),
+                                 1)
                                 ("anniversary",
-                                 (anniversary :> obj))
+                                 (anniversary :> obj),
+                                 1)
                                 ("NoTimeZone",
-                                 (noTimeZone :> obj))
+                                 (noTimeZone :> obj),
+                                 1)
                                 ("UtcTime",
-                                 (utcTime :> obj)) |], "")
+                                 (utcTime :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : birthdate:System.DateTime -> anniversary:System.DateTimeOffset -> noTimeZone:System.DateTime -> utcTime:System.DateTimeOffset -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("birthdate",
-                                 (birthdate :> obj))
+                                 (birthdate :> obj),
+                                 1)
                                 ("anniversary",
-                                 (anniversary :> obj))
+                                 (anniversary :> obj),
+                                 1)
                                 ("NoTimeZone",
-                                 (noTimeZone :> obj))
+                                 (noTimeZone :> obj),
+                                 1)
                                 ("UtcTime",
-                                 (utcTime :> obj)) |], "")
+                                 (utcTime :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Dates.json,False,,,True,False,ValuesOnly.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : birthdate:System.DateTime -> anniversary:System.DateTimeOffset -> noTimeZone:System.DateTime -> utcTime:System.DateTimeOffset -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("birthdate",
-                                 (birthdate :> obj))
+                                 (birthdate :> obj),
+                                 1)
                                 ("anniversary",
-                                 (anniversary :> obj))
+                                 (anniversary :> obj),
+                                 1)
                                 ("NoTimeZone",
-                                 (noTimeZone :> obj))
+                                 (noTimeZone :> obj),
+                                 1)
                                 ("UtcTime",
-                                 (utcTime :> obj)) |], "")
+                                 (utcTime :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,BackwardCompatible.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : mappings:JsonProvider+Mappings -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("Mappings",
-                                 (mappings :> obj)) |], "")
+                                 (mappings :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,11 +45,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     new : 123:JsonProvider+JsonProvider+123[] -> 456:JsonProvider+JsonProvider+123[] -> 789:JsonProvider+JsonProvider+789[] -> JsonProvider+Mappings
     JsonRuntime.CreateRecord([| ("123",
-                                 (123 :> obj))
+                                 (123 :> obj),
+                                 0)
                                 ("456",
-                                 (456 :> obj))
+                                 (456 :> obj),
+                                 0)
                                 ("789",
-                                 (789 :> obj)) |], "")
+                                 (789 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
     JsonDocument.Create(jsonValue, "")
@@ -66,9 +70,11 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
 class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> JsonProvider+123
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj)) |], "")
+                                 (canDelete :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+123
     JsonDocument.Create(jsonValue, "")
@@ -85,11 +91,14 @@ class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj))
+                                 (canDelete :> obj),
+                                 3)
                                 ("ErrorMessage",
-                                 (errorMessage :> obj)) |], "")
+                                 (errorMessage :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+789
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : mappings:JsonProvider+Mappings -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("Mappings",
-                                 (mappings :> obj)) |], "")
+                                 (mappings :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,11 +45,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     new : 123:JsonProvider+JsonProvider+123[] -> 456:JsonProvider+JsonProvider+123[] -> 789:JsonProvider+JsonProvider+789[] -> JsonProvider+Mappings
     JsonRuntime.CreateRecord([| ("123",
-                                 (123 :> obj))
+                                 (123 :> obj),
+                                 0)
                                 ("456",
-                                 (456 :> obj))
+                                 (456 :> obj),
+                                 0)
                                 ("789",
-                                 (789 :> obj)) |], "")
+                                 (789 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
     JsonDocument.Create(jsonValue, "")
@@ -66,9 +70,11 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
 class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> JsonProvider+123
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj)) |], "")
+                                 (canDelete :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+123
     JsonDocument.Create(jsonValue, "")
@@ -85,11 +91,14 @@ class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj))
+                                 (canDelete :> obj),
+                                 3)
                                 ("ErrorMessage",
-                                 (errorMessage :> obj)) |], "")
+                                 (errorMessage :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+789
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : mappings:JsonProvider+Mappings -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("Mappings",
-                                 (mappings :> obj)) |], "")
+                                 (mappings :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,11 +45,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     new : 123:JsonProvider+JsonProvider+123[] -> 456:JsonProvider+JsonProvider+123[] -> 789:JsonProvider+JsonProvider+789[] -> JsonProvider+Mappings
     JsonRuntime.CreateRecord([| ("123",
-                                 (123 :> obj))
+                                 (123 :> obj),
+                                 0)
                                 ("456",
-                                 (456 :> obj))
+                                 (456 :> obj),
+                                 0)
                                 ("789",
-                                 (789 :> obj)) |], "")
+                                 (789 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
     JsonDocument.Create(jsonValue, "")
@@ -66,9 +70,11 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
 class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> JsonProvider+123
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj)) |], "")
+                                 (canDelete :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+123
     JsonDocument.Create(jsonValue, "")
@@ -85,11 +91,14 @@ class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj))
+                                 (canDelete :> obj),
+                                 3)
                                 ("ErrorMessage",
-                                 (errorMessage :> obj)) |], "")
+                                 (errorMessage :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+789
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,False,ValuesOnly.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : mappings:JsonProvider+Mappings -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("Mappings",
-                                 (mappings :> obj)) |], "")
+                                 (mappings :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,11 +45,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     new : 123:JsonProvider+JsonProvider+123[] -> 456:JsonProvider+JsonProvider+123[] -> 789:JsonProvider+JsonProvider+789[] -> JsonProvider+Mappings
     JsonRuntime.CreateRecord([| ("123",
-                                 (123 :> obj))
+                                 (123 :> obj),
+                                 0)
                                 ("456",
-                                 (456 :> obj))
+                                 (456 :> obj),
+                                 0)
                                 ("789",
-                                 (789 :> obj)) |], "")
+                                 (789 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
     JsonDocument.Create(jsonValue, "")
@@ -66,9 +70,11 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
 class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> JsonProvider+123
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj)) |], "")
+                                 (canDelete :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+123
     JsonDocument.Create(jsonValue, "")
@@ -85,11 +91,14 @@ class JsonProvider+123 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+789 : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+789
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj))
+                                 (canDelete :> obj),
+                                 3)
                                 ("ErrorMessage",
-                                 (errorMessage :> obj)) |], "")
+                                 (errorMessage :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+789
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,BackwardCompatible.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : mappings:JsonProvider+Mappings -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("Mappings",
-                                 (mappings :> obj)) |], "")
+                                 (mappings :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -43,7 +44,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     new : items:int * JsonProvider+JsonProvider+MappingsValue[] seq -> JsonProvider+Mappings
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)), 0)
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
     JsonDocument.Create(jsonValue, "")
@@ -76,11 +77,14 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
 class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+MappingsValue
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj))
+                                 (canDelete :> obj),
+                                 3)
                                 ("ErrorMessage",
-                                 (errorMessage :> obj)) |], "")
+                                 (errorMessage :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+MappingsValue
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasHints.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : mappings:JsonProvider+Mappings -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("Mappings",
-                                 (mappings :> obj)) |], "")
+                                 (mappings :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -43,7 +44,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     new : items:int * JsonProvider+JsonProvider+MappingsValue[] seq -> JsonProvider+Mappings
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)), 0)
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
     JsonDocument.Create(jsonValue, "")
@@ -76,11 +77,14 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
 class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+MappingsValue
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj))
+                                 (canDelete :> obj),
+                                 3)
                                 ("ErrorMessage",
-                                 (errorMessage :> obj)) |], "")
+                                 (errorMessage :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+MappingsValue
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesAndInlineSchemasOverrides.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : mappings:JsonProvider+Mappings -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("Mappings",
-                                 (mappings :> obj)) |], "")
+                                 (mappings :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -43,7 +44,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     new : items:int * JsonProvider+JsonProvider+MappingsValue[] seq -> JsonProvider+Mappings
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)), 0)
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
     JsonDocument.Create(jsonValue, "")
@@ -76,11 +77,14 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
 class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+MappingsValue
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj))
+                                 (canDelete :> obj),
+                                 3)
                                 ("ErrorMessage",
-                                 (errorMessage :> obj)) |], "")
+                                 (errorMessage :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+MappingsValue
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference-arrays.json,False,,,True,True,ValuesOnly.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : mappings:JsonProvider+Mappings -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("Mappings",
-                                 (mappings :> obj)) |], "")
+                                 (mappings :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -43,7 +44,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
     new : items:int * JsonProvider+JsonProvider+MappingsValue[] seq -> JsonProvider+Mappings
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:int) -> TextRuntime.ConvertIntegerBack("", Some t)), 0)
 
     new : jsonValue:JsonValue -> JsonProvider+Mappings
     JsonDocument.Create(jsonValue, "")
@@ -76,11 +77,14 @@ class JsonProvider+Mappings : FDR.BaseTypes.IJsonDocument
 class JsonProvider+MappingsValue : FDR.BaseTypes.IJsonDocument
     new : groupId:int -> canDelete:bool -> errorMessage:string option -> JsonProvider+MappingsValue
     JsonRuntime.CreateRecord([| ("GroupId",
-                                 (groupId :> obj))
+                                 (groupId :> obj),
+                                 2)
                                 ("CanDelete",
-                                 (canDelete :> obj))
+                                 (canDelete :> obj),
+                                 3)
                                 ("ErrorMessage",
-                                 (errorMessage :> obj)) |], "")
+                                 (errorMessage :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+MappingsValue
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,False,BackwardCompatible.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : rec:JsonProvider+Rec -> rec2:JsonProvider+Rec2 -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("rec",
-                                 (rec :> obj))
+                                 (rec :> obj),
+                                 0)
                                 ("rec2",
-                                 (rec2 :> obj)) |], "")
+                                 (rec2 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -49,9 +51,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
     new : 0:int -> 1:int option -> JsonProvider+Rec
     JsonRuntime.CreateRecord([| ("0",
-                                 (0 :> obj))
+                                 (0 :> obj),
+                                 1)
                                 ("1",
-                                 (1 :> obj)) |], "")
+                                 (1 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec
     JsonDocument.Create(jsonValue, "")
@@ -67,9 +71,11 @@ class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
     new : 0:JsonProvider+0 option -> 1:JsonProvider+0 -> JsonProvider+Rec2
     JsonRuntime.CreateRecord([| ("0",
-                                 (0 :> obj))
+                                 (0 :> obj),
+                                 0)
                                 ("1",
-                                 (1 :> obj)) |], "")
+                                 (1 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2
     JsonDocument.Create(jsonValue, "")
@@ -84,7 +90,8 @@ class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+0 : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+0
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+0
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : rec:JsonProvider+Rec -> rec2:JsonProvider+Rec2 -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("rec",
-                                 (rec :> obj))
+                                 (rec :> obj),
+                                 0)
                                 ("rec2",
-                                 (rec2 :> obj)) |], "")
+                                 (rec2 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -49,9 +51,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
     new : 0:int -> 1:int option -> JsonProvider+Rec
     JsonRuntime.CreateRecord([| ("0",
-                                 (0 :> obj))
+                                 (0 :> obj),
+                                 1)
                                 ("1",
-                                 (1 :> obj)) |], "")
+                                 (1 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec
     JsonDocument.Create(jsonValue, "")
@@ -67,9 +71,11 @@ class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
     new : 0:JsonProvider+0 option -> 1:JsonProvider+0 -> JsonProvider+Rec2
     JsonRuntime.CreateRecord([| ("0",
-                                 (0 :> obj))
+                                 (0 :> obj),
+                                 0)
                                 ("1",
-                                 (1 :> obj)) |], "")
+                                 (1 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2
     JsonDocument.Create(jsonValue, "")
@@ -84,7 +90,8 @@ class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+0 : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+0
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+0
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : rec:JsonProvider+Rec -> rec2:JsonProvider+Rec2 -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("rec",
-                                 (rec :> obj))
+                                 (rec :> obj),
+                                 0)
                                 ("rec2",
-                                 (rec2 :> obj)) |], "")
+                                 (rec2 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -49,9 +51,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
     new : 0:int -> 1:int option -> JsonProvider+Rec
     JsonRuntime.CreateRecord([| ("0",
-                                 (0 :> obj))
+                                 (0 :> obj),
+                                 1)
                                 ("1",
-                                 (1 :> obj)) |], "")
+                                 (1 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec
     JsonDocument.Create(jsonValue, "")
@@ -67,9 +71,11 @@ class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
     new : 0:JsonProvider+0 option -> 1:JsonProvider+0 -> JsonProvider+Rec2
     JsonRuntime.CreateRecord([| ("0",
-                                 (0 :> obj))
+                                 (0 :> obj),
+                                 0)
                                 ("1",
-                                 (1 :> obj)) |], "")
+                                 (1 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2
     JsonDocument.Create(jsonValue, "")
@@ -84,7 +90,8 @@ class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+0 : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+0
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+0
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,False,ValuesOnly.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : rec:JsonProvider+Rec -> rec2:JsonProvider+Rec2 -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("rec",
-                                 (rec :> obj))
+                                 (rec :> obj),
+                                 0)
                                 ("rec2",
-                                 (rec2 :> obj)) |], "")
+                                 (rec2 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -49,9 +51,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
     new : 0:int -> 1:int option -> JsonProvider+Rec
     JsonRuntime.CreateRecord([| ("0",
-                                 (0 :> obj))
+                                 (0 :> obj),
+                                 1)
                                 ("1",
-                                 (1 :> obj)) |], "")
+                                 (1 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec
     JsonDocument.Create(jsonValue, "")
@@ -67,9 +71,11 @@ class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
     new : 0:JsonProvider+0 option -> 1:JsonProvider+0 -> JsonProvider+Rec2
     JsonRuntime.CreateRecord([| ("0",
-                                 (0 :> obj))
+                                 (0 :> obj),
+                                 0)
                                 ("1",
-                                 (1 :> obj)) |], "")
+                                 (1 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2
     JsonDocument.Create(jsonValue, "")
@@ -84,7 +90,8 @@ class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+0 : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+0
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+0
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,True,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,True,BackwardCompatible.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : rec:JsonProvider+Rec -> rec2:JsonProvider+Rec2 -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("rec",
-                                 (rec :> obj))
+                                 (rec :> obj),
+                                 0)
                                 ("rec2",
-                                 (rec2 :> obj)) |], "")
+                                 (rec2 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -48,7 +50,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
     new : items:bool * int seq -> JsonProvider+Rec
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)), 1)
 
     new : jsonValue:JsonValue -> JsonProvider+Rec
     JsonDocument.Create(jsonValue, "")
@@ -80,7 +82,7 @@ class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
     new : items:bool * JsonProvider+Rec2Value seq -> JsonProvider+Rec2
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)), 0)
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2
     JsonDocument.Create(jsonValue, "")
@@ -113,7 +115,8 @@ class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec2Value : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+Rec2Value
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2Value
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,True,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,True,ValuesAndInlineSchemasHints.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : rec:JsonProvider+Rec -> rec2:JsonProvider+Rec2 -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("rec",
-                                 (rec :> obj))
+                                 (rec :> obj),
+                                 0)
                                 ("rec2",
-                                 (rec2 :> obj)) |], "")
+                                 (rec2 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -48,7 +50,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
     new : items:bool * int seq -> JsonProvider+Rec
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)), 1)
 
     new : jsonValue:JsonValue -> JsonProvider+Rec
     JsonDocument.Create(jsonValue, "")
@@ -80,7 +82,7 @@ class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
     new : items:bool * JsonProvider+Rec2Value seq -> JsonProvider+Rec2
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)), 0)
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2
     JsonDocument.Create(jsonValue, "")
@@ -113,7 +115,8 @@ class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec2Value : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+Rec2Value
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2Value
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,True,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,True,ValuesAndInlineSchemasOverrides.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : rec:JsonProvider+Rec -> rec2:JsonProvider+Rec2 -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("rec",
-                                 (rec :> obj))
+                                 (rec :> obj),
+                                 0)
                                 ("rec2",
-                                 (rec2 :> obj)) |], "")
+                                 (rec2 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -48,7 +50,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
     new : items:bool * int seq -> JsonProvider+Rec
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)), 1)
 
     new : jsonValue:JsonValue -> JsonProvider+Rec
     JsonDocument.Create(jsonValue, "")
@@ -80,7 +82,7 @@ class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
     new : items:bool * JsonProvider+Rec2Value seq -> JsonProvider+Rec2
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)), 0)
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2
     JsonDocument.Create(jsonValue, "")
@@ -113,7 +115,8 @@ class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec2Value : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+Rec2Value
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2Value
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,True,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DictionaryInference.json,False,,,True,True,ValuesOnly.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : rec:JsonProvider+Rec -> rec2:JsonProvider+Rec2 -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("rec",
-                                 (rec :> obj))
+                                 (rec :> obj),
+                                 0)
                                 ("rec2",
-                                 (rec2 :> obj)) |], "")
+                                 (rec2 :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -48,7 +50,7 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
     new : items:bool * int seq -> JsonProvider+Rec
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)), 1)
 
     new : jsonValue:JsonValue -> JsonProvider+Rec
     JsonDocument.Create(jsonValue, "")
@@ -80,7 +82,7 @@ class JsonProvider+Rec : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
     new : items:bool * JsonProvider+Rec2Value seq -> JsonProvider+Rec2
-    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)))
+    JsonRuntime.CreateRecordFromDictionary(items, "", new Func<_,_>(fun (t:bool) -> TextRuntime.ConvertBooleanBack(Some t, false)), 0)
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2
     JsonDocument.Create(jsonValue, "")
@@ -113,7 +115,8 @@ class JsonProvider+Rec2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Rec2Value : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+Rec2Value
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Rec2Value
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True,False,BackwardCompatible.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : main:JsonProvider+Main -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("main",
-                                 (main :> obj)) |], "")
+                                 (main :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
     new : title:string -> nested:JsonProvider+Nested -> JsonProvider+Main
     JsonRuntime.CreateRecord([| ("title",
-                                 (title :> obj))
+                                 (title :> obj),
+                                 1)
                                 ("nested",
-                                 (nested :> obj)) |], "")
+                                 (nested :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Main
     JsonDocument.Create(jsonValue, "")
@@ -62,7 +65,8 @@ class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Nested : FDR.BaseTypes.IJsonDocument
     new : nestedTitle:string -> JsonProvider+Nested
     JsonRuntime.CreateRecord([| ("nestedTitle",
-                                 (nestedTitle :> obj)) |], "")
+                                 (nestedTitle :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Nested
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : main:JsonProvider+Main -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("main",
-                                 (main :> obj)) |], "")
+                                 (main :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
     new : title:string -> nested:JsonProvider+Nested -> JsonProvider+Main
     JsonRuntime.CreateRecord([| ("title",
-                                 (title :> obj))
+                                 (title :> obj),
+                                 1)
                                 ("nested",
-                                 (nested :> obj)) |], "")
+                                 (nested :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Main
     JsonDocument.Create(jsonValue, "")
@@ -62,7 +65,8 @@ class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Nested : FDR.BaseTypes.IJsonDocument
     new : nestedTitle:string -> JsonProvider+Nested
     JsonRuntime.CreateRecord([| ("nestedTitle",
-                                 (nestedTitle :> obj)) |], "")
+                                 (nestedTitle :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Nested
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : main:JsonProvider+Main -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("main",
-                                 (main :> obj)) |], "")
+                                 (main :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
     new : title:string -> nested:JsonProvider+Nested -> JsonProvider+Main
     JsonRuntime.CreateRecord([| ("title",
-                                 (title :> obj))
+                                 (title :> obj),
+                                 1)
                                 ("nested",
-                                 (nested :> obj)) |], "")
+                                 (nested :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Main
     JsonDocument.Create(jsonValue, "")
@@ -62,7 +65,8 @@ class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Nested : FDR.BaseTypes.IJsonDocument
     new : nestedTitle:string -> JsonProvider+Nested
     JsonRuntime.CreateRecord([| ("nestedTitle",
-                                 (nestedTitle :> obj)) |], "")
+                                 (nestedTitle :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Nested
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,DoubleNested.json,False,,,True,False,ValuesOnly.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : main:JsonProvider+Main -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("main",
-                                 (main :> obj)) |], "")
+                                 (main :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
     new : title:string -> nested:JsonProvider+Nested -> JsonProvider+Main
     JsonRuntime.CreateRecord([| ("title",
-                                 (title :> obj))
+                                 (title :> obj),
+                                 1)
                                 ("nested",
-                                 (nested :> obj)) |], "")
+                                 (nested :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Main
     JsonDocument.Create(jsonValue, "")
@@ -62,7 +65,8 @@ class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Nested : FDR.BaseTypes.IJsonDocument
     new : nestedTitle:string -> JsonProvider+Nested
     JsonRuntime.CreateRecord([| ("nestedTitle",
-                                 (nestedTitle :> obj)) |], "")
+                                 (nestedTitle :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Nested
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True,False,BackwardCompatible.expected
@@ -32,43 +32,62 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : url:string -> labelsUrl:string -> commentsUrl:string -> eventsUrl:string -> htmlUrl:string -> id:int -> number:int -> title:string -> user:JsonProvider+User -> labels:JsonProvider+JsonProvider+Label[] -> state:string -> assignee:JsonValue -> milestone:JsonValue -> comments:int -> createdAt:System.DateTimeOffset -> updatedAt:System.DateTimeOffset -> closedAt:JsonValue -> pullRequest:JsonProvider+PullRequest -> body:string option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("labels_url",
-                                 (labelsUrl :> obj))
+                                 (labelsUrl :> obj),
+                                 1)
                                 ("comments_url",
-                                 (commentsUrl :> obj))
+                                 (commentsUrl :> obj),
+                                 1)
                                 ("events_url",
-                                 (eventsUrl :> obj))
+                                 (eventsUrl :> obj),
+                                 1)
                                 ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("number",
-                                 (number :> obj))
+                                 (number :> obj),
+                                 2)
                                 ("title",
-                                 (title :> obj))
+                                 (title :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("labels",
-                                 (labels :> obj))
+                                 (labels :> obj),
+                                 0)
                                 ("state",
-                                 (state :> obj))
+                                 (state :> obj),
+                                 1)
                                 ("assignee",
-                                 (assignee :> obj))
+                                 (assignee :> obj),
+                                 0)
                                 ("milestone",
-                                 (milestone :> obj))
+                                 (milestone :> obj),
+                                 0)
                                 ("comments",
-                                 (comments :> obj))
+                                 (comments :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("updated_at",
-                                 (updatedAt :> obj))
+                                 (updatedAt :> obj),
+                                 1)
                                 ("closed_at",
-                                 (closedAt :> obj))
+                                 (closedAt :> obj),
+                                 0)
                                 ("pull_request",
-                                 (pullRequest :> obj))
+                                 (pullRequest :> obj),
+                                 0)
                                 ("body",
-                                 (body :> obj)) |], "")
+                                 (body :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -146,11 +165,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Label : FDR.BaseTypes.IJsonDocument
     new : url:string -> name:string -> color:JsonProvider+FloatOrString -> JsonProvider+Label
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("color",
-                                 (color :> obj)) |], "")
+                                 (color :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Label
     JsonDocument.Create(jsonValue, "")
@@ -170,11 +192,14 @@ class JsonProvider+Label : FDR.BaseTypes.IJsonDocument
 class JsonProvider+PullRequest : FDR.BaseTypes.IJsonDocument
     new : htmlUrl:string option -> diffUrl:string option -> patchUrl:string option -> JsonProvider+PullRequest
     JsonRuntime.CreateRecord([| ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("diff_url",
-                                 (diffUrl :> obj))
+                                 (diffUrl :> obj),
+                                 1)
                                 ("patch_url",
-                                 (patchUrl :> obj)) |], "")
+                                 (patchUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+PullRequest
     JsonDocument.Create(jsonValue, "")
@@ -192,37 +217,53 @@ class JsonProvider+PullRequest : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : login:string -> id:int -> avatarUrl:string -> gravatarId:System.Guid -> url:string -> htmlUrl:string -> followersUrl:string -> followingUrl:string -> gistsUrl:string -> starredUrl:string -> subscriptionsUrl:string -> organizationsUrl:string -> reposUrl:string -> eventsUrl:string -> receivedEventsUrl:string -> type:string -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("login",
-                                 (login :> obj))
+                                 (login :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("avatar_url",
-                                 (avatarUrl :> obj))
+                                 (avatarUrl :> obj),
+                                 1)
                                 ("gravatar_id",
-                                 (gravatarId :> obj))
+                                 (gravatarId :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("followers_url",
-                                 (followersUrl :> obj))
+                                 (followersUrl :> obj),
+                                 1)
                                 ("following_url",
-                                 (followingUrl :> obj))
+                                 (followingUrl :> obj),
+                                 1)
                                 ("gists_url",
-                                 (gistsUrl :> obj))
+                                 (gistsUrl :> obj),
+                                 1)
                                 ("starred_url",
-                                 (starredUrl :> obj))
+                                 (starredUrl :> obj),
+                                 1)
                                 ("subscriptions_url",
-                                 (subscriptionsUrl :> obj))
+                                 (subscriptionsUrl :> obj),
+                                 1)
                                 ("organizations_url",
-                                 (organizationsUrl :> obj))
+                                 (organizationsUrl :> obj),
+                                 1)
                                 ("repos_url",
-                                 (reposUrl :> obj))
+                                 (reposUrl :> obj),
+                                 1)
                                 ("events_url",
-                                 (eventsUrl :> obj))
+                                 (eventsUrl :> obj),
+                                 1)
                                 ("received_events_url",
-                                 (receivedEventsUrl :> obj))
+                                 (receivedEventsUrl :> obj),
+                                 1)
                                 ("type",
-                                 (type :> obj)) |], "")
+                                 (type :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,43 +32,62 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : url:string -> labelsUrl:string -> commentsUrl:string -> eventsUrl:string -> htmlUrl:string -> id:int -> number:int -> title:string -> user:JsonProvider+User -> labels:JsonProvider+JsonProvider+Label[] -> state:string -> assignee:JsonValue -> milestone:JsonValue -> comments:int -> createdAt:System.DateTimeOffset -> updatedAt:System.DateTimeOffset -> closedAt:JsonValue -> pullRequest:JsonProvider+PullRequest -> body:string option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("labels_url",
-                                 (labelsUrl :> obj))
+                                 (labelsUrl :> obj),
+                                 1)
                                 ("comments_url",
-                                 (commentsUrl :> obj))
+                                 (commentsUrl :> obj),
+                                 1)
                                 ("events_url",
-                                 (eventsUrl :> obj))
+                                 (eventsUrl :> obj),
+                                 1)
                                 ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("number",
-                                 (number :> obj))
+                                 (number :> obj),
+                                 2)
                                 ("title",
-                                 (title :> obj))
+                                 (title :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("labels",
-                                 (labels :> obj))
+                                 (labels :> obj),
+                                 0)
                                 ("state",
-                                 (state :> obj))
+                                 (state :> obj),
+                                 1)
                                 ("assignee",
-                                 (assignee :> obj))
+                                 (assignee :> obj),
+                                 0)
                                 ("milestone",
-                                 (milestone :> obj))
+                                 (milestone :> obj),
+                                 0)
                                 ("comments",
-                                 (comments :> obj))
+                                 (comments :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("updated_at",
-                                 (updatedAt :> obj))
+                                 (updatedAt :> obj),
+                                 1)
                                 ("closed_at",
-                                 (closedAt :> obj))
+                                 (closedAt :> obj),
+                                 0)
                                 ("pull_request",
-                                 (pullRequest :> obj))
+                                 (pullRequest :> obj),
+                                 0)
                                 ("body",
-                                 (body :> obj)) |], "")
+                                 (body :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -146,11 +165,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Label : FDR.BaseTypes.IJsonDocument
     new : url:string -> name:string -> color:JsonProvider+FloatOrString -> JsonProvider+Label
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("color",
-                                 (color :> obj)) |], "")
+                                 (color :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Label
     JsonDocument.Create(jsonValue, "")
@@ -170,11 +192,14 @@ class JsonProvider+Label : FDR.BaseTypes.IJsonDocument
 class JsonProvider+PullRequest : FDR.BaseTypes.IJsonDocument
     new : htmlUrl:string option -> diffUrl:string option -> patchUrl:string option -> JsonProvider+PullRequest
     JsonRuntime.CreateRecord([| ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("diff_url",
-                                 (diffUrl :> obj))
+                                 (diffUrl :> obj),
+                                 1)
                                 ("patch_url",
-                                 (patchUrl :> obj)) |], "")
+                                 (patchUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+PullRequest
     JsonDocument.Create(jsonValue, "")
@@ -192,37 +217,53 @@ class JsonProvider+PullRequest : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : login:string -> id:int -> avatarUrl:string -> gravatarId:System.Guid -> url:string -> htmlUrl:string -> followersUrl:string -> followingUrl:string -> gistsUrl:string -> starredUrl:string -> subscriptionsUrl:string -> organizationsUrl:string -> reposUrl:string -> eventsUrl:string -> receivedEventsUrl:string -> type:string -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("login",
-                                 (login :> obj))
+                                 (login :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("avatar_url",
-                                 (avatarUrl :> obj))
+                                 (avatarUrl :> obj),
+                                 1)
                                 ("gravatar_id",
-                                 (gravatarId :> obj))
+                                 (gravatarId :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("followers_url",
-                                 (followersUrl :> obj))
+                                 (followersUrl :> obj),
+                                 1)
                                 ("following_url",
-                                 (followingUrl :> obj))
+                                 (followingUrl :> obj),
+                                 1)
                                 ("gists_url",
-                                 (gistsUrl :> obj))
+                                 (gistsUrl :> obj),
+                                 1)
                                 ("starred_url",
-                                 (starredUrl :> obj))
+                                 (starredUrl :> obj),
+                                 1)
                                 ("subscriptions_url",
-                                 (subscriptionsUrl :> obj))
+                                 (subscriptionsUrl :> obj),
+                                 1)
                                 ("organizations_url",
-                                 (organizationsUrl :> obj))
+                                 (organizationsUrl :> obj),
+                                 1)
                                 ("repos_url",
-                                 (reposUrl :> obj))
+                                 (reposUrl :> obj),
+                                 1)
                                 ("events_url",
-                                 (eventsUrl :> obj))
+                                 (eventsUrl :> obj),
+                                 1)
                                 ("received_events_url",
-                                 (receivedEventsUrl :> obj))
+                                 (receivedEventsUrl :> obj),
+                                 1)
                                 ("type",
-                                 (type :> obj)) |], "")
+                                 (type :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,43 +32,62 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : url:string -> labelsUrl:string -> commentsUrl:string -> eventsUrl:string -> htmlUrl:string -> id:int -> number:int -> title:string -> user:JsonProvider+User -> labels:JsonProvider+JsonProvider+Label[] -> state:string -> assignee:JsonValue -> milestone:JsonValue -> comments:int -> createdAt:System.DateTimeOffset -> updatedAt:System.DateTimeOffset -> closedAt:JsonValue -> pullRequest:JsonProvider+PullRequest -> body:string option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("labels_url",
-                                 (labelsUrl :> obj))
+                                 (labelsUrl :> obj),
+                                 1)
                                 ("comments_url",
-                                 (commentsUrl :> obj))
+                                 (commentsUrl :> obj),
+                                 1)
                                 ("events_url",
-                                 (eventsUrl :> obj))
+                                 (eventsUrl :> obj),
+                                 1)
                                 ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("number",
-                                 (number :> obj))
+                                 (number :> obj),
+                                 2)
                                 ("title",
-                                 (title :> obj))
+                                 (title :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("labels",
-                                 (labels :> obj))
+                                 (labels :> obj),
+                                 0)
                                 ("state",
-                                 (state :> obj))
+                                 (state :> obj),
+                                 1)
                                 ("assignee",
-                                 (assignee :> obj))
+                                 (assignee :> obj),
+                                 0)
                                 ("milestone",
-                                 (milestone :> obj))
+                                 (milestone :> obj),
+                                 0)
                                 ("comments",
-                                 (comments :> obj))
+                                 (comments :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("updated_at",
-                                 (updatedAt :> obj))
+                                 (updatedAt :> obj),
+                                 1)
                                 ("closed_at",
-                                 (closedAt :> obj))
+                                 (closedAt :> obj),
+                                 0)
                                 ("pull_request",
-                                 (pullRequest :> obj))
+                                 (pullRequest :> obj),
+                                 0)
                                 ("body",
-                                 (body :> obj)) |], "")
+                                 (body :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -146,11 +165,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Label : FDR.BaseTypes.IJsonDocument
     new : url:string -> name:string -> color:JsonProvider+FloatOrString -> JsonProvider+Label
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("color",
-                                 (color :> obj)) |], "")
+                                 (color :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Label
     JsonDocument.Create(jsonValue, "")
@@ -170,11 +192,14 @@ class JsonProvider+Label : FDR.BaseTypes.IJsonDocument
 class JsonProvider+PullRequest : FDR.BaseTypes.IJsonDocument
     new : htmlUrl:string option -> diffUrl:string option -> patchUrl:string option -> JsonProvider+PullRequest
     JsonRuntime.CreateRecord([| ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("diff_url",
-                                 (diffUrl :> obj))
+                                 (diffUrl :> obj),
+                                 1)
                                 ("patch_url",
-                                 (patchUrl :> obj)) |], "")
+                                 (patchUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+PullRequest
     JsonDocument.Create(jsonValue, "")
@@ -192,37 +217,53 @@ class JsonProvider+PullRequest : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : login:string -> id:int -> avatarUrl:string -> gravatarId:System.Guid -> url:string -> htmlUrl:string -> followersUrl:string -> followingUrl:string -> gistsUrl:string -> starredUrl:string -> subscriptionsUrl:string -> organizationsUrl:string -> reposUrl:string -> eventsUrl:string -> receivedEventsUrl:string -> type:string -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("login",
-                                 (login :> obj))
+                                 (login :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("avatar_url",
-                                 (avatarUrl :> obj))
+                                 (avatarUrl :> obj),
+                                 1)
                                 ("gravatar_id",
-                                 (gravatarId :> obj))
+                                 (gravatarId :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("followers_url",
-                                 (followersUrl :> obj))
+                                 (followersUrl :> obj),
+                                 1)
                                 ("following_url",
-                                 (followingUrl :> obj))
+                                 (followingUrl :> obj),
+                                 1)
                                 ("gists_url",
-                                 (gistsUrl :> obj))
+                                 (gistsUrl :> obj),
+                                 1)
                                 ("starred_url",
-                                 (starredUrl :> obj))
+                                 (starredUrl :> obj),
+                                 1)
                                 ("subscriptions_url",
-                                 (subscriptionsUrl :> obj))
+                                 (subscriptionsUrl :> obj),
+                                 1)
                                 ("organizations_url",
-                                 (organizationsUrl :> obj))
+                                 (organizationsUrl :> obj),
+                                 1)
                                 ("repos_url",
-                                 (reposUrl :> obj))
+                                 (reposUrl :> obj),
+                                 1)
                                 ("events_url",
-                                 (eventsUrl :> obj))
+                                 (eventsUrl :> obj),
+                                 1)
                                 ("received_events_url",
-                                 (receivedEventsUrl :> obj))
+                                 (receivedEventsUrl :> obj),
+                                 1)
                                 ("type",
-                                 (type :> obj)) |], "")
+                                 (type :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,GitHub.json,False,,,True,False,ValuesOnly.expected
@@ -32,43 +32,62 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : url:string -> labelsUrl:string -> commentsUrl:string -> eventsUrl:string -> htmlUrl:string -> id:int -> number:int -> title:string -> user:JsonProvider+User -> labels:JsonProvider+JsonProvider+Label[] -> state:string -> assignee:JsonValue -> milestone:JsonValue -> comments:int -> createdAt:System.DateTimeOffset -> updatedAt:System.DateTimeOffset -> closedAt:JsonValue -> pullRequest:JsonProvider+PullRequest -> body:string option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("labels_url",
-                                 (labelsUrl :> obj))
+                                 (labelsUrl :> obj),
+                                 1)
                                 ("comments_url",
-                                 (commentsUrl :> obj))
+                                 (commentsUrl :> obj),
+                                 1)
                                 ("events_url",
-                                 (eventsUrl :> obj))
+                                 (eventsUrl :> obj),
+                                 1)
                                 ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("number",
-                                 (number :> obj))
+                                 (number :> obj),
+                                 2)
                                 ("title",
-                                 (title :> obj))
+                                 (title :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("labels",
-                                 (labels :> obj))
+                                 (labels :> obj),
+                                 0)
                                 ("state",
-                                 (state :> obj))
+                                 (state :> obj),
+                                 1)
                                 ("assignee",
-                                 (assignee :> obj))
+                                 (assignee :> obj),
+                                 0)
                                 ("milestone",
-                                 (milestone :> obj))
+                                 (milestone :> obj),
+                                 0)
                                 ("comments",
-                                 (comments :> obj))
+                                 (comments :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("updated_at",
-                                 (updatedAt :> obj))
+                                 (updatedAt :> obj),
+                                 1)
                                 ("closed_at",
-                                 (closedAt :> obj))
+                                 (closedAt :> obj),
+                                 0)
                                 ("pull_request",
-                                 (pullRequest :> obj))
+                                 (pullRequest :> obj),
+                                 0)
                                 ("body",
-                                 (body :> obj)) |], "")
+                                 (body :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -146,11 +165,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Label : FDR.BaseTypes.IJsonDocument
     new : url:string -> name:string -> color:JsonProvider+FloatOrString -> JsonProvider+Label
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("color",
-                                 (color :> obj)) |], "")
+                                 (color :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Label
     JsonDocument.Create(jsonValue, "")
@@ -170,11 +192,14 @@ class JsonProvider+Label : FDR.BaseTypes.IJsonDocument
 class JsonProvider+PullRequest : FDR.BaseTypes.IJsonDocument
     new : htmlUrl:string option -> diffUrl:string option -> patchUrl:string option -> JsonProvider+PullRequest
     JsonRuntime.CreateRecord([| ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("diff_url",
-                                 (diffUrl :> obj))
+                                 (diffUrl :> obj),
+                                 1)
                                 ("patch_url",
-                                 (patchUrl :> obj)) |], "")
+                                 (patchUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+PullRequest
     JsonDocument.Create(jsonValue, "")
@@ -192,37 +217,53 @@ class JsonProvider+PullRequest : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : login:string -> id:int -> avatarUrl:string -> gravatarId:System.Guid -> url:string -> htmlUrl:string -> followersUrl:string -> followingUrl:string -> gistsUrl:string -> starredUrl:string -> subscriptionsUrl:string -> organizationsUrl:string -> reposUrl:string -> eventsUrl:string -> receivedEventsUrl:string -> type:string -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("login",
-                                 (login :> obj))
+                                 (login :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("avatar_url",
-                                 (avatarUrl :> obj))
+                                 (avatarUrl :> obj),
+                                 1)
                                 ("gravatar_id",
-                                 (gravatarId :> obj))
+                                 (gravatarId :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("html_url",
-                                 (htmlUrl :> obj))
+                                 (htmlUrl :> obj),
+                                 1)
                                 ("followers_url",
-                                 (followersUrl :> obj))
+                                 (followersUrl :> obj),
+                                 1)
                                 ("following_url",
-                                 (followingUrl :> obj))
+                                 (followingUrl :> obj),
+                                 1)
                                 ("gists_url",
-                                 (gistsUrl :> obj))
+                                 (gistsUrl :> obj),
+                                 1)
                                 ("starred_url",
-                                 (starredUrl :> obj))
+                                 (starredUrl :> obj),
+                                 1)
                                 ("subscriptions_url",
-                                 (subscriptionsUrl :> obj))
+                                 (subscriptionsUrl :> obj),
+                                 1)
                                 ("organizations_url",
-                                 (organizationsUrl :> obj))
+                                 (organizationsUrl :> obj),
+                                 1)
                                 ("repos_url",
-                                 (reposUrl :> obj))
+                                 (reposUrl :> obj),
+                                 1)
                                 ("events_url",
-                                 (eventsUrl :> obj))
+                                 (eventsUrl :> obj),
+                                 1)
                                 ("received_events_url",
-                                 (receivedEventsUrl :> obj))
+                                 (receivedEventsUrl :> obj),
+                                 1)
                                 ("type",
-                                 (type :> obj)) |], "")
+                                 (type :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True,False,BackwardCompatible.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : main:JsonProvider+Main -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("main",
-                                 (main :> obj)) |], "")
+                                 (main :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,13 +45,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> isCool:bool -> JsonProvider+Main
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("isCool",
-                                 (isCool :> obj)) |], "")
+                                 (isCool :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Main
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : main:JsonProvider+Main -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("main",
-                                 (main :> obj)) |], "")
+                                 (main :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,13 +45,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> isCool:bool -> JsonProvider+Main
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("isCool",
-                                 (isCool :> obj)) |], "")
+                                 (isCool :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Main
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : main:JsonProvider+Main -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("main",
-                                 (main :> obj)) |], "")
+                                 (main :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,13 +45,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> isCool:bool -> JsonProvider+Main
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("isCool",
-                                 (isCool :> obj)) |], "")
+                                 (isCool :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Main
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Nested.json,False,,,True,False,ValuesOnly.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : main:JsonProvider+Main -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("main",
-                                 (main :> obj)) |], "")
+                                 (main :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,13 +45,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Main : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> isCool:bool -> JsonProvider+Main
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("isCool",
-                                 (isCool :> obj)) |], "")
+                                 (isCool :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Main
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True,False,BackwardCompatible.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : authors:JsonProvider+JsonProvider+Author[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("authors",
-                                 (authors :> obj)) |], "")
+                                 (authors :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Author : FDR.BaseTypes.IJsonDocument
     new : name:string -> age:int option -> JsonProvider+Author
     JsonRuntime.CreateRecord([| ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj)) |], "")
+                                 (age :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Author
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : authors:JsonProvider+JsonProvider+Author[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("authors",
-                                 (authors :> obj)) |], "")
+                                 (authors :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Author : FDR.BaseTypes.IJsonDocument
     new : name:string -> age:int option -> JsonProvider+Author
     JsonRuntime.CreateRecord([| ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj)) |], "")
+                                 (age :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Author
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : authors:JsonProvider+JsonProvider+Author[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("authors",
-                                 (authors :> obj)) |], "")
+                                 (authors :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Author : FDR.BaseTypes.IJsonDocument
     new : name:string -> age:int option -> JsonProvider+Author
     JsonRuntime.CreateRecord([| ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj)) |], "")
+                                 (age :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Author
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,OptionValues.json,False,,,True,False,ValuesOnly.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : authors:JsonProvider+JsonProvider+Author[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("authors",
-                                 (authors :> obj)) |], "")
+                                 (authors :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Author : FDR.BaseTypes.IJsonDocument
     new : name:string -> age:int option -> JsonProvider+Author
     JsonRuntime.CreateRecord([| ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj)) |], "")
+                                 (age :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Author
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True,False,BackwardCompatible.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> isCool:bool -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("isCool",
-                                 (isCool :> obj)) |], "")
+                                 (isCool :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> isCool:bool -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("isCool",
-                                 (isCool :> obj)) |], "")
+                                 (isCool :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> isCool:bool -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("isCool",
-                                 (isCool :> obj)) |], "")
+                                 (isCool :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Simple.json,False,,,True,False,ValuesOnly.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> isCool:bool -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("isCool",
-                                 (isCool :> obj)) |], "")
+                                 (isCool :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True,False,BackwardCompatible.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : items:JsonProvider+JsonProvider+Item[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("items",
-                                 (items :> obj)) |], "")
+                                 (items :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,7 +45,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Item : FDR.BaseTypes.IJsonDocument
     new : id:string -> JsonProvider+Item
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj)) |], "")
+                                 (id :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Item
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : items:JsonProvider+JsonProvider+Item[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("items",
-                                 (items :> obj)) |], "")
+                                 (items :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,7 +45,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Item : FDR.BaseTypes.IJsonDocument
     new : id:string -> JsonProvider+Item
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj)) |], "")
+                                 (id :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Item
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : items:JsonProvider+JsonProvider+Item[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("items",
-                                 (items :> obj)) |], "")
+                                 (items :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,7 +45,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Item : FDR.BaseTypes.IJsonDocument
     new : id:string -> JsonProvider+Item
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj)) |], "")
+                                 (id :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Item
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,SimpleArray.json,False,,,True,False,ValuesOnly.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : items:JsonProvider+JsonProvider+Item[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("items",
-                                 (items :> obj)) |], "")
+                                 (items :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,7 +45,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Item : FDR.BaseTypes.IJsonDocument
     new : id:string -> JsonProvider+Item
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj)) |], "")
+                                 (id :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Item
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True,False,BackwardCompatible.expected
@@ -32,15 +32,20 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : positiveWithDayWithFraction:System.TimeSpan -> positiveWithoutDayWithoutFraction:System.TimeSpan -> negativeWithDayWithFraction:System.TimeSpan -> timespanOneTickGreaterThanMaxValue:string -> timespanOneTickLessThanMinValue:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("positiveWithDayWithFraction",
-                                 (positiveWithDayWithFraction :> obj))
+                                 (positiveWithDayWithFraction :> obj),
+                                 1)
                                 ("positiveWithoutDayWithoutFraction",
-                                 (positiveWithoutDayWithoutFraction :> obj))
+                                 (positiveWithoutDayWithoutFraction :> obj),
+                                 1)
                                 ("negativeWithDayWithFraction",
-                                 (negativeWithDayWithFraction :> obj))
+                                 (negativeWithDayWithFraction :> obj),
+                                 1)
                                 ("timespanOneTickGreaterThanMaxValue",
-                                 (timespanOneTickGreaterThanMaxValue :> obj))
+                                 (timespanOneTickGreaterThanMaxValue :> obj),
+                                 1)
                                 ("timespanOneTickLessThanMinValue",
-                                 (timespanOneTickLessThanMinValue :> obj)) |], "")
+                                 (timespanOneTickLessThanMinValue :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,15 +32,20 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : positiveWithDayWithFraction:System.TimeSpan -> positiveWithoutDayWithoutFraction:System.TimeSpan -> negativeWithDayWithFraction:System.TimeSpan -> timespanOneTickGreaterThanMaxValue:string -> timespanOneTickLessThanMinValue:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("positiveWithDayWithFraction",
-                                 (positiveWithDayWithFraction :> obj))
+                                 (positiveWithDayWithFraction :> obj),
+                                 1)
                                 ("positiveWithoutDayWithoutFraction",
-                                 (positiveWithoutDayWithoutFraction :> obj))
+                                 (positiveWithoutDayWithoutFraction :> obj),
+                                 1)
                                 ("negativeWithDayWithFraction",
-                                 (negativeWithDayWithFraction :> obj))
+                                 (negativeWithDayWithFraction :> obj),
+                                 1)
                                 ("timespanOneTickGreaterThanMaxValue",
-                                 (timespanOneTickGreaterThanMaxValue :> obj))
+                                 (timespanOneTickGreaterThanMaxValue :> obj),
+                                 1)
                                 ("timespanOneTickLessThanMinValue",
-                                 (timespanOneTickLessThanMinValue :> obj)) |], "")
+                                 (timespanOneTickLessThanMinValue :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,15 +32,20 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : positiveWithDayWithFraction:System.TimeSpan -> positiveWithoutDayWithoutFraction:System.TimeSpan -> negativeWithDayWithFraction:System.TimeSpan -> timespanOneTickGreaterThanMaxValue:string -> timespanOneTickLessThanMinValue:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("positiveWithDayWithFraction",
-                                 (positiveWithDayWithFraction :> obj))
+                                 (positiveWithDayWithFraction :> obj),
+                                 1)
                                 ("positiveWithoutDayWithoutFraction",
-                                 (positiveWithoutDayWithoutFraction :> obj))
+                                 (positiveWithoutDayWithoutFraction :> obj),
+                                 1)
                                 ("negativeWithDayWithFraction",
-                                 (negativeWithDayWithFraction :> obj))
+                                 (negativeWithDayWithFraction :> obj),
+                                 1)
                                 ("timespanOneTickGreaterThanMaxValue",
-                                 (timespanOneTickGreaterThanMaxValue :> obj))
+                                 (timespanOneTickGreaterThanMaxValue :> obj),
+                                 1)
                                 ("timespanOneTickLessThanMinValue",
-                                 (timespanOneTickLessThanMinValue :> obj)) |], "")
+                                 (timespanOneTickLessThanMinValue :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TimeSpans.json,False,,,True,False,ValuesOnly.expected
@@ -32,15 +32,20 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : positiveWithDayWithFraction:System.TimeSpan -> positiveWithoutDayWithoutFraction:System.TimeSpan -> negativeWithDayWithFraction:System.TimeSpan -> timespanOneTickGreaterThanMaxValue:string -> timespanOneTickLessThanMinValue:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("positiveWithDayWithFraction",
-                                 (positiveWithDayWithFraction :> obj))
+                                 (positiveWithDayWithFraction :> obj),
+                                 1)
                                 ("positiveWithoutDayWithoutFraction",
-                                 (positiveWithoutDayWithoutFraction :> obj))
+                                 (positiveWithoutDayWithoutFraction :> obj),
+                                 1)
                                 ("negativeWithDayWithFraction",
-                                 (negativeWithDayWithFraction :> obj))
+                                 (negativeWithDayWithFraction :> obj),
+                                 1)
                                 ("timespanOneTickGreaterThanMaxValue",
-                                 (timespanOneTickGreaterThanMaxValue :> obj))
+                                 (timespanOneTickGreaterThanMaxValue :> obj),
+                                 1)
                                 ("timespanOneTickLessThanMinValue",
-                                 (timespanOneTickLessThanMinValue :> obj)) |], "")
+                                 (timespanOneTickLessThanMinValue :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True,False,BackwardCompatible.expected
@@ -32,57 +32,83 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : createdAt:string option -> id:int64 option -> idStr:int64 option -> text:string option -> source:string option -> truncated:bool option -> inReplyToStatusId:int64 option -> inReplyToStatusIdStr:int64 option -> inReplyToUserId:int option -> inReplyToUserIdStr:int option -> inReplyToScreenName:string option -> user:JsonProvider+User option -> geo:JsonValue -> coordinates:JsonValue -> place:JsonProvider+Place option -> contributors:JsonValue -> retweetedStatus:JsonProvider+RetweetedStatus option -> retweetCount:int option -> favoriteCount:int option -> entities:JsonProvider+Entities2 option -> favorited:bool option -> retweeted:bool option -> filterLevel:string option -> possiblySensitive:bool option -> lang:string option -> delete:JsonProvider+Delete option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("retweeted_status",
-                                 (retweetedStatus :> obj))
+                                 (retweetedStatus :> obj),
+                                 0)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("favorite_count",
-                                 (favoriteCount :> obj))
+                                 (favoriteCount :> obj),
+                                 2)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("filter_level",
-                                 (filterLevel :> obj))
+                                 (filterLevel :> obj),
+                                 1)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("delete",
-                                 (delete :> obj)) |], "")
+                                 (delete :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -169,7 +195,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
     new : status:JsonProvider+Status -> JsonProvider+Delete
     JsonRuntime.CreateRecord([| ("status",
-                                 (status :> obj)) |], "")
+                                 (status :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Delete
     JsonDocument.Create(jsonValue, "")
@@ -181,13 +208,17 @@ class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
     new : hashtags:JsonProvider+JsonProvider+Hashtag[] -> symbols:JsonValue[] -> urls:JsonProvider+JsonProvider+Url[] -> userMentions:JsonProvider+JsonProvider+UserMention[] -> JsonProvider+Entities2
     JsonRuntime.CreateRecord([| ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("symbols",
-                                 (symbols :> obj))
+                                 (symbols :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("user_mentions",
-                                 (userMentions :> obj)) |], "")
+                                 (userMentions :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities2
     JsonDocument.Create(jsonValue, "")
@@ -208,23 +239,32 @@ class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
     new : id:string -> url:string -> placeType:string -> name:string -> fullName:string -> countryCode:string -> country:string -> boundingBox:JsonProvider+BoundingBox -> attributes:JsonProvider+Attributes -> JsonProvider+Place
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("place_type",
-                                 (placeType :> obj))
+                                 (placeType :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("full_name",
-                                 (fullName :> obj))
+                                 (fullName :> obj),
+                                 1)
                                 ("country_code",
-                                 (countryCode :> obj))
+                                 (countryCode :> obj),
+                                 1)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 1)
                                 ("bounding_box",
-                                 (boundingBox :> obj))
+                                 (boundingBox :> obj),
+                                 0)
                                 ("attributes",
-                                 (attributes :> obj)) |], "")
+                                 (attributes :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Place
     JsonDocument.Create(jsonValue, "")
@@ -267,51 +307,74 @@ class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
     new : createdAt:string -> id:int64 -> idStr:int64 -> text:string -> source:string -> truncated:bool -> inReplyToStatusId:JsonValue -> inReplyToStatusIdStr:JsonValue -> inReplyToUserId:int option -> inReplyToUserIdStr:int option -> inReplyToScreenName:string option -> user:JsonProvider+User2 -> geo:JsonValue -> coordinates:JsonValue -> place:JsonValue -> contributors:JsonValue -> retweetCount:int -> favoriteCount:int -> entities:JsonProvider+Entities -> favorited:bool -> retweeted:bool -> lang:string -> possiblySensitive:bool option -> JsonProvider+RetweetedStatus
     JsonRuntime.CreateRecord([| ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 0)
                                 ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("favorite_count",
-                                 (favoriteCount :> obj))
+                                 (favoriteCount :> obj),
+                                 2)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj)) |], "")
+                                 (possiblySensitive :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RetweetedStatus
     JsonDocument.Create(jsonValue, "")
@@ -400,81 +463,119 @@ class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : id:int -> idStr:int -> name:string -> screenName:string -> location:string option -> url:string option -> description:string -> protected:bool -> followersCount:int -> friendsCount:int -> listedCount:int -> createdAt:string -> favouritesCount:int -> utcOffset:int option -> timeZone:string option -> geoEnabled:bool -> verified:bool -> statusesCount:int -> lang:string -> contributorsEnabled:bool -> isTranslator:bool -> profileBackgroundColor:JsonProvider+IntOrString -> profileBackgroundImageUrl:string -> profileBackgroundImageUrlHttps:string -> profileBackgroundTile:bool -> profileImageUrl:string -> profileImageUrlHttps:string -> profileBannerUrl:string option -> profileLinkColor:JsonProvider+IntOrString -> profileSidebarBorderColor:JsonProvider+IntOrString -> profileSidebarFillColor:JsonProvider+IntOrString -> profileTextColor:JsonProvider+IntOrString -> profileUseBackgroundImage:bool -> defaultProfile:bool -> defaultProfileImage:bool -> following:JsonValue -> followRequestSent:JsonValue -> notifications:JsonValue -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("notifications",
-                                 (notifications :> obj)) |], "")
+                                 (notifications :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")
@@ -630,9 +731,11 @@ class JsonProvider+Attributes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[][][] -> JsonProvider+BoundingBox
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+BoundingBox
     JsonDocument.Create(jsonValue, "")
@@ -648,15 +751,20 @@ class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
     new : hashtags:JsonProvider+JsonProvider+Hashtag[] -> symbols:JsonValue[] -> urls:JsonProvider+JsonProvider+Url[] -> userMentions:JsonProvider+JsonProvider+UserMention[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities
     JsonRuntime.CreateRecord([| ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("symbols",
-                                 (symbols :> obj))
+                                 (symbols :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities
     JsonDocument.Create(jsonValue, "")
@@ -680,9 +788,11 @@ class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hashtag : FDR.BaseTypes.IJsonDocument
     new : text:string -> indices:int[] -> JsonProvider+Hashtag
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hashtag
     JsonDocument.Create(jsonValue, "")
@@ -718,13 +828,17 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
     new : id:int64 -> userId:int -> idStr:int64 -> userIdStr:int -> JsonProvider+Status
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("user_id",
-                                 (userId :> obj))
+                                 (userId :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("user_id_str",
-                                 (userIdStr :> obj)) |], "")
+                                 (userIdStr :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Status
     JsonDocument.Create(jsonValue, "")
@@ -749,13 +863,17 @@ class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
     new : url:string -> expandedUrl:string -> displayUrl:string -> indices:int[] -> JsonProvider+Url
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Url
     JsonDocument.Create(jsonValue, "")
@@ -779,81 +897,119 @@ class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
     new : id:int -> idStr:int -> name:string -> screenName:string -> location:string option -> url:string option -> description:string -> protected:bool -> followersCount:int -> friendsCount:int -> listedCount:int -> createdAt:string -> favouritesCount:int -> utcOffset:int option -> timeZone:string option -> geoEnabled:bool -> verified:bool -> statusesCount:int -> lang:string -> contributorsEnabled:bool -> isTranslator:bool -> profileBackgroundColor:JsonProvider+IntOrString -> profileBackgroundImageUrl:string -> profileBackgroundImageUrlHttps:string -> profileBackgroundTile:bool -> profileImageUrl:string -> profileImageUrlHttps:string -> profileBannerUrl:string option -> profileLinkColor:string -> profileSidebarBorderColor:JsonProvider+IntOrString -> profileSidebarFillColor:JsonProvider+IntOrString -> profileTextColor:JsonProvider+IntOrString -> profileUseBackgroundImage:bool -> defaultProfile:bool -> defaultProfileImage:bool -> following:JsonValue -> followRequestSent:JsonValue -> notifications:JsonValue -> JsonProvider+User2
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("notifications",
-                                 (notifications :> obj)) |], "")
+                                 (notifications :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User2
     JsonDocument.Create(jsonValue, "")
@@ -1002,15 +1158,20 @@ class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
     new : screenName:string -> name:string -> id:int -> idStr:int -> indices:int[] -> JsonProvider+UserMention
     JsonRuntime.CreateRecord([| ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+UserMention
     JsonDocument.Create(jsonValue, "")
@@ -1038,29 +1199,41 @@ class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
     new : id:int64 -> idStr:int64 -> indices:int[] -> mediaUrl:string -> mediaUrlHttps:string -> url:string -> displayUrl:string -> expandedUrl:string -> type:string -> sizes:JsonProvider+Sizes -> sourceStatusId:int64 -> sourceStatusIdStr:int64 -> JsonProvider+Media
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("media_url",
-                                 (mediaUrl :> obj))
+                                 (mediaUrl :> obj),
+                                 1)
                                 ("media_url_https",
-                                 (mediaUrlHttps :> obj))
+                                 (mediaUrlHttps :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("sizes",
-                                 (sizes :> obj))
+                                 (sizes :> obj),
+                                 0)
                                 ("source_status_id",
-                                 (sourceStatusId :> obj))
+                                 (sourceStatusId :> obj),
+                                 2)
                                 ("source_status_id_str",
-                                 (sourceStatusIdStr :> obj)) |], "")
+                                 (sourceStatusIdStr :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Media
     JsonDocument.Create(jsonValue, "")
@@ -1115,13 +1288,17 @@ class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
     new : small:JsonProvider+Small -> thumb:JsonProvider+Small -> large:JsonProvider+Small -> medium:JsonProvider+Small -> JsonProvider+Sizes
     JsonRuntime.CreateRecord([| ("small",
-                                 (small :> obj))
+                                 (small :> obj),
+                                 0)
                                 ("thumb",
-                                 (thumb :> obj))
+                                 (thumb :> obj),
+                                 0)
                                 ("large",
-                                 (large :> obj))
+                                 (large :> obj),
+                                 0)
                                 ("medium",
-                                 (medium :> obj)) |], "")
+                                 (medium :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Sizes
     JsonDocument.Create(jsonValue, "")
@@ -1142,11 +1319,14 @@ class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Small : FDR.BaseTypes.IJsonDocument
     new : w:int -> h:int -> resize:string -> JsonProvider+Small
     JsonRuntime.CreateRecord([| ("w",
-                                 (w :> obj))
+                                 (w :> obj),
+                                 2)
                                 ("h",
-                                 (h :> obj))
+                                 (h :> obj),
+                                 2)
                                 ("resize",
-                                 (resize :> obj)) |], "")
+                                 (resize :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Small
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,57 +32,83 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : createdAt:string option -> id:int64 option -> idStr:int64 option -> text:string option -> source:string option -> truncated:bool option -> inReplyToStatusId:int64 option -> inReplyToStatusIdStr:int64 option -> inReplyToUserId:int option -> inReplyToUserIdStr:int option -> inReplyToScreenName:string option -> user:JsonProvider+User option -> geo:JsonValue -> coordinates:JsonValue -> place:JsonProvider+Place option -> contributors:JsonValue -> retweetedStatus:JsonProvider+RetweetedStatus option -> retweetCount:int option -> favoriteCount:int option -> entities:JsonProvider+Entities2 option -> favorited:bool option -> retweeted:bool option -> filterLevel:string option -> possiblySensitive:bool option -> lang:string option -> delete:JsonProvider+Delete option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("retweeted_status",
-                                 (retweetedStatus :> obj))
+                                 (retweetedStatus :> obj),
+                                 0)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("favorite_count",
-                                 (favoriteCount :> obj))
+                                 (favoriteCount :> obj),
+                                 2)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("filter_level",
-                                 (filterLevel :> obj))
+                                 (filterLevel :> obj),
+                                 1)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("delete",
-                                 (delete :> obj)) |], "")
+                                 (delete :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -169,7 +195,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
     new : status:JsonProvider+Status -> JsonProvider+Delete
     JsonRuntime.CreateRecord([| ("status",
-                                 (status :> obj)) |], "")
+                                 (status :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Delete
     JsonDocument.Create(jsonValue, "")
@@ -181,13 +208,17 @@ class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
     new : hashtags:JsonProvider+JsonProvider+Hashtag[] -> symbols:JsonValue[] -> urls:JsonProvider+JsonProvider+Url[] -> userMentions:JsonProvider+JsonProvider+UserMention[] -> JsonProvider+Entities2
     JsonRuntime.CreateRecord([| ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("symbols",
-                                 (symbols :> obj))
+                                 (symbols :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("user_mentions",
-                                 (userMentions :> obj)) |], "")
+                                 (userMentions :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities2
     JsonDocument.Create(jsonValue, "")
@@ -208,23 +239,32 @@ class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
     new : id:string -> url:string -> placeType:string -> name:string -> fullName:string -> countryCode:string -> country:string -> boundingBox:JsonProvider+BoundingBox -> attributes:JsonProvider+Attributes -> JsonProvider+Place
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("place_type",
-                                 (placeType :> obj))
+                                 (placeType :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("full_name",
-                                 (fullName :> obj))
+                                 (fullName :> obj),
+                                 1)
                                 ("country_code",
-                                 (countryCode :> obj))
+                                 (countryCode :> obj),
+                                 1)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 1)
                                 ("bounding_box",
-                                 (boundingBox :> obj))
+                                 (boundingBox :> obj),
+                                 0)
                                 ("attributes",
-                                 (attributes :> obj)) |], "")
+                                 (attributes :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Place
     JsonDocument.Create(jsonValue, "")
@@ -267,51 +307,74 @@ class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
     new : createdAt:string -> id:int64 -> idStr:int64 -> text:string -> source:string -> truncated:bool -> inReplyToStatusId:JsonValue -> inReplyToStatusIdStr:JsonValue -> inReplyToUserId:int option -> inReplyToUserIdStr:int option -> inReplyToScreenName:string option -> user:JsonProvider+User2 -> geo:JsonValue -> coordinates:JsonValue -> place:JsonValue -> contributors:JsonValue -> retweetCount:int -> favoriteCount:int -> entities:JsonProvider+Entities -> favorited:bool -> retweeted:bool -> lang:string -> possiblySensitive:bool option -> JsonProvider+RetweetedStatus
     JsonRuntime.CreateRecord([| ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 0)
                                 ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("favorite_count",
-                                 (favoriteCount :> obj))
+                                 (favoriteCount :> obj),
+                                 2)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj)) |], "")
+                                 (possiblySensitive :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RetweetedStatus
     JsonDocument.Create(jsonValue, "")
@@ -400,81 +463,119 @@ class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : id:int -> idStr:int -> name:string -> screenName:string -> location:string option -> url:string option -> description:string -> protected:bool -> followersCount:int -> friendsCount:int -> listedCount:int -> createdAt:string -> favouritesCount:int -> utcOffset:int option -> timeZone:string option -> geoEnabled:bool -> verified:bool -> statusesCount:int -> lang:string -> contributorsEnabled:bool -> isTranslator:bool -> profileBackgroundColor:JsonProvider+IntOrString -> profileBackgroundImageUrl:string -> profileBackgroundImageUrlHttps:string -> profileBackgroundTile:bool -> profileImageUrl:string -> profileImageUrlHttps:string -> profileBannerUrl:string option -> profileLinkColor:JsonProvider+IntOrString -> profileSidebarBorderColor:JsonProvider+IntOrString -> profileSidebarFillColor:JsonProvider+IntOrString -> profileTextColor:JsonProvider+IntOrString -> profileUseBackgroundImage:bool -> defaultProfile:bool -> defaultProfileImage:bool -> following:JsonValue -> followRequestSent:JsonValue -> notifications:JsonValue -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("notifications",
-                                 (notifications :> obj)) |], "")
+                                 (notifications :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")
@@ -630,9 +731,11 @@ class JsonProvider+Attributes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[][][] -> JsonProvider+BoundingBox
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+BoundingBox
     JsonDocument.Create(jsonValue, "")
@@ -648,15 +751,20 @@ class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
     new : hashtags:JsonProvider+JsonProvider+Hashtag[] -> symbols:JsonValue[] -> urls:JsonProvider+JsonProvider+Url[] -> userMentions:JsonProvider+JsonProvider+UserMention[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities
     JsonRuntime.CreateRecord([| ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("symbols",
-                                 (symbols :> obj))
+                                 (symbols :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities
     JsonDocument.Create(jsonValue, "")
@@ -680,9 +788,11 @@ class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hashtag : FDR.BaseTypes.IJsonDocument
     new : text:string -> indices:int[] -> JsonProvider+Hashtag
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hashtag
     JsonDocument.Create(jsonValue, "")
@@ -718,13 +828,17 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
     new : id:int64 -> userId:int -> idStr:int64 -> userIdStr:int -> JsonProvider+Status
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("user_id",
-                                 (userId :> obj))
+                                 (userId :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("user_id_str",
-                                 (userIdStr :> obj)) |], "")
+                                 (userIdStr :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Status
     JsonDocument.Create(jsonValue, "")
@@ -749,13 +863,17 @@ class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
     new : url:string -> expandedUrl:string -> displayUrl:string -> indices:int[] -> JsonProvider+Url
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Url
     JsonDocument.Create(jsonValue, "")
@@ -779,81 +897,119 @@ class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
     new : id:int -> idStr:int -> name:string -> screenName:string -> location:string option -> url:string option -> description:string -> protected:bool -> followersCount:int -> friendsCount:int -> listedCount:int -> createdAt:string -> favouritesCount:int -> utcOffset:int option -> timeZone:string option -> geoEnabled:bool -> verified:bool -> statusesCount:int -> lang:string -> contributorsEnabled:bool -> isTranslator:bool -> profileBackgroundColor:JsonProvider+IntOrString -> profileBackgroundImageUrl:string -> profileBackgroundImageUrlHttps:string -> profileBackgroundTile:bool -> profileImageUrl:string -> profileImageUrlHttps:string -> profileBannerUrl:string option -> profileLinkColor:string -> profileSidebarBorderColor:JsonProvider+IntOrString -> profileSidebarFillColor:JsonProvider+IntOrString -> profileTextColor:JsonProvider+IntOrString -> profileUseBackgroundImage:bool -> defaultProfile:bool -> defaultProfileImage:bool -> following:JsonValue -> followRequestSent:JsonValue -> notifications:JsonValue -> JsonProvider+User2
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("notifications",
-                                 (notifications :> obj)) |], "")
+                                 (notifications :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User2
     JsonDocument.Create(jsonValue, "")
@@ -1002,15 +1158,20 @@ class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
     new : screenName:string -> name:string -> id:int -> idStr:int -> indices:int[] -> JsonProvider+UserMention
     JsonRuntime.CreateRecord([| ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+UserMention
     JsonDocument.Create(jsonValue, "")
@@ -1038,29 +1199,41 @@ class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
     new : id:int64 -> idStr:int64 -> indices:int[] -> mediaUrl:string -> mediaUrlHttps:string -> url:string -> displayUrl:string -> expandedUrl:string -> type:string -> sizes:JsonProvider+Sizes -> sourceStatusId:int64 -> sourceStatusIdStr:int64 -> JsonProvider+Media
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("media_url",
-                                 (mediaUrl :> obj))
+                                 (mediaUrl :> obj),
+                                 1)
                                 ("media_url_https",
-                                 (mediaUrlHttps :> obj))
+                                 (mediaUrlHttps :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("sizes",
-                                 (sizes :> obj))
+                                 (sizes :> obj),
+                                 0)
                                 ("source_status_id",
-                                 (sourceStatusId :> obj))
+                                 (sourceStatusId :> obj),
+                                 2)
                                 ("source_status_id_str",
-                                 (sourceStatusIdStr :> obj)) |], "")
+                                 (sourceStatusIdStr :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Media
     JsonDocument.Create(jsonValue, "")
@@ -1115,13 +1288,17 @@ class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
     new : small:JsonProvider+Small -> thumb:JsonProvider+Small -> large:JsonProvider+Small -> medium:JsonProvider+Small -> JsonProvider+Sizes
     JsonRuntime.CreateRecord([| ("small",
-                                 (small :> obj))
+                                 (small :> obj),
+                                 0)
                                 ("thumb",
-                                 (thumb :> obj))
+                                 (thumb :> obj),
+                                 0)
                                 ("large",
-                                 (large :> obj))
+                                 (large :> obj),
+                                 0)
                                 ("medium",
-                                 (medium :> obj)) |], "")
+                                 (medium :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Sizes
     JsonDocument.Create(jsonValue, "")
@@ -1142,11 +1319,14 @@ class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Small : FDR.BaseTypes.IJsonDocument
     new : w:int -> h:int -> resize:string -> JsonProvider+Small
     JsonRuntime.CreateRecord([| ("w",
-                                 (w :> obj))
+                                 (w :> obj),
+                                 2)
                                 ("h",
-                                 (h :> obj))
+                                 (h :> obj),
+                                 2)
                                 ("resize",
-                                 (resize :> obj)) |], "")
+                                 (resize :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Small
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,57 +32,83 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : createdAt:string option -> id:int64 option -> idStr:int64 option -> text:string option -> source:string option -> truncated:bool option -> inReplyToStatusId:int64 option -> inReplyToStatusIdStr:int64 option -> inReplyToUserId:int option -> inReplyToUserIdStr:int option -> inReplyToScreenName:string option -> user:JsonProvider+User option -> geo:JsonValue -> coordinates:JsonValue -> place:JsonProvider+Place option -> contributors:JsonValue -> retweetedStatus:JsonProvider+RetweetedStatus option -> retweetCount:int option -> favoriteCount:int option -> entities:JsonProvider+Entities2 option -> favorited:bool option -> retweeted:bool option -> filterLevel:string option -> possiblySensitive:bool option -> lang:string option -> delete:JsonProvider+Delete option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("retweeted_status",
-                                 (retweetedStatus :> obj))
+                                 (retweetedStatus :> obj),
+                                 0)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("favorite_count",
-                                 (favoriteCount :> obj))
+                                 (favoriteCount :> obj),
+                                 2)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("filter_level",
-                                 (filterLevel :> obj))
+                                 (filterLevel :> obj),
+                                 1)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("delete",
-                                 (delete :> obj)) |], "")
+                                 (delete :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -169,7 +195,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
     new : status:JsonProvider+Status -> JsonProvider+Delete
     JsonRuntime.CreateRecord([| ("status",
-                                 (status :> obj)) |], "")
+                                 (status :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Delete
     JsonDocument.Create(jsonValue, "")
@@ -181,13 +208,17 @@ class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
     new : hashtags:JsonProvider+JsonProvider+Hashtag[] -> symbols:JsonValue[] -> urls:JsonProvider+JsonProvider+Url[] -> userMentions:JsonProvider+JsonProvider+UserMention[] -> JsonProvider+Entities2
     JsonRuntime.CreateRecord([| ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("symbols",
-                                 (symbols :> obj))
+                                 (symbols :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("user_mentions",
-                                 (userMentions :> obj)) |], "")
+                                 (userMentions :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities2
     JsonDocument.Create(jsonValue, "")
@@ -208,23 +239,32 @@ class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
     new : id:string -> url:string -> placeType:string -> name:string -> fullName:string -> countryCode:string -> country:string -> boundingBox:JsonProvider+BoundingBox -> attributes:JsonProvider+Attributes -> JsonProvider+Place
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("place_type",
-                                 (placeType :> obj))
+                                 (placeType :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("full_name",
-                                 (fullName :> obj))
+                                 (fullName :> obj),
+                                 1)
                                 ("country_code",
-                                 (countryCode :> obj))
+                                 (countryCode :> obj),
+                                 1)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 1)
                                 ("bounding_box",
-                                 (boundingBox :> obj))
+                                 (boundingBox :> obj),
+                                 0)
                                 ("attributes",
-                                 (attributes :> obj)) |], "")
+                                 (attributes :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Place
     JsonDocument.Create(jsonValue, "")
@@ -267,51 +307,74 @@ class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
     new : createdAt:string -> id:int64 -> idStr:int64 -> text:string -> source:string -> truncated:bool -> inReplyToStatusId:JsonValue -> inReplyToStatusIdStr:JsonValue -> inReplyToUserId:int option -> inReplyToUserIdStr:int option -> inReplyToScreenName:string option -> user:JsonProvider+User2 -> geo:JsonValue -> coordinates:JsonValue -> place:JsonValue -> contributors:JsonValue -> retweetCount:int -> favoriteCount:int -> entities:JsonProvider+Entities -> favorited:bool -> retweeted:bool -> lang:string -> possiblySensitive:bool option -> JsonProvider+RetweetedStatus
     JsonRuntime.CreateRecord([| ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 0)
                                 ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("favorite_count",
-                                 (favoriteCount :> obj))
+                                 (favoriteCount :> obj),
+                                 2)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj)) |], "")
+                                 (possiblySensitive :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RetweetedStatus
     JsonDocument.Create(jsonValue, "")
@@ -400,81 +463,119 @@ class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : id:int -> idStr:int -> name:string -> screenName:string -> location:string option -> url:string option -> description:string -> protected:bool -> followersCount:int -> friendsCount:int -> listedCount:int -> createdAt:string -> favouritesCount:int -> utcOffset:int option -> timeZone:string option -> geoEnabled:bool -> verified:bool -> statusesCount:int -> lang:string -> contributorsEnabled:bool -> isTranslator:bool -> profileBackgroundColor:JsonProvider+IntOrString -> profileBackgroundImageUrl:string -> profileBackgroundImageUrlHttps:string -> profileBackgroundTile:bool -> profileImageUrl:string -> profileImageUrlHttps:string -> profileBannerUrl:string option -> profileLinkColor:JsonProvider+IntOrString -> profileSidebarBorderColor:JsonProvider+IntOrString -> profileSidebarFillColor:JsonProvider+IntOrString -> profileTextColor:JsonProvider+IntOrString -> profileUseBackgroundImage:bool -> defaultProfile:bool -> defaultProfileImage:bool -> following:JsonValue -> followRequestSent:JsonValue -> notifications:JsonValue -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("notifications",
-                                 (notifications :> obj)) |], "")
+                                 (notifications :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")
@@ -630,9 +731,11 @@ class JsonProvider+Attributes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[][][] -> JsonProvider+BoundingBox
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+BoundingBox
     JsonDocument.Create(jsonValue, "")
@@ -648,15 +751,20 @@ class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
     new : hashtags:JsonProvider+JsonProvider+Hashtag[] -> symbols:JsonValue[] -> urls:JsonProvider+JsonProvider+Url[] -> userMentions:JsonProvider+JsonProvider+UserMention[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities
     JsonRuntime.CreateRecord([| ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("symbols",
-                                 (symbols :> obj))
+                                 (symbols :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities
     JsonDocument.Create(jsonValue, "")
@@ -680,9 +788,11 @@ class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hashtag : FDR.BaseTypes.IJsonDocument
     new : text:string -> indices:int[] -> JsonProvider+Hashtag
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hashtag
     JsonDocument.Create(jsonValue, "")
@@ -718,13 +828,17 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
     new : id:int64 -> userId:int -> idStr:int64 -> userIdStr:int -> JsonProvider+Status
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("user_id",
-                                 (userId :> obj))
+                                 (userId :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("user_id_str",
-                                 (userIdStr :> obj)) |], "")
+                                 (userIdStr :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Status
     JsonDocument.Create(jsonValue, "")
@@ -749,13 +863,17 @@ class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
     new : url:string -> expandedUrl:string -> displayUrl:string -> indices:int[] -> JsonProvider+Url
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Url
     JsonDocument.Create(jsonValue, "")
@@ -779,81 +897,119 @@ class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
     new : id:int -> idStr:int -> name:string -> screenName:string -> location:string option -> url:string option -> description:string -> protected:bool -> followersCount:int -> friendsCount:int -> listedCount:int -> createdAt:string -> favouritesCount:int -> utcOffset:int option -> timeZone:string option -> geoEnabled:bool -> verified:bool -> statusesCount:int -> lang:string -> contributorsEnabled:bool -> isTranslator:bool -> profileBackgroundColor:JsonProvider+IntOrString -> profileBackgroundImageUrl:string -> profileBackgroundImageUrlHttps:string -> profileBackgroundTile:bool -> profileImageUrl:string -> profileImageUrlHttps:string -> profileBannerUrl:string option -> profileLinkColor:string -> profileSidebarBorderColor:JsonProvider+IntOrString -> profileSidebarFillColor:JsonProvider+IntOrString -> profileTextColor:JsonProvider+IntOrString -> profileUseBackgroundImage:bool -> defaultProfile:bool -> defaultProfileImage:bool -> following:JsonValue -> followRequestSent:JsonValue -> notifications:JsonValue -> JsonProvider+User2
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("notifications",
-                                 (notifications :> obj)) |], "")
+                                 (notifications :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User2
     JsonDocument.Create(jsonValue, "")
@@ -1002,15 +1158,20 @@ class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
     new : screenName:string -> name:string -> id:int -> idStr:int -> indices:int[] -> JsonProvider+UserMention
     JsonRuntime.CreateRecord([| ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+UserMention
     JsonDocument.Create(jsonValue, "")
@@ -1038,29 +1199,41 @@ class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
     new : id:int64 -> idStr:int64 -> indices:int[] -> mediaUrl:string -> mediaUrlHttps:string -> url:string -> displayUrl:string -> expandedUrl:string -> type:string -> sizes:JsonProvider+Sizes -> sourceStatusId:int64 -> sourceStatusIdStr:int64 -> JsonProvider+Media
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("media_url",
-                                 (mediaUrl :> obj))
+                                 (mediaUrl :> obj),
+                                 1)
                                 ("media_url_https",
-                                 (mediaUrlHttps :> obj))
+                                 (mediaUrlHttps :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("sizes",
-                                 (sizes :> obj))
+                                 (sizes :> obj),
+                                 0)
                                 ("source_status_id",
-                                 (sourceStatusId :> obj))
+                                 (sourceStatusId :> obj),
+                                 2)
                                 ("source_status_id_str",
-                                 (sourceStatusIdStr :> obj)) |], "")
+                                 (sourceStatusIdStr :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Media
     JsonDocument.Create(jsonValue, "")
@@ -1115,13 +1288,17 @@ class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
     new : small:JsonProvider+Small -> thumb:JsonProvider+Small -> large:JsonProvider+Small -> medium:JsonProvider+Small -> JsonProvider+Sizes
     JsonRuntime.CreateRecord([| ("small",
-                                 (small :> obj))
+                                 (small :> obj),
+                                 0)
                                 ("thumb",
-                                 (thumb :> obj))
+                                 (thumb :> obj),
+                                 0)
                                 ("large",
-                                 (large :> obj))
+                                 (large :> obj),
+                                 0)
                                 ("medium",
-                                 (medium :> obj)) |], "")
+                                 (medium :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Sizes
     JsonDocument.Create(jsonValue, "")
@@ -1142,11 +1319,14 @@ class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Small : FDR.BaseTypes.IJsonDocument
     new : w:int -> h:int -> resize:string -> JsonProvider+Small
     JsonRuntime.CreateRecord([| ("w",
-                                 (w :> obj))
+                                 (w :> obj),
+                                 2)
                                 ("h",
-                                 (h :> obj))
+                                 (h :> obj),
+                                 2)
                                 ("resize",
-                                 (resize :> obj)) |], "")
+                                 (resize :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Small
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterSample.json,True,,,True,False,ValuesOnly.expected
@@ -32,57 +32,83 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : createdAt:string option -> id:int64 option -> idStr:int64 option -> text:string option -> source:string option -> truncated:bool option -> inReplyToStatusId:int64 option -> inReplyToStatusIdStr:int64 option -> inReplyToUserId:int option -> inReplyToUserIdStr:int option -> inReplyToScreenName:string option -> user:JsonProvider+User option -> geo:JsonValue -> coordinates:JsonValue -> place:JsonProvider+Place option -> contributors:JsonValue -> retweetedStatus:JsonProvider+RetweetedStatus option -> retweetCount:int option -> favoriteCount:int option -> entities:JsonProvider+Entities2 option -> favorited:bool option -> retweeted:bool option -> filterLevel:string option -> possiblySensitive:bool option -> lang:string option -> delete:JsonProvider+Delete option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("retweeted_status",
-                                 (retweetedStatus :> obj))
+                                 (retweetedStatus :> obj),
+                                 0)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("favorite_count",
-                                 (favoriteCount :> obj))
+                                 (favoriteCount :> obj),
+                                 2)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("filter_level",
-                                 (filterLevel :> obj))
+                                 (filterLevel :> obj),
+                                 1)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("delete",
-                                 (delete :> obj)) |], "")
+                                 (delete :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -169,7 +195,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
     new : status:JsonProvider+Status -> JsonProvider+Delete
     JsonRuntime.CreateRecord([| ("status",
-                                 (status :> obj)) |], "")
+                                 (status :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Delete
     JsonDocument.Create(jsonValue, "")
@@ -181,13 +208,17 @@ class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
     new : hashtags:JsonProvider+JsonProvider+Hashtag[] -> symbols:JsonValue[] -> urls:JsonProvider+JsonProvider+Url[] -> userMentions:JsonProvider+JsonProvider+UserMention[] -> JsonProvider+Entities2
     JsonRuntime.CreateRecord([| ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("symbols",
-                                 (symbols :> obj))
+                                 (symbols :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("user_mentions",
-                                 (userMentions :> obj)) |], "")
+                                 (userMentions :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities2
     JsonDocument.Create(jsonValue, "")
@@ -208,23 +239,32 @@ class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
     new : id:string -> url:string -> placeType:string -> name:string -> fullName:string -> countryCode:string -> country:string -> boundingBox:JsonProvider+BoundingBox -> attributes:JsonProvider+Attributes -> JsonProvider+Place
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("place_type",
-                                 (placeType :> obj))
+                                 (placeType :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("full_name",
-                                 (fullName :> obj))
+                                 (fullName :> obj),
+                                 1)
                                 ("country_code",
-                                 (countryCode :> obj))
+                                 (countryCode :> obj),
+                                 1)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 1)
                                 ("bounding_box",
-                                 (boundingBox :> obj))
+                                 (boundingBox :> obj),
+                                 0)
                                 ("attributes",
-                                 (attributes :> obj)) |], "")
+                                 (attributes :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Place
     JsonDocument.Create(jsonValue, "")
@@ -267,51 +307,74 @@ class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
     new : createdAt:string -> id:int64 -> idStr:int64 -> text:string -> source:string -> truncated:bool -> inReplyToStatusId:JsonValue -> inReplyToStatusIdStr:JsonValue -> inReplyToUserId:int option -> inReplyToUserIdStr:int option -> inReplyToScreenName:string option -> user:JsonProvider+User2 -> geo:JsonValue -> coordinates:JsonValue -> place:JsonValue -> contributors:JsonValue -> retweetCount:int -> favoriteCount:int -> entities:JsonProvider+Entities -> favorited:bool -> retweeted:bool -> lang:string -> possiblySensitive:bool option -> JsonProvider+RetweetedStatus
     JsonRuntime.CreateRecord([| ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 0)
                                 ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("favorite_count",
-                                 (favoriteCount :> obj))
+                                 (favoriteCount :> obj),
+                                 2)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj)) |], "")
+                                 (possiblySensitive :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RetweetedStatus
     JsonDocument.Create(jsonValue, "")
@@ -400,81 +463,119 @@ class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : id:int -> idStr:int -> name:string -> screenName:string -> location:string option -> url:string option -> description:string -> protected:bool -> followersCount:int -> friendsCount:int -> listedCount:int -> createdAt:string -> favouritesCount:int -> utcOffset:int option -> timeZone:string option -> geoEnabled:bool -> verified:bool -> statusesCount:int -> lang:string -> contributorsEnabled:bool -> isTranslator:bool -> profileBackgroundColor:JsonProvider+IntOrString -> profileBackgroundImageUrl:string -> profileBackgroundImageUrlHttps:string -> profileBackgroundTile:bool -> profileImageUrl:string -> profileImageUrlHttps:string -> profileBannerUrl:string option -> profileLinkColor:JsonProvider+IntOrString -> profileSidebarBorderColor:JsonProvider+IntOrString -> profileSidebarFillColor:JsonProvider+IntOrString -> profileTextColor:JsonProvider+IntOrString -> profileUseBackgroundImage:bool -> defaultProfile:bool -> defaultProfileImage:bool -> following:JsonValue -> followRequestSent:JsonValue -> notifications:JsonValue -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("notifications",
-                                 (notifications :> obj)) |], "")
+                                 (notifications :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")
@@ -630,9 +731,11 @@ class JsonProvider+Attributes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[][][] -> JsonProvider+BoundingBox
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+BoundingBox
     JsonDocument.Create(jsonValue, "")
@@ -648,15 +751,20 @@ class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
     new : hashtags:JsonProvider+JsonProvider+Hashtag[] -> symbols:JsonValue[] -> urls:JsonProvider+JsonProvider+Url[] -> userMentions:JsonProvider+JsonProvider+UserMention[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities
     JsonRuntime.CreateRecord([| ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("symbols",
-                                 (symbols :> obj))
+                                 (symbols :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities
     JsonDocument.Create(jsonValue, "")
@@ -680,9 +788,11 @@ class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hashtag : FDR.BaseTypes.IJsonDocument
     new : text:string -> indices:int[] -> JsonProvider+Hashtag
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hashtag
     JsonDocument.Create(jsonValue, "")
@@ -718,13 +828,17 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
     new : id:int64 -> userId:int -> idStr:int64 -> userIdStr:int -> JsonProvider+Status
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("user_id",
-                                 (userId :> obj))
+                                 (userId :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("user_id_str",
-                                 (userIdStr :> obj)) |], "")
+                                 (userIdStr :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Status
     JsonDocument.Create(jsonValue, "")
@@ -749,13 +863,17 @@ class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
     new : url:string -> expandedUrl:string -> displayUrl:string -> indices:int[] -> JsonProvider+Url
     JsonRuntime.CreateRecord([| ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Url
     JsonDocument.Create(jsonValue, "")
@@ -779,81 +897,119 @@ class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
     new : id:int -> idStr:int -> name:string -> screenName:string -> location:string option -> url:string option -> description:string -> protected:bool -> followersCount:int -> friendsCount:int -> listedCount:int -> createdAt:string -> favouritesCount:int -> utcOffset:int option -> timeZone:string option -> geoEnabled:bool -> verified:bool -> statusesCount:int -> lang:string -> contributorsEnabled:bool -> isTranslator:bool -> profileBackgroundColor:JsonProvider+IntOrString -> profileBackgroundImageUrl:string -> profileBackgroundImageUrlHttps:string -> profileBackgroundTile:bool -> profileImageUrl:string -> profileImageUrlHttps:string -> profileBannerUrl:string option -> profileLinkColor:string -> profileSidebarBorderColor:JsonProvider+IntOrString -> profileSidebarFillColor:JsonProvider+IntOrString -> profileTextColor:JsonProvider+IntOrString -> profileUseBackgroundImage:bool -> defaultProfile:bool -> defaultProfileImage:bool -> following:JsonValue -> followRequestSent:JsonValue -> notifications:JsonValue -> JsonProvider+User2
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("notifications",
-                                 (notifications :> obj)) |], "")
+                                 (notifications :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User2
     JsonDocument.Create(jsonValue, "")
@@ -1002,15 +1158,20 @@ class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
     new : screenName:string -> name:string -> id:int -> idStr:int -> indices:int[] -> JsonProvider+UserMention
     JsonRuntime.CreateRecord([| ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+UserMention
     JsonDocument.Create(jsonValue, "")
@@ -1038,29 +1199,41 @@ class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
     new : id:int64 -> idStr:int64 -> indices:int[] -> mediaUrl:string -> mediaUrlHttps:string -> url:string -> displayUrl:string -> expandedUrl:string -> type:string -> sizes:JsonProvider+Sizes -> sourceStatusId:int64 -> sourceStatusIdStr:int64 -> JsonProvider+Media
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("media_url",
-                                 (mediaUrl :> obj))
+                                 (mediaUrl :> obj),
+                                 1)
                                 ("media_url_https",
-                                 (mediaUrlHttps :> obj))
+                                 (mediaUrlHttps :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("sizes",
-                                 (sizes :> obj))
+                                 (sizes :> obj),
+                                 0)
                                 ("source_status_id",
-                                 (sourceStatusId :> obj))
+                                 (sourceStatusId :> obj),
+                                 2)
                                 ("source_status_id_str",
-                                 (sourceStatusIdStr :> obj)) |], "")
+                                 (sourceStatusIdStr :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Media
     JsonDocument.Create(jsonValue, "")
@@ -1115,13 +1288,17 @@ class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
     new : small:JsonProvider+Small -> thumb:JsonProvider+Small -> large:JsonProvider+Small -> medium:JsonProvider+Small -> JsonProvider+Sizes
     JsonRuntime.CreateRecord([| ("small",
-                                 (small :> obj))
+                                 (small :> obj),
+                                 0)
                                 ("thumb",
-                                 (thumb :> obj))
+                                 (thumb :> obj),
+                                 0)
                                 ("large",
-                                 (large :> obj))
+                                 (large :> obj),
+                                 0)
                                 ("medium",
-                                 (medium :> obj)) |], "")
+                                 (medium :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Sizes
     JsonDocument.Create(jsonValue, "")
@@ -1142,11 +1319,14 @@ class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Small : FDR.BaseTypes.IJsonDocument
     new : w:int -> h:int -> resize:string -> JsonProvider+Small
     JsonRuntime.CreateRecord([| ("w",
-                                 (w :> obj))
+                                 (w :> obj),
+                                 2)
                                 ("h",
-                                 (h :> obj))
+                                 (h :> obj),
+                                 2)
                                 ("resize",
-                                 (resize :> obj)) |], "")
+                                 (resize :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Small
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True,False,BackwardCompatible.expected
@@ -32,53 +32,77 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : inReplyToStatusIdStr:int64 option -> text:string option -> inReplyToUserIdStr:int option -> retweetCount:int option -> geo:JsonProvider+Geo option -> source:string option -> retweeted:bool option -> truncated:bool option -> idStr:int64 option -> entities:JsonProvider+Entities option -> inReplyToUserId:int option -> inReplyToStatusId:int64 option -> place:JsonProvider+Place option -> coordinates:JsonProvider+Geo option -> inReplyToScreenName:string option -> createdAt:string option -> user:JsonProvider+User option -> id:int64 option -> contributors:JsonValue -> favorited:bool option -> possiblySensitive:bool option -> possiblySensitiveEditable:bool option -> retweetedStatus:JsonProvider+RetweetedStatus option -> delete:JsonProvider+Delete option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("possibly_sensitive_editable",
-                                 (possiblySensitiveEditable :> obj))
+                                 (possiblySensitiveEditable :> obj),
+                                 3)
                                 ("retweeted_status",
-                                 (retweetedStatus :> obj))
+                                 (retweetedStatus :> obj),
+                                 0)
                                 ("delete",
-                                 (delete :> obj)) |], "")
+                                 (delete :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -159,7 +183,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
     new : status:JsonProvider+Status -> JsonProvider+Delete
     JsonRuntime.CreateRecord([| ("status",
-                                 (status :> obj)) |], "")
+                                 (status :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Delete
     JsonDocument.Create(jsonValue, "")
@@ -171,13 +196,17 @@ class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
     new : userMentions:JsonProvider+JsonProvider+UserMention[] -> hashtags:JsonProvider+JsonProvider+Hashtag[] -> urls:JsonProvider+JsonProvider+Url[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities
     JsonRuntime.CreateRecord([| ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities
     JsonDocument.Create(jsonValue, "")
@@ -198,9 +227,11 @@ class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Geo : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[] -> JsonProvider+Geo
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Geo
     JsonDocument.Create(jsonValue, "")
@@ -216,23 +247,32 @@ class JsonProvider+Geo : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
     new : countryCode:string -> attributes:JsonProvider+Attributes -> fullName:string -> placeType:string -> name:string -> country:string -> id:string -> url:string -> boundingBox:JsonProvider+BoundingBox -> JsonProvider+Place
     JsonRuntime.CreateRecord([| ("country_code",
-                                 (countryCode :> obj))
+                                 (countryCode :> obj),
+                                 1)
                                 ("attributes",
-                                 (attributes :> obj))
+                                 (attributes :> obj),
+                                 0)
                                 ("full_name",
-                                 (fullName :> obj))
+                                 (fullName :> obj),
+                                 1)
                                 ("place_type",
-                                 (placeType :> obj))
+                                 (placeType :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("bounding_box",
-                                 (boundingBox :> obj)) |], "")
+                                 (boundingBox :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Place
     JsonDocument.Create(jsonValue, "")
@@ -275,49 +315,71 @@ class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
     new : inReplyToStatusIdStr:int64 option -> text:string -> inReplyToUserIdStr:int option -> retweetCount:int -> geo:JsonValue -> source:string -> retweeted:bool -> truncated:bool -> idStr:int64 -> entities:JsonProvider+Entities2 -> inReplyToUserId:int option -> inReplyToStatusId:int64 option -> place:JsonValue -> coordinates:JsonValue -> inReplyToScreenName:string option -> createdAt:string -> user:JsonProvider+User2 -> id:int64 -> contributors:JsonValue -> favorited:bool -> possiblySensitive:bool option -> possiblySensitiveEditable:bool option -> JsonProvider+RetweetedStatus
     JsonRuntime.CreateRecord([| ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("possibly_sensitive_editable",
-                                 (possiblySensitiveEditable :> obj)) |], "")
+                                 (possiblySensitiveEditable :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RetweetedStatus
     JsonDocument.Create(jsonValue, "")
@@ -401,81 +463,119 @@ class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : notifications:JsonValue -> contributorsEnabled:bool -> timeZone:string option -> profileBackgroundColor:JsonProvider+IntOrString -> location:JsonProvider+IntOrString -> profileBackgroundTile:bool -> profileImageUrlHttps:string -> defaultProfileImage:bool -> followRequestSent:JsonValue -> profileSidebarFillColor:JsonProvider+IntOrString -> description:string option -> profileBannerUrl:string option -> favouritesCount:int -> screenName:string -> profileSidebarBorderColor:JsonProvider+FloatOrString -> idStr:int -> verified:bool -> lang:string -> statusesCount:int -> profileUseBackgroundImage:bool -> protected:bool -> profileImageUrl:string -> listedCount:int -> geoEnabled:bool -> createdAt:string -> profileTextColor:JsonProvider+FloatOrString -> name:string -> profileBackgroundImageUrl:string -> friendsCount:int -> url:string option -> id:int -> isTranslator:bool -> defaultProfile:bool -> following:JsonValue -> profileBackgroundImageUrlHttps:string -> utcOffset:int option -> profileLinkColor:JsonProvider+IntOrString -> followersCount:int -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("notifications",
-                                 (notifications :> obj))
+                                 (notifications :> obj),
+                                 0)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 0)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("followers_count",
-                                 (followersCount :> obj)) |], "")
+                                 (followersCount :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")
@@ -630,9 +730,11 @@ class JsonProvider+Attributes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[][][] -> JsonProvider+BoundingBox
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+BoundingBox
     JsonDocument.Create(jsonValue, "")
@@ -648,13 +750,17 @@ class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
     new : userMentions:JsonProvider+JsonProvider+UserMention[] -> hashtags:JsonProvider+JsonProvider+Hashtag[] -> urls:JsonProvider+JsonProvider+Url[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities2
     JsonRuntime.CreateRecord([| ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities2
     JsonDocument.Create(jsonValue, "")
@@ -695,9 +801,11 @@ class JsonProvider+FloatOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hashtag : FDR.BaseTypes.IJsonDocument
     new : text:string -> indices:int[] -> JsonProvider+Hashtag
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hashtag
     JsonDocument.Create(jsonValue, "")
@@ -733,25 +841,35 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
     new : type:string -> expandedUrl:string -> indices:int[] -> mediaUrlHttps:string -> sizes:JsonProvider+Sizes -> idStr:int64 -> mediaUrl:string -> id:int64 -> url:string -> displayUrl:string -> JsonProvider+Media
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("media_url_https",
-                                 (mediaUrlHttps :> obj))
+                                 (mediaUrlHttps :> obj),
+                                 1)
                                 ("sizes",
-                                 (sizes :> obj))
+                                 (sizes :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("media_url",
-                                 (mediaUrl :> obj))
+                                 (mediaUrl :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj)) |], "")
+                                 (displayUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Media
     JsonDocument.Create(jsonValue, "")
@@ -798,13 +916,17 @@ class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
     new : userIdStr:int -> idStr:int64 -> id:int64 -> userId:int -> JsonProvider+Status
     JsonRuntime.CreateRecord([| ("user_id_str",
-                                 (userIdStr :> obj))
+                                 (userIdStr :> obj),
+                                 1)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("user_id",
-                                 (userId :> obj)) |], "")
+                                 (userId :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Status
     JsonDocument.Create(jsonValue, "")
@@ -829,13 +951,17 @@ class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
     new : expandedUrl:string -> indices:int[] -> displayUrl:string -> url:string -> JsonProvider+Url
     JsonRuntime.CreateRecord([| ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj)) |], "")
+                                 (url :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Url
     JsonDocument.Create(jsonValue, "")
@@ -859,81 +985,119 @@ class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
     new : notifications:JsonValue -> contributorsEnabled:bool -> timeZone:string option -> profileBackgroundColor:JsonProvider+IntOrString -> location:string option -> profileBackgroundTile:bool -> profileImageUrlHttps:string -> defaultProfileImage:bool -> followRequestSent:JsonValue -> profileSidebarFillColor:JsonProvider+IntOrString -> description:string option -> favouritesCount:int -> screenName:string -> profileSidebarBorderColor:JsonProvider+IntOrString -> idStr:int -> verified:bool -> lang:string -> statusesCount:int -> profileUseBackgroundImage:bool -> protected:bool -> profileImageUrl:string -> listedCount:int -> geoEnabled:bool -> createdAt:string -> profileTextColor:JsonProvider+IntOrString -> name:string -> profileBackgroundImageUrl:string -> friendsCount:int -> url:string option -> id:int -> isTranslator:bool -> defaultProfile:bool -> following:JsonValue -> profileBackgroundImageUrlHttps:string -> utcOffset:int option -> profileLinkColor:JsonProvider+IntOrString -> followersCount:int -> profileBannerUrl:string option -> JsonProvider+User2
     JsonRuntime.CreateRecord([| ("notifications",
-                                 (notifications :> obj))
+                                 (notifications :> obj),
+                                 0)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj)) |], "")
+                                 (profileBannerUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User2
     JsonDocument.Create(jsonValue, "")
@@ -1080,15 +1244,20 @@ class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
     new : indices:int[] -> screenName:string -> idStr:int -> name:string -> id:int -> JsonProvider+UserMention
     JsonRuntime.CreateRecord([| ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj)) |], "")
+                                 (id :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+UserMention
     JsonDocument.Create(jsonValue, "")
@@ -1116,13 +1285,17 @@ class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
     new : thumb:JsonProvider+Thumb -> medium:JsonProvider+Thumb -> large:JsonProvider+Thumb -> small:JsonProvider+Thumb -> JsonProvider+Sizes
     JsonRuntime.CreateRecord([| ("thumb",
-                                 (thumb :> obj))
+                                 (thumb :> obj),
+                                 0)
                                 ("medium",
-                                 (medium :> obj))
+                                 (medium :> obj),
+                                 0)
                                 ("large",
-                                 (large :> obj))
+                                 (large :> obj),
+                                 0)
                                 ("small",
-                                 (small :> obj)) |], "")
+                                 (small :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Sizes
     JsonDocument.Create(jsonValue, "")
@@ -1143,11 +1316,14 @@ class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Thumb : FDR.BaseTypes.IJsonDocument
     new : h:int -> w:int -> resize:string -> JsonProvider+Thumb
     JsonRuntime.CreateRecord([| ("h",
-                                 (h :> obj))
+                                 (h :> obj),
+                                 2)
                                 ("w",
-                                 (w :> obj))
+                                 (w :> obj),
+                                 2)
                                 ("resize",
-                                 (resize :> obj)) |], "")
+                                 (resize :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Thumb
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,53 +32,77 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : inReplyToStatusIdStr:int64 option -> text:string option -> inReplyToUserIdStr:int option -> retweetCount:int option -> geo:JsonProvider+Geo option -> source:string option -> retweeted:bool option -> truncated:bool option -> idStr:int64 option -> entities:JsonProvider+Entities option -> inReplyToUserId:int option -> inReplyToStatusId:int64 option -> place:JsonProvider+Place option -> coordinates:JsonProvider+Geo option -> inReplyToScreenName:string option -> createdAt:string option -> user:JsonProvider+User option -> id:int64 option -> contributors:JsonValue -> favorited:bool option -> possiblySensitive:bool option -> possiblySensitiveEditable:bool option -> retweetedStatus:JsonProvider+RetweetedStatus option -> delete:JsonProvider+Delete option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("possibly_sensitive_editable",
-                                 (possiblySensitiveEditable :> obj))
+                                 (possiblySensitiveEditable :> obj),
+                                 3)
                                 ("retweeted_status",
-                                 (retweetedStatus :> obj))
+                                 (retweetedStatus :> obj),
+                                 0)
                                 ("delete",
-                                 (delete :> obj)) |], "")
+                                 (delete :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -159,7 +183,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
     new : status:JsonProvider+Status -> JsonProvider+Delete
     JsonRuntime.CreateRecord([| ("status",
-                                 (status :> obj)) |], "")
+                                 (status :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Delete
     JsonDocument.Create(jsonValue, "")
@@ -171,13 +196,17 @@ class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
     new : userMentions:JsonProvider+JsonProvider+UserMention[] -> hashtags:JsonProvider+JsonProvider+Hashtag[] -> urls:JsonProvider+JsonProvider+Url[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities
     JsonRuntime.CreateRecord([| ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities
     JsonDocument.Create(jsonValue, "")
@@ -198,9 +227,11 @@ class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Geo : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[] -> JsonProvider+Geo
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Geo
     JsonDocument.Create(jsonValue, "")
@@ -216,23 +247,32 @@ class JsonProvider+Geo : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
     new : countryCode:string -> attributes:JsonProvider+Attributes -> fullName:string -> placeType:string -> name:string -> country:string -> id:string -> url:string -> boundingBox:JsonProvider+BoundingBox -> JsonProvider+Place
     JsonRuntime.CreateRecord([| ("country_code",
-                                 (countryCode :> obj))
+                                 (countryCode :> obj),
+                                 1)
                                 ("attributes",
-                                 (attributes :> obj))
+                                 (attributes :> obj),
+                                 0)
                                 ("full_name",
-                                 (fullName :> obj))
+                                 (fullName :> obj),
+                                 1)
                                 ("place_type",
-                                 (placeType :> obj))
+                                 (placeType :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("bounding_box",
-                                 (boundingBox :> obj)) |], "")
+                                 (boundingBox :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Place
     JsonDocument.Create(jsonValue, "")
@@ -275,49 +315,71 @@ class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
     new : inReplyToStatusIdStr:int64 option -> text:string -> inReplyToUserIdStr:int option -> retweetCount:int -> geo:JsonValue -> source:string -> retweeted:bool -> truncated:bool -> idStr:int64 -> entities:JsonProvider+Entities2 -> inReplyToUserId:int option -> inReplyToStatusId:int64 option -> place:JsonValue -> coordinates:JsonValue -> inReplyToScreenName:string option -> createdAt:string -> user:JsonProvider+User2 -> id:int64 -> contributors:JsonValue -> favorited:bool -> possiblySensitive:bool option -> possiblySensitiveEditable:bool option -> JsonProvider+RetweetedStatus
     JsonRuntime.CreateRecord([| ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("possibly_sensitive_editable",
-                                 (possiblySensitiveEditable :> obj)) |], "")
+                                 (possiblySensitiveEditable :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RetweetedStatus
     JsonDocument.Create(jsonValue, "")
@@ -401,81 +463,119 @@ class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : notifications:JsonValue -> contributorsEnabled:bool -> timeZone:string option -> profileBackgroundColor:JsonProvider+IntOrString -> location:JsonProvider+IntOrString -> profileBackgroundTile:bool -> profileImageUrlHttps:string -> defaultProfileImage:bool -> followRequestSent:JsonValue -> profileSidebarFillColor:JsonProvider+IntOrString -> description:string option -> profileBannerUrl:string option -> favouritesCount:int -> screenName:string -> profileSidebarBorderColor:JsonProvider+FloatOrString -> idStr:int -> verified:bool -> lang:string -> statusesCount:int -> profileUseBackgroundImage:bool -> protected:bool -> profileImageUrl:string -> listedCount:int -> geoEnabled:bool -> createdAt:string -> profileTextColor:JsonProvider+FloatOrString -> name:string -> profileBackgroundImageUrl:string -> friendsCount:int -> url:string option -> id:int -> isTranslator:bool -> defaultProfile:bool -> following:JsonValue -> profileBackgroundImageUrlHttps:string -> utcOffset:int option -> profileLinkColor:JsonProvider+IntOrString -> followersCount:int -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("notifications",
-                                 (notifications :> obj))
+                                 (notifications :> obj),
+                                 0)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 0)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("followers_count",
-                                 (followersCount :> obj)) |], "")
+                                 (followersCount :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")
@@ -630,9 +730,11 @@ class JsonProvider+Attributes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[][][] -> JsonProvider+BoundingBox
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+BoundingBox
     JsonDocument.Create(jsonValue, "")
@@ -648,13 +750,17 @@ class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
     new : userMentions:JsonProvider+JsonProvider+UserMention[] -> hashtags:JsonProvider+JsonProvider+Hashtag[] -> urls:JsonProvider+JsonProvider+Url[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities2
     JsonRuntime.CreateRecord([| ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities2
     JsonDocument.Create(jsonValue, "")
@@ -695,9 +801,11 @@ class JsonProvider+FloatOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hashtag : FDR.BaseTypes.IJsonDocument
     new : text:string -> indices:int[] -> JsonProvider+Hashtag
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hashtag
     JsonDocument.Create(jsonValue, "")
@@ -733,25 +841,35 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
     new : type:string -> expandedUrl:string -> indices:int[] -> mediaUrlHttps:string -> sizes:JsonProvider+Sizes -> idStr:int64 -> mediaUrl:string -> id:int64 -> url:string -> displayUrl:string -> JsonProvider+Media
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("media_url_https",
-                                 (mediaUrlHttps :> obj))
+                                 (mediaUrlHttps :> obj),
+                                 1)
                                 ("sizes",
-                                 (sizes :> obj))
+                                 (sizes :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("media_url",
-                                 (mediaUrl :> obj))
+                                 (mediaUrl :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj)) |], "")
+                                 (displayUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Media
     JsonDocument.Create(jsonValue, "")
@@ -798,13 +916,17 @@ class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
     new : userIdStr:int -> idStr:int64 -> id:int64 -> userId:int -> JsonProvider+Status
     JsonRuntime.CreateRecord([| ("user_id_str",
-                                 (userIdStr :> obj))
+                                 (userIdStr :> obj),
+                                 1)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("user_id",
-                                 (userId :> obj)) |], "")
+                                 (userId :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Status
     JsonDocument.Create(jsonValue, "")
@@ -829,13 +951,17 @@ class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
     new : expandedUrl:string -> indices:int[] -> displayUrl:string -> url:string -> JsonProvider+Url
     JsonRuntime.CreateRecord([| ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj)) |], "")
+                                 (url :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Url
     JsonDocument.Create(jsonValue, "")
@@ -859,81 +985,119 @@ class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
     new : notifications:JsonValue -> contributorsEnabled:bool -> timeZone:string option -> profileBackgroundColor:JsonProvider+IntOrString -> location:string option -> profileBackgroundTile:bool -> profileImageUrlHttps:string -> defaultProfileImage:bool -> followRequestSent:JsonValue -> profileSidebarFillColor:JsonProvider+IntOrString -> description:string option -> favouritesCount:int -> screenName:string -> profileSidebarBorderColor:JsonProvider+IntOrString -> idStr:int -> verified:bool -> lang:string -> statusesCount:int -> profileUseBackgroundImage:bool -> protected:bool -> profileImageUrl:string -> listedCount:int -> geoEnabled:bool -> createdAt:string -> profileTextColor:JsonProvider+IntOrString -> name:string -> profileBackgroundImageUrl:string -> friendsCount:int -> url:string option -> id:int -> isTranslator:bool -> defaultProfile:bool -> following:JsonValue -> profileBackgroundImageUrlHttps:string -> utcOffset:int option -> profileLinkColor:JsonProvider+IntOrString -> followersCount:int -> profileBannerUrl:string option -> JsonProvider+User2
     JsonRuntime.CreateRecord([| ("notifications",
-                                 (notifications :> obj))
+                                 (notifications :> obj),
+                                 0)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj)) |], "")
+                                 (profileBannerUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User2
     JsonDocument.Create(jsonValue, "")
@@ -1080,15 +1244,20 @@ class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
     new : indices:int[] -> screenName:string -> idStr:int -> name:string -> id:int -> JsonProvider+UserMention
     JsonRuntime.CreateRecord([| ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj)) |], "")
+                                 (id :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+UserMention
     JsonDocument.Create(jsonValue, "")
@@ -1116,13 +1285,17 @@ class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
     new : thumb:JsonProvider+Thumb -> medium:JsonProvider+Thumb -> large:JsonProvider+Thumb -> small:JsonProvider+Thumb -> JsonProvider+Sizes
     JsonRuntime.CreateRecord([| ("thumb",
-                                 (thumb :> obj))
+                                 (thumb :> obj),
+                                 0)
                                 ("medium",
-                                 (medium :> obj))
+                                 (medium :> obj),
+                                 0)
                                 ("large",
-                                 (large :> obj))
+                                 (large :> obj),
+                                 0)
                                 ("small",
-                                 (small :> obj)) |], "")
+                                 (small :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Sizes
     JsonDocument.Create(jsonValue, "")
@@ -1143,11 +1316,14 @@ class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Thumb : FDR.BaseTypes.IJsonDocument
     new : h:int -> w:int -> resize:string -> JsonProvider+Thumb
     JsonRuntime.CreateRecord([| ("h",
-                                 (h :> obj))
+                                 (h :> obj),
+                                 2)
                                 ("w",
-                                 (w :> obj))
+                                 (w :> obj),
+                                 2)
                                 ("resize",
-                                 (resize :> obj)) |], "")
+                                 (resize :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Thumb
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,53 +32,77 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : inReplyToStatusIdStr:int64 option -> text:string option -> inReplyToUserIdStr:int option -> retweetCount:int option -> geo:JsonProvider+Geo option -> source:string option -> retweeted:bool option -> truncated:bool option -> idStr:int64 option -> entities:JsonProvider+Entities option -> inReplyToUserId:int option -> inReplyToStatusId:int64 option -> place:JsonProvider+Place option -> coordinates:JsonProvider+Geo option -> inReplyToScreenName:string option -> createdAt:string option -> user:JsonProvider+User option -> id:int64 option -> contributors:JsonValue -> favorited:bool option -> possiblySensitive:bool option -> possiblySensitiveEditable:bool option -> retweetedStatus:JsonProvider+RetweetedStatus option -> delete:JsonProvider+Delete option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("possibly_sensitive_editable",
-                                 (possiblySensitiveEditable :> obj))
+                                 (possiblySensitiveEditable :> obj),
+                                 3)
                                 ("retweeted_status",
-                                 (retweetedStatus :> obj))
+                                 (retweetedStatus :> obj),
+                                 0)
                                 ("delete",
-                                 (delete :> obj)) |], "")
+                                 (delete :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -159,7 +183,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
     new : status:JsonProvider+Status -> JsonProvider+Delete
     JsonRuntime.CreateRecord([| ("status",
-                                 (status :> obj)) |], "")
+                                 (status :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Delete
     JsonDocument.Create(jsonValue, "")
@@ -171,13 +196,17 @@ class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
     new : userMentions:JsonProvider+JsonProvider+UserMention[] -> hashtags:JsonProvider+JsonProvider+Hashtag[] -> urls:JsonProvider+JsonProvider+Url[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities
     JsonRuntime.CreateRecord([| ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities
     JsonDocument.Create(jsonValue, "")
@@ -198,9 +227,11 @@ class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Geo : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[] -> JsonProvider+Geo
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Geo
     JsonDocument.Create(jsonValue, "")
@@ -216,23 +247,32 @@ class JsonProvider+Geo : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
     new : countryCode:string -> attributes:JsonProvider+Attributes -> fullName:string -> placeType:string -> name:string -> country:string -> id:string -> url:string -> boundingBox:JsonProvider+BoundingBox -> JsonProvider+Place
     JsonRuntime.CreateRecord([| ("country_code",
-                                 (countryCode :> obj))
+                                 (countryCode :> obj),
+                                 1)
                                 ("attributes",
-                                 (attributes :> obj))
+                                 (attributes :> obj),
+                                 0)
                                 ("full_name",
-                                 (fullName :> obj))
+                                 (fullName :> obj),
+                                 1)
                                 ("place_type",
-                                 (placeType :> obj))
+                                 (placeType :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("bounding_box",
-                                 (boundingBox :> obj)) |], "")
+                                 (boundingBox :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Place
     JsonDocument.Create(jsonValue, "")
@@ -275,49 +315,71 @@ class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
     new : inReplyToStatusIdStr:int64 option -> text:string -> inReplyToUserIdStr:int option -> retweetCount:int -> geo:JsonValue -> source:string -> retweeted:bool -> truncated:bool -> idStr:int64 -> entities:JsonProvider+Entities2 -> inReplyToUserId:int option -> inReplyToStatusId:int64 option -> place:JsonValue -> coordinates:JsonValue -> inReplyToScreenName:string option -> createdAt:string -> user:JsonProvider+User2 -> id:int64 -> contributors:JsonValue -> favorited:bool -> possiblySensitive:bool option -> possiblySensitiveEditable:bool option -> JsonProvider+RetweetedStatus
     JsonRuntime.CreateRecord([| ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("possibly_sensitive_editable",
-                                 (possiblySensitiveEditable :> obj)) |], "")
+                                 (possiblySensitiveEditable :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RetweetedStatus
     JsonDocument.Create(jsonValue, "")
@@ -401,81 +463,119 @@ class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : notifications:JsonValue -> contributorsEnabled:bool -> timeZone:string option -> profileBackgroundColor:JsonProvider+IntOrString -> location:JsonProvider+IntOrString -> profileBackgroundTile:bool -> profileImageUrlHttps:string -> defaultProfileImage:bool -> followRequestSent:JsonValue -> profileSidebarFillColor:JsonProvider+IntOrString -> description:string option -> profileBannerUrl:string option -> favouritesCount:int -> screenName:string -> profileSidebarBorderColor:JsonProvider+FloatOrString -> idStr:int -> verified:bool -> lang:string -> statusesCount:int -> profileUseBackgroundImage:bool -> protected:bool -> profileImageUrl:string -> listedCount:int -> geoEnabled:bool -> createdAt:string -> profileTextColor:JsonProvider+FloatOrString -> name:string -> profileBackgroundImageUrl:string -> friendsCount:int -> url:string option -> id:int -> isTranslator:bool -> defaultProfile:bool -> following:JsonValue -> profileBackgroundImageUrlHttps:string -> utcOffset:int option -> profileLinkColor:JsonProvider+IntOrString -> followersCount:int -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("notifications",
-                                 (notifications :> obj))
+                                 (notifications :> obj),
+                                 0)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 0)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("followers_count",
-                                 (followersCount :> obj)) |], "")
+                                 (followersCount :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")
@@ -630,9 +730,11 @@ class JsonProvider+Attributes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[][][] -> JsonProvider+BoundingBox
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+BoundingBox
     JsonDocument.Create(jsonValue, "")
@@ -648,13 +750,17 @@ class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
     new : userMentions:JsonProvider+JsonProvider+UserMention[] -> hashtags:JsonProvider+JsonProvider+Hashtag[] -> urls:JsonProvider+JsonProvider+Url[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities2
     JsonRuntime.CreateRecord([| ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities2
     JsonDocument.Create(jsonValue, "")
@@ -695,9 +801,11 @@ class JsonProvider+FloatOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hashtag : FDR.BaseTypes.IJsonDocument
     new : text:string -> indices:int[] -> JsonProvider+Hashtag
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hashtag
     JsonDocument.Create(jsonValue, "")
@@ -733,25 +841,35 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
     new : type:string -> expandedUrl:string -> indices:int[] -> mediaUrlHttps:string -> sizes:JsonProvider+Sizes -> idStr:int64 -> mediaUrl:string -> id:int64 -> url:string -> displayUrl:string -> JsonProvider+Media
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("media_url_https",
-                                 (mediaUrlHttps :> obj))
+                                 (mediaUrlHttps :> obj),
+                                 1)
                                 ("sizes",
-                                 (sizes :> obj))
+                                 (sizes :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("media_url",
-                                 (mediaUrl :> obj))
+                                 (mediaUrl :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj)) |], "")
+                                 (displayUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Media
     JsonDocument.Create(jsonValue, "")
@@ -798,13 +916,17 @@ class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
     new : userIdStr:int -> idStr:int64 -> id:int64 -> userId:int -> JsonProvider+Status
     JsonRuntime.CreateRecord([| ("user_id_str",
-                                 (userIdStr :> obj))
+                                 (userIdStr :> obj),
+                                 1)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("user_id",
-                                 (userId :> obj)) |], "")
+                                 (userId :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Status
     JsonDocument.Create(jsonValue, "")
@@ -829,13 +951,17 @@ class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
     new : expandedUrl:string -> indices:int[] -> displayUrl:string -> url:string -> JsonProvider+Url
     JsonRuntime.CreateRecord([| ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj)) |], "")
+                                 (url :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Url
     JsonDocument.Create(jsonValue, "")
@@ -859,81 +985,119 @@ class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
     new : notifications:JsonValue -> contributorsEnabled:bool -> timeZone:string option -> profileBackgroundColor:JsonProvider+IntOrString -> location:string option -> profileBackgroundTile:bool -> profileImageUrlHttps:string -> defaultProfileImage:bool -> followRequestSent:JsonValue -> profileSidebarFillColor:JsonProvider+IntOrString -> description:string option -> favouritesCount:int -> screenName:string -> profileSidebarBorderColor:JsonProvider+IntOrString -> idStr:int -> verified:bool -> lang:string -> statusesCount:int -> profileUseBackgroundImage:bool -> protected:bool -> profileImageUrl:string -> listedCount:int -> geoEnabled:bool -> createdAt:string -> profileTextColor:JsonProvider+IntOrString -> name:string -> profileBackgroundImageUrl:string -> friendsCount:int -> url:string option -> id:int -> isTranslator:bool -> defaultProfile:bool -> following:JsonValue -> profileBackgroundImageUrlHttps:string -> utcOffset:int option -> profileLinkColor:JsonProvider+IntOrString -> followersCount:int -> profileBannerUrl:string option -> JsonProvider+User2
     JsonRuntime.CreateRecord([| ("notifications",
-                                 (notifications :> obj))
+                                 (notifications :> obj),
+                                 0)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj)) |], "")
+                                 (profileBannerUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User2
     JsonDocument.Create(jsonValue, "")
@@ -1080,15 +1244,20 @@ class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
     new : indices:int[] -> screenName:string -> idStr:int -> name:string -> id:int -> JsonProvider+UserMention
     JsonRuntime.CreateRecord([| ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj)) |], "")
+                                 (id :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+UserMention
     JsonDocument.Create(jsonValue, "")
@@ -1116,13 +1285,17 @@ class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
     new : thumb:JsonProvider+Thumb -> medium:JsonProvider+Thumb -> large:JsonProvider+Thumb -> small:JsonProvider+Thumb -> JsonProvider+Sizes
     JsonRuntime.CreateRecord([| ("thumb",
-                                 (thumb :> obj))
+                                 (thumb :> obj),
+                                 0)
                                 ("medium",
-                                 (medium :> obj))
+                                 (medium :> obj),
+                                 0)
                                 ("large",
-                                 (large :> obj))
+                                 (large :> obj),
+                                 0)
                                 ("small",
-                                 (small :> obj)) |], "")
+                                 (small :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Sizes
     JsonDocument.Create(jsonValue, "")
@@ -1143,11 +1316,14 @@ class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Thumb : FDR.BaseTypes.IJsonDocument
     new : h:int -> w:int -> resize:string -> JsonProvider+Thumb
     JsonRuntime.CreateRecord([| ("h",
-                                 (h :> obj))
+                                 (h :> obj),
+                                 2)
                                 ("w",
-                                 (w :> obj))
+                                 (w :> obj),
+                                 2)
                                 ("resize",
-                                 (resize :> obj)) |], "")
+                                 (resize :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Thumb
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TwitterStream.json,True,,,True,False,ValuesOnly.expected
@@ -32,53 +32,77 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : inReplyToStatusIdStr:int64 option -> text:string option -> inReplyToUserIdStr:int option -> retweetCount:int option -> geo:JsonProvider+Geo option -> source:string option -> retweeted:bool option -> truncated:bool option -> idStr:int64 option -> entities:JsonProvider+Entities option -> inReplyToUserId:int option -> inReplyToStatusId:int64 option -> place:JsonProvider+Place option -> coordinates:JsonProvider+Geo option -> inReplyToScreenName:string option -> createdAt:string option -> user:JsonProvider+User option -> id:int64 option -> contributors:JsonValue -> favorited:bool option -> possiblySensitive:bool option -> possiblySensitiveEditable:bool option -> retweetedStatus:JsonProvider+RetweetedStatus option -> delete:JsonProvider+Delete option -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("possibly_sensitive_editable",
-                                 (possiblySensitiveEditable :> obj))
+                                 (possiblySensitiveEditable :> obj),
+                                 3)
                                 ("retweeted_status",
-                                 (retweetedStatus :> obj))
+                                 (retweetedStatus :> obj),
+                                 0)
                                 ("delete",
-                                 (delete :> obj)) |], "")
+                                 (delete :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -159,7 +183,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
     new : status:JsonProvider+Status -> JsonProvider+Delete
     JsonRuntime.CreateRecord([| ("status",
-                                 (status :> obj)) |], "")
+                                 (status :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Delete
     JsonDocument.Create(jsonValue, "")
@@ -171,13 +196,17 @@ class JsonProvider+Delete : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
     new : userMentions:JsonProvider+JsonProvider+UserMention[] -> hashtags:JsonProvider+JsonProvider+Hashtag[] -> urls:JsonProvider+JsonProvider+Url[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities
     JsonRuntime.CreateRecord([| ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities
     JsonDocument.Create(jsonValue, "")
@@ -198,9 +227,11 @@ class JsonProvider+Entities : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Geo : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[] -> JsonProvider+Geo
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Geo
     JsonDocument.Create(jsonValue, "")
@@ -216,23 +247,32 @@ class JsonProvider+Geo : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
     new : countryCode:string -> attributes:JsonProvider+Attributes -> fullName:string -> placeType:string -> name:string -> country:string -> id:string -> url:string -> boundingBox:JsonProvider+BoundingBox -> JsonProvider+Place
     JsonRuntime.CreateRecord([| ("country_code",
-                                 (countryCode :> obj))
+                                 (countryCode :> obj),
+                                 1)
                                 ("attributes",
-                                 (attributes :> obj))
+                                 (attributes :> obj),
+                                 0)
                                 ("full_name",
-                                 (fullName :> obj))
+                                 (fullName :> obj),
+                                 1)
                                 ("place_type",
-                                 (placeType :> obj))
+                                 (placeType :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("bounding_box",
-                                 (boundingBox :> obj)) |], "")
+                                 (boundingBox :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Place
     JsonDocument.Create(jsonValue, "")
@@ -275,49 +315,71 @@ class JsonProvider+Place : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
     new : inReplyToStatusIdStr:int64 option -> text:string -> inReplyToUserIdStr:int option -> retweetCount:int -> geo:JsonValue -> source:string -> retweeted:bool -> truncated:bool -> idStr:int64 -> entities:JsonProvider+Entities2 -> inReplyToUserId:int option -> inReplyToStatusId:int64 option -> place:JsonValue -> coordinates:JsonValue -> inReplyToScreenName:string option -> createdAt:string -> user:JsonProvider+User2 -> id:int64 -> contributors:JsonValue -> favorited:bool -> possiblySensitive:bool option -> possiblySensitiveEditable:bool option -> JsonProvider+RetweetedStatus
     JsonRuntime.CreateRecord([| ("in_reply_to_status_id_str",
-                                 (inReplyToStatusIdStr :> obj))
+                                 (inReplyToStatusIdStr :> obj),
+                                 1)
                                 ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("in_reply_to_user_id_str",
-                                 (inReplyToUserIdStr :> obj))
+                                 (inReplyToUserIdStr :> obj),
+                                 1)
                                 ("retweet_count",
-                                 (retweetCount :> obj))
+                                 (retweetCount :> obj),
+                                 2)
                                 ("geo",
-                                 (geo :> obj))
+                                 (geo :> obj),
+                                 0)
                                 ("source",
-                                 (source :> obj))
+                                 (source :> obj),
+                                 1)
                                 ("retweeted",
-                                 (retweeted :> obj))
+                                 (retweeted :> obj),
+                                 3)
                                 ("truncated",
-                                 (truncated :> obj))
+                                 (truncated :> obj),
+                                 3)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("entities",
-                                 (entities :> obj))
+                                 (entities :> obj),
+                                 0)
                                 ("in_reply_to_user_id",
-                                 (inReplyToUserId :> obj))
+                                 (inReplyToUserId :> obj),
+                                 2)
                                 ("in_reply_to_status_id",
-                                 (inReplyToStatusId :> obj))
+                                 (inReplyToStatusId :> obj),
+                                 2)
                                 ("place",
-                                 (place :> obj))
+                                 (place :> obj),
+                                 0)
                                 ("coordinates",
-                                 (coordinates :> obj))
+                                 (coordinates :> obj),
+                                 0)
                                 ("in_reply_to_screen_name",
-                                 (inReplyToScreenName :> obj))
+                                 (inReplyToScreenName :> obj),
+                                 1)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("user",
-                                 (user :> obj))
+                                 (user :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("contributors",
-                                 (contributors :> obj))
+                                 (contributors :> obj),
+                                 0)
                                 ("favorited",
-                                 (favorited :> obj))
+                                 (favorited :> obj),
+                                 3)
                                 ("possibly_sensitive",
-                                 (possiblySensitive :> obj))
+                                 (possiblySensitive :> obj),
+                                 3)
                                 ("possibly_sensitive_editable",
-                                 (possiblySensitiveEditable :> obj)) |], "")
+                                 (possiblySensitiveEditable :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RetweetedStatus
     JsonDocument.Create(jsonValue, "")
@@ -401,81 +463,119 @@ class JsonProvider+RetweetedStatus : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User : FDR.BaseTypes.IJsonDocument
     new : notifications:JsonValue -> contributorsEnabled:bool -> timeZone:string option -> profileBackgroundColor:JsonProvider+IntOrString -> location:JsonProvider+IntOrString -> profileBackgroundTile:bool -> profileImageUrlHttps:string -> defaultProfileImage:bool -> followRequestSent:JsonValue -> profileSidebarFillColor:JsonProvider+IntOrString -> description:string option -> profileBannerUrl:string option -> favouritesCount:int -> screenName:string -> profileSidebarBorderColor:JsonProvider+FloatOrString -> idStr:int -> verified:bool -> lang:string -> statusesCount:int -> profileUseBackgroundImage:bool -> protected:bool -> profileImageUrl:string -> listedCount:int -> geoEnabled:bool -> createdAt:string -> profileTextColor:JsonProvider+FloatOrString -> name:string -> profileBackgroundImageUrl:string -> friendsCount:int -> url:string option -> id:int -> isTranslator:bool -> defaultProfile:bool -> following:JsonValue -> profileBackgroundImageUrlHttps:string -> utcOffset:int option -> profileLinkColor:JsonProvider+IntOrString -> followersCount:int -> JsonProvider+User
     JsonRuntime.CreateRecord([| ("notifications",
-                                 (notifications :> obj))
+                                 (notifications :> obj),
+                                 0)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 0)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj))
+                                 (profileBannerUrl :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("followers_count",
-                                 (followersCount :> obj)) |], "")
+                                 (followersCount :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User
     JsonDocument.Create(jsonValue, "")
@@ -630,9 +730,11 @@ class JsonProvider+Attributes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
     new : type:string -> coordinates:decimal[][][] -> JsonProvider+BoundingBox
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("coordinates",
-                                 (coordinates :> obj)) |], "")
+                                 (coordinates :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+BoundingBox
     JsonDocument.Create(jsonValue, "")
@@ -648,13 +750,17 @@ class JsonProvider+BoundingBox : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Entities2 : FDR.BaseTypes.IJsonDocument
     new : userMentions:JsonProvider+JsonProvider+UserMention[] -> hashtags:JsonProvider+JsonProvider+Hashtag[] -> urls:JsonProvider+JsonProvider+Url[] -> media:JsonProvider+JsonProvider+Media[] -> JsonProvider+Entities2
     JsonRuntime.CreateRecord([| ("user_mentions",
-                                 (userMentions :> obj))
+                                 (userMentions :> obj),
+                                 0)
                                 ("hashtags",
-                                 (hashtags :> obj))
+                                 (hashtags :> obj),
+                                 0)
                                 ("urls",
-                                 (urls :> obj))
+                                 (urls :> obj),
+                                 0)
                                 ("media",
-                                 (media :> obj)) |], "")
+                                 (media :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Entities2
     JsonDocument.Create(jsonValue, "")
@@ -695,9 +801,11 @@ class JsonProvider+FloatOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hashtag : FDR.BaseTypes.IJsonDocument
     new : text:string -> indices:int[] -> JsonProvider+Hashtag
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj))
+                                 (text :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj)) |], "")
+                                 (indices :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hashtag
     JsonDocument.Create(jsonValue, "")
@@ -733,25 +841,35 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
     new : type:string -> expandedUrl:string -> indices:int[] -> mediaUrlHttps:string -> sizes:JsonProvider+Sizes -> idStr:int64 -> mediaUrl:string -> id:int64 -> url:string -> displayUrl:string -> JsonProvider+Media
     JsonRuntime.CreateRecord([| ("type",
-                                 (type :> obj))
+                                 (type :> obj),
+                                 1)
                                 ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("media_url_https",
-                                 (mediaUrlHttps :> obj))
+                                 (mediaUrlHttps :> obj),
+                                 1)
                                 ("sizes",
-                                 (sizes :> obj))
+                                 (sizes :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("media_url",
-                                 (mediaUrl :> obj))
+                                 (mediaUrl :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("display_url",
-                                 (displayUrl :> obj)) |], "")
+                                 (displayUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Media
     JsonDocument.Create(jsonValue, "")
@@ -798,13 +916,17 @@ class JsonProvider+Media : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
     new : userIdStr:int -> idStr:int64 -> id:int64 -> userId:int -> JsonProvider+Status
     JsonRuntime.CreateRecord([| ("user_id_str",
-                                 (userIdStr :> obj))
+                                 (userIdStr :> obj),
+                                 1)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("user_id",
-                                 (userId :> obj)) |], "")
+                                 (userId :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Status
     JsonDocument.Create(jsonValue, "")
@@ -829,13 +951,17 @@ class JsonProvider+Status : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
     new : expandedUrl:string -> indices:int[] -> displayUrl:string -> url:string -> JsonProvider+Url
     JsonRuntime.CreateRecord([| ("expanded_url",
-                                 (expandedUrl :> obj))
+                                 (expandedUrl :> obj),
+                                 1)
                                 ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("display_url",
-                                 (displayUrl :> obj))
+                                 (displayUrl :> obj),
+                                 1)
                                 ("url",
-                                 (url :> obj)) |], "")
+                                 (url :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Url
     JsonDocument.Create(jsonValue, "")
@@ -859,81 +985,119 @@ class JsonProvider+Url : FDR.BaseTypes.IJsonDocument
 class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
     new : notifications:JsonValue -> contributorsEnabled:bool -> timeZone:string option -> profileBackgroundColor:JsonProvider+IntOrString -> location:string option -> profileBackgroundTile:bool -> profileImageUrlHttps:string -> defaultProfileImage:bool -> followRequestSent:JsonValue -> profileSidebarFillColor:JsonProvider+IntOrString -> description:string option -> favouritesCount:int -> screenName:string -> profileSidebarBorderColor:JsonProvider+IntOrString -> idStr:int -> verified:bool -> lang:string -> statusesCount:int -> profileUseBackgroundImage:bool -> protected:bool -> profileImageUrl:string -> listedCount:int -> geoEnabled:bool -> createdAt:string -> profileTextColor:JsonProvider+IntOrString -> name:string -> profileBackgroundImageUrl:string -> friendsCount:int -> url:string option -> id:int -> isTranslator:bool -> defaultProfile:bool -> following:JsonValue -> profileBackgroundImageUrlHttps:string -> utcOffset:int option -> profileLinkColor:JsonProvider+IntOrString -> followersCount:int -> profileBannerUrl:string option -> JsonProvider+User2
     JsonRuntime.CreateRecord([| ("notifications",
-                                 (notifications :> obj))
+                                 (notifications :> obj),
+                                 0)
                                 ("contributors_enabled",
-                                 (contributorsEnabled :> obj))
+                                 (contributorsEnabled :> obj),
+                                 3)
                                 ("time_zone",
-                                 (timeZone :> obj))
+                                 (timeZone :> obj),
+                                 1)
                                 ("profile_background_color",
-                                 (profileBackgroundColor :> obj))
+                                 (profileBackgroundColor :> obj),
+                                 0)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("profile_background_tile",
-                                 (profileBackgroundTile :> obj))
+                                 (profileBackgroundTile :> obj),
+                                 3)
                                 ("profile_image_url_https",
-                                 (profileImageUrlHttps :> obj))
+                                 (profileImageUrlHttps :> obj),
+                                 1)
                                 ("default_profile_image",
-                                 (defaultProfileImage :> obj))
+                                 (defaultProfileImage :> obj),
+                                 3)
                                 ("follow_request_sent",
-                                 (followRequestSent :> obj))
+                                 (followRequestSent :> obj),
+                                 0)
                                 ("profile_sidebar_fill_color",
-                                 (profileSidebarFillColor :> obj))
+                                 (profileSidebarFillColor :> obj),
+                                 0)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("favourites_count",
-                                 (favouritesCount :> obj))
+                                 (favouritesCount :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("profile_sidebar_border_color",
-                                 (profileSidebarBorderColor :> obj))
+                                 (profileSidebarBorderColor :> obj),
+                                 0)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("verified",
-                                 (verified :> obj))
+                                 (verified :> obj),
+                                 3)
                                 ("lang",
-                                 (lang :> obj))
+                                 (lang :> obj),
+                                 1)
                                 ("statuses_count",
-                                 (statusesCount :> obj))
+                                 (statusesCount :> obj),
+                                 2)
                                 ("profile_use_background_image",
-                                 (profileUseBackgroundImage :> obj))
+                                 (profileUseBackgroundImage :> obj),
+                                 3)
                                 ("protected",
-                                 (protected :> obj))
+                                 (protected :> obj),
+                                 3)
                                 ("profile_image_url",
-                                 (profileImageUrl :> obj))
+                                 (profileImageUrl :> obj),
+                                 1)
                                 ("listed_count",
-                                 (listedCount :> obj))
+                                 (listedCount :> obj),
+                                 2)
                                 ("geo_enabled",
-                                 (geoEnabled :> obj))
+                                 (geoEnabled :> obj),
+                                 3)
                                 ("created_at",
-                                 (createdAt :> obj))
+                                 (createdAt :> obj),
+                                 1)
                                 ("profile_text_color",
-                                 (profileTextColor :> obj))
+                                 (profileTextColor :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("profile_background_image_url",
-                                 (profileBackgroundImageUrl :> obj))
+                                 (profileBackgroundImageUrl :> obj),
+                                 1)
                                 ("friends_count",
-                                 (friendsCount :> obj))
+                                 (friendsCount :> obj),
+                                 2)
                                 ("url",
-                                 (url :> obj))
+                                 (url :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("is_translator",
-                                 (isTranslator :> obj))
+                                 (isTranslator :> obj),
+                                 3)
                                 ("default_profile",
-                                 (defaultProfile :> obj))
+                                 (defaultProfile :> obj),
+                                 3)
                                 ("following",
-                                 (following :> obj))
+                                 (following :> obj),
+                                 0)
                                 ("profile_background_image_url_https",
-                                 (profileBackgroundImageUrlHttps :> obj))
+                                 (profileBackgroundImageUrlHttps :> obj),
+                                 1)
                                 ("utc_offset",
-                                 (utcOffset :> obj))
+                                 (utcOffset :> obj),
+                                 2)
                                 ("profile_link_color",
-                                 (profileLinkColor :> obj))
+                                 (profileLinkColor :> obj),
+                                 0)
                                 ("followers_count",
-                                 (followersCount :> obj))
+                                 (followersCount :> obj),
+                                 2)
                                 ("profile_banner_url",
-                                 (profileBannerUrl :> obj)) |], "")
+                                 (profileBannerUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+User2
     JsonDocument.Create(jsonValue, "")
@@ -1080,15 +1244,20 @@ class JsonProvider+User2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
     new : indices:int[] -> screenName:string -> idStr:int -> name:string -> id:int -> JsonProvider+UserMention
     JsonRuntime.CreateRecord([| ("indices",
-                                 (indices :> obj))
+                                 (indices :> obj),
+                                 2)
                                 ("screen_name",
-                                 (screenName :> obj))
+                                 (screenName :> obj),
+                                 1)
                                 ("id_str",
-                                 (idStr :> obj))
+                                 (idStr :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj)) |], "")
+                                 (id :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+UserMention
     JsonDocument.Create(jsonValue, "")
@@ -1116,13 +1285,17 @@ class JsonProvider+UserMention : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
     new : thumb:JsonProvider+Thumb -> medium:JsonProvider+Thumb -> large:JsonProvider+Thumb -> small:JsonProvider+Thumb -> JsonProvider+Sizes
     JsonRuntime.CreateRecord([| ("thumb",
-                                 (thumb :> obj))
+                                 (thumb :> obj),
+                                 0)
                                 ("medium",
-                                 (medium :> obj))
+                                 (medium :> obj),
+                                 0)
                                 ("large",
-                                 (large :> obj))
+                                 (large :> obj),
+                                 0)
                                 ("small",
-                                 (small :> obj)) |], "")
+                                 (small :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Sizes
     JsonDocument.Create(jsonValue, "")
@@ -1143,11 +1316,14 @@ class JsonProvider+Sizes : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Thumb : FDR.BaseTypes.IJsonDocument
     new : h:int -> w:int -> resize:string -> JsonProvider+Thumb
     JsonRuntime.CreateRecord([| ("h",
-                                 (h :> obj))
+                                 (h :> obj),
+                                 2)
                                 ("w",
-                                 (w :> obj))
+                                 (w :> obj),
+                                 2)
                                 ("resize",
-                                 (resize :> obj)) |], "")
+                                 (resize :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Thumb
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,False,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,False,False,BackwardCompatible.expected
@@ -32,11 +32,14 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : intLike:string -> boolLike1:decimal -> boolLike2:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("intLike",
-                                 (intLike :> obj))
+                                 (intLike :> obj),
+                                 1)
                                 ("boolLike1",
-                                 (boolLike1 :> obj))
+                                 (boolLike1 :> obj),
+                                 2)
                                 ("boolLike2",
-                                 (boolLike2 :> obj)) |], "")
+                                 (boolLike2 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True,False,BackwardCompatible.expected
@@ -32,11 +32,14 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : intLike:int -> boolLike1:bool -> boolLike2:bool -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("intLike",
-                                 (intLike :> obj))
+                                 (intLike :> obj),
+                                 1)
                                 ("boolLike1",
-                                 (boolLike1 :> obj))
+                                 (boolLike1 :> obj),
+                                 2)
                                 ("boolLike2",
-                                 (boolLike2 :> obj)) |], "")
+                                 (boolLike2 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,11 +32,14 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : intLike:int -> boolLike1:bool -> boolLike2:bool -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("intLike",
-                                 (intLike :> obj))
+                                 (intLike :> obj),
+                                 1)
                                 ("boolLike1",
-                                 (boolLike1 :> obj))
+                                 (boolLike1 :> obj),
+                                 2)
                                 ("boolLike2",
-                                 (boolLike2 :> obj)) |], "")
+                                 (boolLike2 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,11 +32,14 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : intLike:int -> boolLike1:bool -> boolLike2:bool -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("intLike",
-                                 (intLike :> obj))
+                                 (intLike :> obj),
+                                 1)
                                 ("boolLike1",
-                                 (boolLike1 :> obj))
+                                 (boolLike1 :> obj),
+                                 2)
                                 ("boolLike2",
-                                 (boolLike2 :> obj)) |], "")
+                                 (boolLike2 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,TypeInference.json,False,,,True,False,ValuesOnly.expected
@@ -32,11 +32,14 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : intLike:int -> boolLike1:bool -> boolLike2:bool -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("intLike",
-                                 (intLike :> obj))
+                                 (intLike :> obj),
+                                 1)
                                 ("boolLike1",
-                                 (boolLike1 :> obj))
+                                 (boolLike1 :> obj),
+                                 2)
                                 ("boolLike2",
-                                 (boolLike2 :> obj)) |], "")
+                                 (boolLike2 :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True,False,BackwardCompatible.expected
@@ -32,15 +32,20 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : game:JsonProvider+Game -> hero:JsonProvider+Hero -> token:string -> viewUrl:string -> playUrl:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("game",
-                                 (game :> obj))
+                                 (game :> obj),
+                                 0)
                                 ("hero",
-                                 (hero :> obj))
+                                 (hero :> obj),
+                                 0)
                                 ("token",
-                                 (token :> obj))
+                                 (token :> obj),
+                                 1)
                                 ("viewUrl",
-                                 (viewUrl :> obj))
+                                 (viewUrl :> obj),
+                                 1)
                                 ("playUrl",
-                                 (playUrl :> obj)) |], "")
+                                 (playUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -67,17 +72,23 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Game : FDR.BaseTypes.IJsonDocument
     new : id:string -> turn:int -> maxTurns:int -> heroes:JsonProvider+JsonProvider+Hero[] -> board:JsonProvider+Board -> finished:bool -> JsonProvider+Game
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("turn",
-                                 (turn :> obj))
+                                 (turn :> obj),
+                                 2)
                                 ("maxTurns",
-                                 (maxTurns :> obj))
+                                 (maxTurns :> obj),
+                                 2)
                                 ("heroes",
-                                 (heroes :> obj))
+                                 (heroes :> obj),
+                                 0)
                                 ("board",
-                                 (board :> obj))
+                                 (board :> obj),
+                                 0)
                                 ("finished",
-                                 (finished :> obj)) |], "")
+                                 (finished :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Game
     JsonDocument.Create(jsonValue, "")
@@ -108,25 +119,35 @@ class JsonProvider+Game : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hero : FDR.BaseTypes.IJsonDocument
     new : id:int -> name:string -> userId:string -> elo:int -> pos:JsonProvider+Pos -> life:int -> gold:int -> mineCount:int -> spawnPos:JsonProvider+Pos -> crashed:bool -> JsonProvider+Hero
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("userId",
-                                 (userId :> obj))
+                                 (userId :> obj),
+                                 1)
                                 ("elo",
-                                 (elo :> obj))
+                                 (elo :> obj),
+                                 2)
                                 ("pos",
-                                 (pos :> obj))
+                                 (pos :> obj),
+                                 0)
                                 ("life",
-                                 (life :> obj))
+                                 (life :> obj),
+                                 2)
                                 ("gold",
-                                 (gold :> obj))
+                                 (gold :> obj),
+                                 2)
                                 ("mineCount",
-                                 (mineCount :> obj))
+                                 (mineCount :> obj),
+                                 2)
                                 ("spawnPos",
-                                 (spawnPos :> obj))
+                                 (spawnPos :> obj),
+                                 0)
                                 ("crashed",
-                                 (crashed :> obj)) |], "")
+                                 (crashed :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hero
     JsonDocument.Create(jsonValue, "")
@@ -173,9 +194,11 @@ class JsonProvider+Hero : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Board : FDR.BaseTypes.IJsonDocument
     new : size:int -> tiles:string -> JsonProvider+Board
     JsonRuntime.CreateRecord([| ("size",
-                                 (size :> obj))
+                                 (size :> obj),
+                                 2)
                                 ("tiles",
-                                 (tiles :> obj)) |], "")
+                                 (tiles :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Board
     JsonDocument.Create(jsonValue, "")
@@ -192,9 +215,11 @@ class JsonProvider+Board : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Pos : FDR.BaseTypes.IJsonDocument
     new : x:int -> y:int -> JsonProvider+Pos
     JsonRuntime.CreateRecord([| ("x",
-                                 (x :> obj))
+                                 (x :> obj),
+                                 2)
                                 ("y",
-                                 (y :> obj)) |], "")
+                                 (y :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Pos
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,15 +32,20 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : game:JsonProvider+Game -> hero:JsonProvider+Hero -> token:string -> viewUrl:string -> playUrl:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("game",
-                                 (game :> obj))
+                                 (game :> obj),
+                                 0)
                                 ("hero",
-                                 (hero :> obj))
+                                 (hero :> obj),
+                                 0)
                                 ("token",
-                                 (token :> obj))
+                                 (token :> obj),
+                                 1)
                                 ("viewUrl",
-                                 (viewUrl :> obj))
+                                 (viewUrl :> obj),
+                                 1)
                                 ("playUrl",
-                                 (playUrl :> obj)) |], "")
+                                 (playUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -67,17 +72,23 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Game : FDR.BaseTypes.IJsonDocument
     new : id:string -> turn:int -> maxTurns:int -> heroes:JsonProvider+JsonProvider+Hero[] -> board:JsonProvider+Board -> finished:bool -> JsonProvider+Game
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("turn",
-                                 (turn :> obj))
+                                 (turn :> obj),
+                                 2)
                                 ("maxTurns",
-                                 (maxTurns :> obj))
+                                 (maxTurns :> obj),
+                                 2)
                                 ("heroes",
-                                 (heroes :> obj))
+                                 (heroes :> obj),
+                                 0)
                                 ("board",
-                                 (board :> obj))
+                                 (board :> obj),
+                                 0)
                                 ("finished",
-                                 (finished :> obj)) |], "")
+                                 (finished :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Game
     JsonDocument.Create(jsonValue, "")
@@ -108,25 +119,35 @@ class JsonProvider+Game : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hero : FDR.BaseTypes.IJsonDocument
     new : id:int -> name:string -> userId:string -> elo:int -> pos:JsonProvider+Pos -> life:int -> gold:int -> mineCount:int -> spawnPos:JsonProvider+Pos -> crashed:bool -> JsonProvider+Hero
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("userId",
-                                 (userId :> obj))
+                                 (userId :> obj),
+                                 1)
                                 ("elo",
-                                 (elo :> obj))
+                                 (elo :> obj),
+                                 2)
                                 ("pos",
-                                 (pos :> obj))
+                                 (pos :> obj),
+                                 0)
                                 ("life",
-                                 (life :> obj))
+                                 (life :> obj),
+                                 2)
                                 ("gold",
-                                 (gold :> obj))
+                                 (gold :> obj),
+                                 2)
                                 ("mineCount",
-                                 (mineCount :> obj))
+                                 (mineCount :> obj),
+                                 2)
                                 ("spawnPos",
-                                 (spawnPos :> obj))
+                                 (spawnPos :> obj),
+                                 0)
                                 ("crashed",
-                                 (crashed :> obj)) |], "")
+                                 (crashed :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hero
     JsonDocument.Create(jsonValue, "")
@@ -173,9 +194,11 @@ class JsonProvider+Hero : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Board : FDR.BaseTypes.IJsonDocument
     new : size:int -> tiles:string -> JsonProvider+Board
     JsonRuntime.CreateRecord([| ("size",
-                                 (size :> obj))
+                                 (size :> obj),
+                                 2)
                                 ("tiles",
-                                 (tiles :> obj)) |], "")
+                                 (tiles :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Board
     JsonDocument.Create(jsonValue, "")
@@ -192,9 +215,11 @@ class JsonProvider+Board : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Pos : FDR.BaseTypes.IJsonDocument
     new : x:int -> y:int -> JsonProvider+Pos
     JsonRuntime.CreateRecord([| ("x",
-                                 (x :> obj))
+                                 (x :> obj),
+                                 2)
                                 ("y",
-                                 (y :> obj)) |], "")
+                                 (y :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Pos
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,15 +32,20 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : game:JsonProvider+Game -> hero:JsonProvider+Hero -> token:string -> viewUrl:string -> playUrl:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("game",
-                                 (game :> obj))
+                                 (game :> obj),
+                                 0)
                                 ("hero",
-                                 (hero :> obj))
+                                 (hero :> obj),
+                                 0)
                                 ("token",
-                                 (token :> obj))
+                                 (token :> obj),
+                                 1)
                                 ("viewUrl",
-                                 (viewUrl :> obj))
+                                 (viewUrl :> obj),
+                                 1)
                                 ("playUrl",
-                                 (playUrl :> obj)) |], "")
+                                 (playUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -67,17 +72,23 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Game : FDR.BaseTypes.IJsonDocument
     new : id:string -> turn:int -> maxTurns:int -> heroes:JsonProvider+JsonProvider+Hero[] -> board:JsonProvider+Board -> finished:bool -> JsonProvider+Game
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("turn",
-                                 (turn :> obj))
+                                 (turn :> obj),
+                                 2)
                                 ("maxTurns",
-                                 (maxTurns :> obj))
+                                 (maxTurns :> obj),
+                                 2)
                                 ("heroes",
-                                 (heroes :> obj))
+                                 (heroes :> obj),
+                                 0)
                                 ("board",
-                                 (board :> obj))
+                                 (board :> obj),
+                                 0)
                                 ("finished",
-                                 (finished :> obj)) |], "")
+                                 (finished :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Game
     JsonDocument.Create(jsonValue, "")
@@ -108,25 +119,35 @@ class JsonProvider+Game : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hero : FDR.BaseTypes.IJsonDocument
     new : id:int -> name:string -> userId:string -> elo:int -> pos:JsonProvider+Pos -> life:int -> gold:int -> mineCount:int -> spawnPos:JsonProvider+Pos -> crashed:bool -> JsonProvider+Hero
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("userId",
-                                 (userId :> obj))
+                                 (userId :> obj),
+                                 1)
                                 ("elo",
-                                 (elo :> obj))
+                                 (elo :> obj),
+                                 2)
                                 ("pos",
-                                 (pos :> obj))
+                                 (pos :> obj),
+                                 0)
                                 ("life",
-                                 (life :> obj))
+                                 (life :> obj),
+                                 2)
                                 ("gold",
-                                 (gold :> obj))
+                                 (gold :> obj),
+                                 2)
                                 ("mineCount",
-                                 (mineCount :> obj))
+                                 (mineCount :> obj),
+                                 2)
                                 ("spawnPos",
-                                 (spawnPos :> obj))
+                                 (spawnPos :> obj),
+                                 0)
                                 ("crashed",
-                                 (crashed :> obj)) |], "")
+                                 (crashed :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hero
     JsonDocument.Create(jsonValue, "")
@@ -173,9 +194,11 @@ class JsonProvider+Hero : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Board : FDR.BaseTypes.IJsonDocument
     new : size:int -> tiles:string -> JsonProvider+Board
     JsonRuntime.CreateRecord([| ("size",
-                                 (size :> obj))
+                                 (size :> obj),
+                                 2)
                                 ("tiles",
-                                 (tiles :> obj)) |], "")
+                                 (tiles :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Board
     JsonDocument.Create(jsonValue, "")
@@ -192,9 +215,11 @@ class JsonProvider+Board : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Pos : FDR.BaseTypes.IJsonDocument
     new : x:int -> y:int -> JsonProvider+Pos
     JsonRuntime.CreateRecord([| ("x",
-                                 (x :> obj))
+                                 (x :> obj),
+                                 2)
                                 ("y",
-                                 (y :> obj)) |], "")
+                                 (y :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Pos
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,Vindinium.json,False,,,True,False,ValuesOnly.expected
@@ -32,15 +32,20 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : game:JsonProvider+Game -> hero:JsonProvider+Hero -> token:string -> viewUrl:string -> playUrl:string -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("game",
-                                 (game :> obj))
+                                 (game :> obj),
+                                 0)
                                 ("hero",
-                                 (hero :> obj))
+                                 (hero :> obj),
+                                 0)
                                 ("token",
-                                 (token :> obj))
+                                 (token :> obj),
+                                 1)
                                 ("viewUrl",
-                                 (viewUrl :> obj))
+                                 (viewUrl :> obj),
+                                 1)
                                 ("playUrl",
-                                 (playUrl :> obj)) |], "")
+                                 (playUrl :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -67,17 +72,23 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Game : FDR.BaseTypes.IJsonDocument
     new : id:string -> turn:int -> maxTurns:int -> heroes:JsonProvider+JsonProvider+Hero[] -> board:JsonProvider+Board -> finished:bool -> JsonProvider+Game
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("turn",
-                                 (turn :> obj))
+                                 (turn :> obj),
+                                 2)
                                 ("maxTurns",
-                                 (maxTurns :> obj))
+                                 (maxTurns :> obj),
+                                 2)
                                 ("heroes",
-                                 (heroes :> obj))
+                                 (heroes :> obj),
+                                 0)
                                 ("board",
-                                 (board :> obj))
+                                 (board :> obj),
+                                 0)
                                 ("finished",
-                                 (finished :> obj)) |], "")
+                                 (finished :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Game
     JsonDocument.Create(jsonValue, "")
@@ -108,25 +119,35 @@ class JsonProvider+Game : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Hero : FDR.BaseTypes.IJsonDocument
     new : id:int -> name:string -> userId:string -> elo:int -> pos:JsonProvider+Pos -> life:int -> gold:int -> mineCount:int -> spawnPos:JsonProvider+Pos -> crashed:bool -> JsonProvider+Hero
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("userId",
-                                 (userId :> obj))
+                                 (userId :> obj),
+                                 1)
                                 ("elo",
-                                 (elo :> obj))
+                                 (elo :> obj),
+                                 2)
                                 ("pos",
-                                 (pos :> obj))
+                                 (pos :> obj),
+                                 0)
                                 ("life",
-                                 (life :> obj))
+                                 (life :> obj),
+                                 2)
                                 ("gold",
-                                 (gold :> obj))
+                                 (gold :> obj),
+                                 2)
                                 ("mineCount",
-                                 (mineCount :> obj))
+                                 (mineCount :> obj),
+                                 2)
                                 ("spawnPos",
-                                 (spawnPos :> obj))
+                                 (spawnPos :> obj),
+                                 0)
                                 ("crashed",
-                                 (crashed :> obj)) |], "")
+                                 (crashed :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Hero
     JsonDocument.Create(jsonValue, "")
@@ -173,9 +194,11 @@ class JsonProvider+Hero : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Board : FDR.BaseTypes.IJsonDocument
     new : size:int -> tiles:string -> JsonProvider+Board
     JsonRuntime.CreateRecord([| ("size",
-                                 (size :> obj))
+                                 (size :> obj),
+                                 2)
                                 ("tiles",
-                                 (tiles :> obj)) |], "")
+                                 (tiles :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Board
     JsonDocument.Create(jsonValue, "")
@@ -192,9 +215,11 @@ class JsonProvider+Board : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Pos : FDR.BaseTypes.IJsonDocument
     new : x:int -> y:int -> JsonProvider+Pos
     JsonRuntime.CreateRecord([| ("x",
-                                 (x :> obj))
+                                 (x :> obj),
+                                 2)
                                 ("y",
-                                 (y :> obj)) |], "")
+                                 (y :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Pos
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True,False,BackwardCompatible.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> address:JsonProvider+Address -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("address",
-                                 (address :> obj)) |], "")
+                                 (address :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -62,13 +66,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Address : FDR.BaseTypes.IJsonDocument
     new : streetAddress:string -> city:string -> state:string -> postalCode:int -> JsonProvider+Address
     JsonRuntime.CreateRecord([| ("streetAddress",
-                                 (streetAddress :> obj))
+                                 (streetAddress :> obj),
+                                 1)
                                 ("city",
-                                 (city :> obj))
+                                 (city :> obj),
+                                 1)
                                 ("state",
-                                 (state :> obj))
+                                 (state :> obj),
+                                 1)
                                 ("postalCode",
-                                 (postalCode :> obj)) |], "")
+                                 (postalCode :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Address
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> address:JsonProvider+Address -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("address",
-                                 (address :> obj)) |], "")
+                                 (address :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -62,13 +66,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Address : FDR.BaseTypes.IJsonDocument
     new : streetAddress:string -> city:string -> state:string -> postalCode:int -> JsonProvider+Address
     JsonRuntime.CreateRecord([| ("streetAddress",
-                                 (streetAddress :> obj))
+                                 (streetAddress :> obj),
+                                 1)
                                 ("city",
-                                 (city :> obj))
+                                 (city :> obj),
+                                 1)
                                 ("state",
-                                 (state :> obj))
+                                 (state :> obj),
+                                 1)
                                 ("postalCode",
-                                 (postalCode :> obj)) |], "")
+                                 (postalCode :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Address
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> address:JsonProvider+Address -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("address",
-                                 (address :> obj)) |], "")
+                                 (address :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -62,13 +66,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Address : FDR.BaseTypes.IJsonDocument
     new : streetAddress:string -> city:string -> state:string -> postalCode:int -> JsonProvider+Address
     JsonRuntime.CreateRecord([| ("streetAddress",
-                                 (streetAddress :> obj))
+                                 (streetAddress :> obj),
+                                 1)
                                 ("city",
-                                 (city :> obj))
+                                 (city :> obj),
+                                 1)
                                 ("state",
-                                 (state :> obj))
+                                 (state :> obj),
+                                 1)
                                 ("postalCode",
-                                 (postalCode :> obj)) |], "")
+                                 (postalCode :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Address
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WikiData.json,False,,,True,False,ValuesOnly.expected
@@ -32,13 +32,17 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : firstName:string -> lastName:string -> age:int -> address:JsonProvider+Address -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("firstName",
-                                 (firstName :> obj))
+                                 (firstName :> obj),
+                                 1)
                                 ("lastName",
-                                 (lastName :> obj))
+                                 (lastName :> obj),
+                                 1)
                                 ("age",
-                                 (age :> obj))
+                                 (age :> obj),
+                                 2)
                                 ("address",
-                                 (address :> obj)) |], "")
+                                 (address :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -62,13 +66,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Address : FDR.BaseTypes.IJsonDocument
     new : streetAddress:string -> city:string -> state:string -> postalCode:int -> JsonProvider+Address
     JsonRuntime.CreateRecord([| ("streetAddress",
-                                 (streetAddress :> obj))
+                                 (streetAddress :> obj),
+                                 1)
                                 ("city",
-                                 (city :> obj))
+                                 (city :> obj),
+                                 1)
                                 ("state",
-                                 (state :> obj))
+                                 (state :> obj),
+                                 1)
                                 ("postalCode",
-                                 (postalCode :> obj)) |], "")
+                                 (postalCode :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Address
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True,False,BackwardCompatible.expected
@@ -31,8 +31,10 @@ class JsonProvider : obj
 
 class JsonProvider+WorldBank : FDR.BaseTypes.IJsonDocument
     new : array:JsonProvider+JsonProvider+Record[] -> record:JsonProvider+Record2 -> JsonProvider+WorldBank
-    JsonRuntime.CreateArray([| (array :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((array :> obj),
+                                0)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+WorldBank
     JsonDocument.Create(jsonValue, "")
@@ -47,15 +49,20 @@ class JsonProvider+WorldBank : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
     new : indicator:JsonProvider+Indicator -> country:JsonProvider+Indicator -> value:decimal option -> decimal:int -> date:int -> JsonProvider+Record
     JsonRuntime.CreateRecord([| ("indicator",
-                                 (indicator :> obj))
+                                 (indicator :> obj),
+                                 0)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 0)
                                 ("value",
-                                 (value :> obj))
+                                 (value :> obj),
+                                 1)
                                 ("decimal",
-                                 (decimal :> obj))
+                                 (decimal :> obj),
+                                 1)
                                 ("date",
-                                 (date :> obj)) |], "")
+                                 (date :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record
     JsonDocument.Create(jsonValue, "")
@@ -81,13 +88,17 @@ class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record2 : FDR.BaseTypes.IJsonDocument
     new : page:int -> pages:int -> perPage:int -> total:int -> JsonProvider+Record2
     JsonRuntime.CreateRecord([| ("page",
-                                 (page :> obj))
+                                 (page :> obj),
+                                 2)
                                 ("pages",
-                                 (pages :> obj))
+                                 (pages :> obj),
+                                 2)
                                 ("per_page",
-                                 (perPage :> obj))
+                                 (perPage :> obj),
+                                 1)
                                 ("total",
-                                 (total :> obj)) |], "")
+                                 (total :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record2
     JsonDocument.Create(jsonValue, "")
@@ -112,9 +123,11 @@ class JsonProvider+Record2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Indicator : FDR.BaseTypes.IJsonDocument
     new : id:string -> value:string -> JsonProvider+Indicator
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("value",
-                                 (value :> obj)) |], "")
+                                 (value :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Indicator
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True,False,ValuesAndInlineSchemasHints.expected
@@ -31,8 +31,10 @@ class JsonProvider : obj
 
 class JsonProvider+WorldBank : FDR.BaseTypes.IJsonDocument
     new : array:JsonProvider+JsonProvider+Record[] -> record:JsonProvider+Record2 -> JsonProvider+WorldBank
-    JsonRuntime.CreateArray([| (array :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((array :> obj),
+                                0)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+WorldBank
     JsonDocument.Create(jsonValue, "")
@@ -47,15 +49,20 @@ class JsonProvider+WorldBank : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
     new : indicator:JsonProvider+Indicator -> country:JsonProvider+Indicator -> value:decimal option -> decimal:int -> date:int -> JsonProvider+Record
     JsonRuntime.CreateRecord([| ("indicator",
-                                 (indicator :> obj))
+                                 (indicator :> obj),
+                                 0)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 0)
                                 ("value",
-                                 (value :> obj))
+                                 (value :> obj),
+                                 1)
                                 ("decimal",
-                                 (decimal :> obj))
+                                 (decimal :> obj),
+                                 1)
                                 ("date",
-                                 (date :> obj)) |], "")
+                                 (date :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record
     JsonDocument.Create(jsonValue, "")
@@ -81,13 +88,17 @@ class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record2 : FDR.BaseTypes.IJsonDocument
     new : page:int -> pages:int -> perPage:int -> total:int -> JsonProvider+Record2
     JsonRuntime.CreateRecord([| ("page",
-                                 (page :> obj))
+                                 (page :> obj),
+                                 2)
                                 ("pages",
-                                 (pages :> obj))
+                                 (pages :> obj),
+                                 2)
                                 ("per_page",
-                                 (perPage :> obj))
+                                 (perPage :> obj),
+                                 1)
                                 ("total",
-                                 (total :> obj)) |], "")
+                                 (total :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record2
     JsonDocument.Create(jsonValue, "")
@@ -112,9 +123,11 @@ class JsonProvider+Record2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Indicator : FDR.BaseTypes.IJsonDocument
     new : id:string -> value:string -> JsonProvider+Indicator
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("value",
-                                 (value :> obj)) |], "")
+                                 (value :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Indicator
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -31,8 +31,10 @@ class JsonProvider : obj
 
 class JsonProvider+WorldBank : FDR.BaseTypes.IJsonDocument
     new : array:JsonProvider+JsonProvider+Record[] -> record:JsonProvider+Record2 -> JsonProvider+WorldBank
-    JsonRuntime.CreateArray([| (array :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((array :> obj),
+                                0)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+WorldBank
     JsonDocument.Create(jsonValue, "")
@@ -47,15 +49,20 @@ class JsonProvider+WorldBank : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
     new : indicator:JsonProvider+Indicator -> country:JsonProvider+Indicator -> value:decimal option -> decimal:int -> date:int -> JsonProvider+Record
     JsonRuntime.CreateRecord([| ("indicator",
-                                 (indicator :> obj))
+                                 (indicator :> obj),
+                                 0)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 0)
                                 ("value",
-                                 (value :> obj))
+                                 (value :> obj),
+                                 1)
                                 ("decimal",
-                                 (decimal :> obj))
+                                 (decimal :> obj),
+                                 1)
                                 ("date",
-                                 (date :> obj)) |], "")
+                                 (date :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record
     JsonDocument.Create(jsonValue, "")
@@ -81,13 +88,17 @@ class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record2 : FDR.BaseTypes.IJsonDocument
     new : page:int -> pages:int -> perPage:int -> total:int -> JsonProvider+Record2
     JsonRuntime.CreateRecord([| ("page",
-                                 (page :> obj))
+                                 (page :> obj),
+                                 2)
                                 ("pages",
-                                 (pages :> obj))
+                                 (pages :> obj),
+                                 2)
                                 ("per_page",
-                                 (perPage :> obj))
+                                 (perPage :> obj),
+                                 1)
                                 ("total",
-                                 (total :> obj)) |], "")
+                                 (total :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record2
     JsonDocument.Create(jsonValue, "")
@@ -112,9 +123,11 @@ class JsonProvider+Record2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Indicator : FDR.BaseTypes.IJsonDocument
     new : id:string -> value:string -> JsonProvider+Indicator
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("value",
-                                 (value :> obj)) |], "")
+                                 (value :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Indicator
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,WorldBank.json,False,WorldBank,,True,False,ValuesOnly.expected
@@ -31,8 +31,10 @@ class JsonProvider : obj
 
 class JsonProvider+WorldBank : FDR.BaseTypes.IJsonDocument
     new : array:JsonProvider+JsonProvider+Record[] -> record:JsonProvider+Record2 -> JsonProvider+WorldBank
-    JsonRuntime.CreateArray([| (array :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((array :> obj),
+                                0)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+WorldBank
     JsonDocument.Create(jsonValue, "")
@@ -47,15 +49,20 @@ class JsonProvider+WorldBank : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
     new : indicator:JsonProvider+Indicator -> country:JsonProvider+Indicator -> value:decimal option -> decimal:int -> date:int -> JsonProvider+Record
     JsonRuntime.CreateRecord([| ("indicator",
-                                 (indicator :> obj))
+                                 (indicator :> obj),
+                                 0)
                                 ("country",
-                                 (country :> obj))
+                                 (country :> obj),
+                                 0)
                                 ("value",
-                                 (value :> obj))
+                                 (value :> obj),
+                                 1)
                                 ("decimal",
-                                 (decimal :> obj))
+                                 (decimal :> obj),
+                                 1)
                                 ("date",
-                                 (date :> obj)) |], "")
+                                 (date :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record
     JsonDocument.Create(jsonValue, "")
@@ -81,13 +88,17 @@ class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record2 : FDR.BaseTypes.IJsonDocument
     new : page:int -> pages:int -> perPage:int -> total:int -> JsonProvider+Record2
     JsonRuntime.CreateRecord([| ("page",
-                                 (page :> obj))
+                                 (page :> obj),
+                                 2)
                                 ("pages",
-                                 (pages :> obj))
+                                 (pages :> obj),
+                                 2)
                                 ("per_page",
-                                 (perPage :> obj))
+                                 (perPage :> obj),
+                                 1)
                                 ("total",
-                                 (total :> obj)) |], "")
+                                 (total :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record2
     JsonDocument.Create(jsonValue, "")
@@ -112,9 +123,11 @@ class JsonProvider+Record2 : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Indicator : FDR.BaseTypes.IJsonDocument
     new : id:string -> value:string -> JsonProvider+Indicator
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("value",
-                                 (value :> obj)) |], "")
+                                 (value :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Indicator
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True,False,BackwardCompatible.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : ab:JsonProvider+Ab -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("ab",
-                                 (ab :> obj)) |], "")
+                                 (ab :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,7 +45,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Ab : FDR.BaseTypes.IJsonDocument
     new : persons:JsonProvider+JsonProvider+Person[] -> JsonProvider+Ab
     JsonRuntime.CreateRecord([| ("persons",
-                                 (persons :> obj)) |], "")
+                                 (persons :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Ab
     JsonDocument.Create(jsonValue, "")
@@ -56,11 +58,14 @@ class JsonProvider+Ab : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Person : FDR.BaseTypes.IJsonDocument
     new : contacts:JsonProvider+JsonProvider+Contact[] -> emails:JsonValue[] -> phones:JsonValue[] -> JsonProvider+Person
     JsonRuntime.CreateRecord([| ("contacts",
-                                 (contacts :> obj))
+                                 (contacts :> obj),
+                                 0)
                                 ("emails",
-                                 (emails :> obj))
+                                 (emails :> obj),
+                                 0)
                                 ("phones",
-                                 (phones :> obj)) |], "")
+                                 (phones :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Person
     JsonDocument.Create(jsonValue, "")
@@ -78,13 +83,17 @@ class JsonProvider+Person : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Contact : FDR.BaseTypes.IJsonDocument
     new : emailCapability:int[] -> emailImEnabled:bool[] -> emails:string[] -> phones:JsonValue[] -> JsonProvider+Contact
     JsonRuntime.CreateRecord([| ("emailCapability",
-                                 (emailCapability :> obj))
+                                 (emailCapability :> obj),
+                                 0)
                                 ("emailIMEnabled",
-                                 (emailImEnabled :> obj))
+                                 (emailImEnabled :> obj),
+                                 3)
                                 ("emails",
-                                 (emails :> obj))
+                                 (emails :> obj),
+                                 0)
                                 ("phones",
-                                 (phones :> obj)) |], "")
+                                 (phones :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Contact
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : ab:JsonProvider+Ab -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("ab",
-                                 (ab :> obj)) |], "")
+                                 (ab :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,7 +45,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Ab : FDR.BaseTypes.IJsonDocument
     new : persons:JsonProvider+JsonProvider+Person[] -> JsonProvider+Ab
     JsonRuntime.CreateRecord([| ("persons",
-                                 (persons :> obj)) |], "")
+                                 (persons :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Ab
     JsonDocument.Create(jsonValue, "")
@@ -56,11 +58,14 @@ class JsonProvider+Ab : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Person : FDR.BaseTypes.IJsonDocument
     new : contacts:JsonProvider+JsonProvider+Contact[] -> emails:JsonValue[] -> phones:JsonValue[] -> JsonProvider+Person
     JsonRuntime.CreateRecord([| ("contacts",
-                                 (contacts :> obj))
+                                 (contacts :> obj),
+                                 0)
                                 ("emails",
-                                 (emails :> obj))
+                                 (emails :> obj),
+                                 0)
                                 ("phones",
-                                 (phones :> obj)) |], "")
+                                 (phones :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Person
     JsonDocument.Create(jsonValue, "")
@@ -78,13 +83,17 @@ class JsonProvider+Person : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Contact : FDR.BaseTypes.IJsonDocument
     new : emailCapability:int[] -> emailImEnabled:bool[] -> emails:string[] -> phones:JsonValue[] -> JsonProvider+Contact
     JsonRuntime.CreateRecord([| ("emailCapability",
-                                 (emailCapability :> obj))
+                                 (emailCapability :> obj),
+                                 0)
                                 ("emailIMEnabled",
-                                 (emailImEnabled :> obj))
+                                 (emailImEnabled :> obj),
+                                 3)
                                 ("emails",
-                                 (emails :> obj))
+                                 (emails :> obj),
+                                 0)
                                 ("phones",
-                                 (phones :> obj)) |], "")
+                                 (phones :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Contact
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : ab:JsonProvider+Ab -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("ab",
-                                 (ab :> obj)) |], "")
+                                 (ab :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,7 +45,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Ab : FDR.BaseTypes.IJsonDocument
     new : persons:JsonProvider+JsonProvider+Person[] -> JsonProvider+Ab
     JsonRuntime.CreateRecord([| ("persons",
-                                 (persons :> obj)) |], "")
+                                 (persons :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Ab
     JsonDocument.Create(jsonValue, "")
@@ -56,11 +58,14 @@ class JsonProvider+Ab : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Person : FDR.BaseTypes.IJsonDocument
     new : contacts:JsonProvider+JsonProvider+Contact[] -> emails:JsonValue[] -> phones:JsonValue[] -> JsonProvider+Person
     JsonRuntime.CreateRecord([| ("contacts",
-                                 (contacts :> obj))
+                                 (contacts :> obj),
+                                 0)
                                 ("emails",
-                                 (emails :> obj))
+                                 (emails :> obj),
+                                 0)
                                 ("phones",
-                                 (phones :> obj)) |], "")
+                                 (phones :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Person
     JsonDocument.Create(jsonValue, "")
@@ -78,13 +83,17 @@ class JsonProvider+Person : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Contact : FDR.BaseTypes.IJsonDocument
     new : emailCapability:int[] -> emailImEnabled:bool[] -> emails:string[] -> phones:JsonValue[] -> JsonProvider+Contact
     JsonRuntime.CreateRecord([| ("emailCapability",
-                                 (emailCapability :> obj))
+                                 (emailCapability :> obj),
+                                 0)
                                 ("emailIMEnabled",
-                                 (emailImEnabled :> obj))
+                                 (emailImEnabled :> obj),
+                                 3)
                                 ("emails",
-                                 (emails :> obj))
+                                 (emails :> obj),
+                                 0)
                                 ("phones",
-                                 (phones :> obj)) |], "")
+                                 (phones :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Contact
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,contacts.json,False,,,True,False,ValuesOnly.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : ab:JsonProvider+Ab -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("ab",
-                                 (ab :> obj)) |], "")
+                                 (ab :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,7 +45,8 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Ab : FDR.BaseTypes.IJsonDocument
     new : persons:JsonProvider+JsonProvider+Person[] -> JsonProvider+Ab
     JsonRuntime.CreateRecord([| ("persons",
-                                 (persons :> obj)) |], "")
+                                 (persons :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Ab
     JsonDocument.Create(jsonValue, "")
@@ -56,11 +58,14 @@ class JsonProvider+Ab : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Person : FDR.BaseTypes.IJsonDocument
     new : contacts:JsonProvider+JsonProvider+Contact[] -> emails:JsonValue[] -> phones:JsonValue[] -> JsonProvider+Person
     JsonRuntime.CreateRecord([| ("contacts",
-                                 (contacts :> obj))
+                                 (contacts :> obj),
+                                 0)
                                 ("emails",
-                                 (emails :> obj))
+                                 (emails :> obj),
+                                 0)
                                 ("phones",
-                                 (phones :> obj)) |], "")
+                                 (phones :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Person
     JsonDocument.Create(jsonValue, "")
@@ -78,13 +83,17 @@ class JsonProvider+Person : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Contact : FDR.BaseTypes.IJsonDocument
     new : emailCapability:int[] -> emailImEnabled:bool[] -> emails:string[] -> phones:JsonValue[] -> JsonProvider+Contact
     JsonRuntime.CreateRecord([| ("emailCapability",
-                                 (emailCapability :> obj))
+                                 (emailCapability :> obj),
+                                 0)
                                 ("emailIMEnabled",
-                                 (emailImEnabled :> obj))
+                                 (emailImEnabled :> obj),
+                                 3)
                                 ("emails",
-                                 (emails :> obj))
+                                 (emails :> obj),
+                                 0)
                                 ("phones",
-                                 (phones :> obj)) |], "")
+                                 (phones :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Contact
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True,False,BackwardCompatible.expected
@@ -32,27 +32,38 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : recordProperty:JsonProvider+RecordProperty -> nullProperty:JsonValue -> emptyStringProperty:JsonValue -> emptyArrayProperty:JsonValue[] -> oneElementArrayProperty:int[] -> multipleElementsArrayProperty:int[] -> arrayOfObjects:JsonProvider+JsonProvider+ArrayOfObject[] -> optionalPrimitives:JsonProvider+JsonProvider+OptionalPrimitive[] -> optionalRecords:JsonProvider+JsonProvider+OptionalRecord[] -> heterogeneousArray:JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray -> heterogeneousRecords:JsonProvider+JsonProvider+HeterogeneousRecord[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("recordProperty",
-                                 (recordProperty :> obj))
+                                 (recordProperty :> obj),
+                                 0)
                                 ("nullProperty",
-                                 (nullProperty :> obj))
+                                 (nullProperty :> obj),
+                                 0)
                                 ("emptyStringProperty",
-                                 (emptyStringProperty :> obj))
+                                 (emptyStringProperty :> obj),
+                                 0)
                                 ("emptyArrayProperty",
-                                 (emptyArrayProperty :> obj))
+                                 (emptyArrayProperty :> obj),
+                                 0)
                                 ("oneElementArrayProperty",
-                                 (oneElementArrayProperty :> obj))
+                                 (oneElementArrayProperty :> obj),
+                                 2)
                                 ("multipleElementsArrayProperty",
-                                 (multipleElementsArrayProperty :> obj))
+                                 (multipleElementsArrayProperty :> obj),
+                                 2)
                                 ("arrayOfObjects",
-                                 (arrayOfObjects :> obj))
+                                 (arrayOfObjects :> obj),
+                                 0)
                                 ("optionalPrimitives",
-                                 (optionalPrimitives :> obj))
+                                 (optionalPrimitives :> obj),
+                                 0)
                                 ("optionalRecords",
-                                 (optionalRecords :> obj))
+                                 (optionalRecords :> obj),
+                                 0)
                                 ("heterogeneousArray",
-                                 (heterogeneousArray :> obj))
+                                 (heterogeneousArray :> obj),
+                                 0)
                                 ("heterogeneousRecords",
-                                 (heterogeneousRecords :> obj)) |], "")
+                                 (heterogeneousRecords :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -94,11 +105,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+ArrayOfObject : FDR.BaseTypes.IJsonDocument
     new : heterogeneousArrayProperty:JsonProvider+NumbersOrBooleanOrString -> heterogeneousProperty:JsonProvider+IntOrBooleanOrDateTime -> heterogeneousOptionalProperty:JsonProvider+IntOrBoolean -> JsonProvider+ArrayOfObject
     JsonRuntime.CreateRecord([| ("heterogeneousArrayProperty",
-                                 (heterogeneousArrayProperty :> obj))
+                                 (heterogeneousArrayProperty :> obj),
+                                 0)
                                 ("heterogeneousProperty",
-                                 (heterogeneousProperty :> obj))
+                                 (heterogeneousProperty :> obj),
+                                 0)
                                 ("heterogeneousOptionalProperty",
-                                 (heterogeneousOptionalProperty :> obj)) |], "")
+                                 (heterogeneousOptionalProperty :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+ArrayOfObject
     JsonDocument.Create(jsonValue, "")
@@ -116,7 +130,8 @@ class JsonProvider+ArrayOfObject : FDR.BaseTypes.IJsonDocument
 class JsonProvider+HeterogeneousRecord : FDR.BaseTypes.IJsonDocument
     new : b:JsonProvider+IntOrBooleanOrArrayOrB -> JsonProvider+HeterogeneousRecord
     JsonRuntime.CreateRecord([| ("b",
-                                 (b :> obj)) |], "")
+                                 (b :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+HeterogeneousRecord
     JsonDocument.Create(jsonValue, "")
@@ -127,10 +142,14 @@ class JsonProvider+HeterogeneousRecord : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray : FDR.BaseTypes.IJsonDocument
     new : number:int -> boolean:bool -> arrays:JsonProvider+JsonProvider+NumbersOrBooleanOrHeterogeneousArray[] -> record:JsonProvider+OptionalBecauseMissing -> JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray
-    JsonRuntime.CreateArray([| (number :> obj)
-                               (boolean :> obj)
-                               (arrays :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((number :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((arrays :> obj),
+                                0)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray
     JsonDocument.Create(jsonValue, "")
@@ -153,15 +172,20 @@ class JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray : FDR.BaseTypes.IJso
 class JsonProvider+OptionalPrimitive : FDR.BaseTypes.IJsonDocument
     new : optionalBecauseMissing:int option -> optionalBecauseNull:int option -> optionalBecauseEmptyString:int option -> notOptional:int -> nullNotOptional:JsonValue -> JsonProvider+OptionalPrimitive
     JsonRuntime.CreateRecord([| ("optionalBecauseMissing",
-                                 (optionalBecauseMissing :> obj))
+                                 (optionalBecauseMissing :> obj),
+                                 2)
                                 ("optionalBecauseNull",
-                                 (optionalBecauseNull :> obj))
+                                 (optionalBecauseNull :> obj),
+                                 2)
                                 ("optionalBecauseEmptyString",
-                                 (optionalBecauseEmptyString :> obj))
+                                 (optionalBecauseEmptyString :> obj),
+                                 2)
                                 ("notOptional",
-                                 (notOptional :> obj))
+                                 (notOptional :> obj),
+                                 1)
                                 ("nullNotOptional",
-                                 (nullNotOptional :> obj)) |], "")
+                                 (nullNotOptional :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalPrimitive
     JsonDocument.Create(jsonValue, "")
@@ -186,13 +210,17 @@ class JsonProvider+OptionalPrimitive : FDR.BaseTypes.IJsonDocument
 class JsonProvider+OptionalRecord : FDR.BaseTypes.IJsonDocument
     new : optionalBecauseMissing:JsonProvider+OptionalBecauseMissing option -> optionalBecauseNull:JsonProvider+OptionalBecauseMissing option -> optionalBecauseEmptyString:JsonProvider+OptionalBecauseMissing option -> notOptional:JsonProvider+OptionalBecauseMissing -> JsonProvider+OptionalRecord
     JsonRuntime.CreateRecord([| ("optionalBecauseMissing",
-                                 (optionalBecauseMissing :> obj))
+                                 (optionalBecauseMissing :> obj),
+                                 0)
                                 ("optionalBecauseNull",
-                                 (optionalBecauseNull :> obj))
+                                 (optionalBecauseNull :> obj),
+                                 0)
                                 ("optionalBecauseEmptyString",
-                                 (optionalBecauseEmptyString :> obj))
+                                 (optionalBecauseEmptyString :> obj),
+                                 0)
                                 ("notOptional",
-                                 (notOptional :> obj)) |], "")
+                                 (notOptional :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalRecord
     JsonDocument.Create(jsonValue, "")
@@ -213,21 +241,29 @@ class JsonProvider+OptionalRecord : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RecordProperty : FDR.BaseTypes.IJsonDocument
     new : stringProperty:string -> intProperty:int -> int64Property:int64 -> decimalProperty:decimal -> floatProperty:float -> boolProperty:bool -> dateProperty:System.DateTime -> guidProperty:System.Guid -> JsonProvider+RecordProperty
     JsonRuntime.CreateRecord([| ("stringProperty",
-                                 (stringProperty :> obj))
+                                 (stringProperty :> obj),
+                                 1)
                                 ("intProperty",
-                                 (intProperty :> obj))
+                                 (intProperty :> obj),
+                                 2)
                                 ("int64Property",
-                                 (int64Property :> obj))
+                                 (int64Property :> obj),
+                                 2)
                                 ("decimalProperty",
-                                 (decimalProperty :> obj))
+                                 (decimalProperty :> obj),
+                                 2)
                                 ("floatProperty",
-                                 (floatProperty :> obj))
+                                 (floatProperty :> obj),
+                                 2)
                                 ("boolProperty",
-                                 (boolProperty :> obj))
+                                 (boolProperty :> obj),
+                                 3)
                                 ("dateProperty",
-                                 (dateProperty :> obj))
+                                 (dateProperty :> obj),
+                                 1)
                                 ("guidProperty",
-                                 (guidProperty :> obj)) |], "")
+                                 (guidProperty :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RecordProperty
     JsonDocument.Create(jsonValue, "")
@@ -345,9 +381,12 @@ class JsonProvider+IntOrBooleanOrDateTime : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+NumbersOrBooleanOrHeterogeneousArray : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool option -> record:JsonProvider+OptionalBecauseMissing option -> JsonProvider+NumbersOrBooleanOrHeterogeneousArray
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrHeterogeneousArray
     JsonDocument.Create(jsonValue, "")
@@ -364,9 +403,12 @@ class JsonProvider+NumbersOrBooleanOrHeterogeneousArray : FDR.BaseTypes.IJsonDoc
 
 class JsonProvider+NumbersOrBooleanOrString : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool -> string:string option -> JsonProvider+NumbersOrBooleanOrString
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (string :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((string :> obj),
+                                1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrString
     JsonDocument.Create(jsonValue, "")
@@ -385,7 +427,8 @@ class JsonProvider+NumbersOrBooleanOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+OptionalBecauseMissing : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+OptionalBecauseMissing
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalBecauseMissing
     JsonDocument.Create(jsonValue, "")
@@ -397,9 +440,12 @@ class JsonProvider+OptionalBecauseMissing : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+NumbersOrBooleanOrB : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool option -> record:JsonProvider+OptionalBecauseMissing option -> JsonProvider+NumbersOrBooleanOrB
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrB
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,27 +32,38 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : recordProperty:JsonProvider+RecordProperty -> nullProperty:JsonValue -> emptyStringProperty:JsonValue -> emptyArrayProperty:JsonValue[] -> oneElementArrayProperty:int[] -> multipleElementsArrayProperty:int[] -> arrayOfObjects:JsonProvider+JsonProvider+ArrayOfObject[] -> optionalPrimitives:JsonProvider+JsonProvider+OptionalPrimitive[] -> optionalRecords:JsonProvider+JsonProvider+OptionalRecord[] -> heterogeneousArray:JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray -> heterogeneousRecords:JsonProvider+JsonProvider+HeterogeneousRecord[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("recordProperty",
-                                 (recordProperty :> obj))
+                                 (recordProperty :> obj),
+                                 0)
                                 ("nullProperty",
-                                 (nullProperty :> obj))
+                                 (nullProperty :> obj),
+                                 0)
                                 ("emptyStringProperty",
-                                 (emptyStringProperty :> obj))
+                                 (emptyStringProperty :> obj),
+                                 0)
                                 ("emptyArrayProperty",
-                                 (emptyArrayProperty :> obj))
+                                 (emptyArrayProperty :> obj),
+                                 0)
                                 ("oneElementArrayProperty",
-                                 (oneElementArrayProperty :> obj))
+                                 (oneElementArrayProperty :> obj),
+                                 2)
                                 ("multipleElementsArrayProperty",
-                                 (multipleElementsArrayProperty :> obj))
+                                 (multipleElementsArrayProperty :> obj),
+                                 2)
                                 ("arrayOfObjects",
-                                 (arrayOfObjects :> obj))
+                                 (arrayOfObjects :> obj),
+                                 0)
                                 ("optionalPrimitives",
-                                 (optionalPrimitives :> obj))
+                                 (optionalPrimitives :> obj),
+                                 0)
                                 ("optionalRecords",
-                                 (optionalRecords :> obj))
+                                 (optionalRecords :> obj),
+                                 0)
                                 ("heterogeneousArray",
-                                 (heterogeneousArray :> obj))
+                                 (heterogeneousArray :> obj),
+                                 0)
                                 ("heterogeneousRecords",
-                                 (heterogeneousRecords :> obj)) |], "")
+                                 (heterogeneousRecords :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -94,11 +105,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+ArrayOfObject : FDR.BaseTypes.IJsonDocument
     new : heterogeneousArrayProperty:JsonProvider+NumbersOrBooleanOrString -> heterogeneousProperty:JsonProvider+IntOrBooleanOrDateTime -> heterogeneousOptionalProperty:JsonProvider+IntOrBoolean -> JsonProvider+ArrayOfObject
     JsonRuntime.CreateRecord([| ("heterogeneousArrayProperty",
-                                 (heterogeneousArrayProperty :> obj))
+                                 (heterogeneousArrayProperty :> obj),
+                                 0)
                                 ("heterogeneousProperty",
-                                 (heterogeneousProperty :> obj))
+                                 (heterogeneousProperty :> obj),
+                                 0)
                                 ("heterogeneousOptionalProperty",
-                                 (heterogeneousOptionalProperty :> obj)) |], "")
+                                 (heterogeneousOptionalProperty :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+ArrayOfObject
     JsonDocument.Create(jsonValue, "")
@@ -116,7 +130,8 @@ class JsonProvider+ArrayOfObject : FDR.BaseTypes.IJsonDocument
 class JsonProvider+HeterogeneousRecord : FDR.BaseTypes.IJsonDocument
     new : b:JsonProvider+IntOrBooleanOrArrayOrB -> JsonProvider+HeterogeneousRecord
     JsonRuntime.CreateRecord([| ("b",
-                                 (b :> obj)) |], "")
+                                 (b :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+HeterogeneousRecord
     JsonDocument.Create(jsonValue, "")
@@ -127,10 +142,14 @@ class JsonProvider+HeterogeneousRecord : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray : FDR.BaseTypes.IJsonDocument
     new : number:int -> boolean:bool -> arrays:JsonProvider+JsonProvider+NumbersOrBooleanOrHeterogeneousArray[] -> record:JsonProvider+OptionalBecauseMissing -> JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray
-    JsonRuntime.CreateArray([| (number :> obj)
-                               (boolean :> obj)
-                               (arrays :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((number :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((arrays :> obj),
+                                0)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray
     JsonDocument.Create(jsonValue, "")
@@ -153,15 +172,20 @@ class JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray : FDR.BaseTypes.IJso
 class JsonProvider+OptionalPrimitive : FDR.BaseTypes.IJsonDocument
     new : optionalBecauseMissing:int option -> optionalBecauseNull:int option -> optionalBecauseEmptyString:int option -> notOptional:int -> nullNotOptional:JsonValue -> JsonProvider+OptionalPrimitive
     JsonRuntime.CreateRecord([| ("optionalBecauseMissing",
-                                 (optionalBecauseMissing :> obj))
+                                 (optionalBecauseMissing :> obj),
+                                 2)
                                 ("optionalBecauseNull",
-                                 (optionalBecauseNull :> obj))
+                                 (optionalBecauseNull :> obj),
+                                 2)
                                 ("optionalBecauseEmptyString",
-                                 (optionalBecauseEmptyString :> obj))
+                                 (optionalBecauseEmptyString :> obj),
+                                 2)
                                 ("notOptional",
-                                 (notOptional :> obj))
+                                 (notOptional :> obj),
+                                 1)
                                 ("nullNotOptional",
-                                 (nullNotOptional :> obj)) |], "")
+                                 (nullNotOptional :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalPrimitive
     JsonDocument.Create(jsonValue, "")
@@ -186,13 +210,17 @@ class JsonProvider+OptionalPrimitive : FDR.BaseTypes.IJsonDocument
 class JsonProvider+OptionalRecord : FDR.BaseTypes.IJsonDocument
     new : optionalBecauseMissing:JsonProvider+OptionalBecauseMissing option -> optionalBecauseNull:JsonProvider+OptionalBecauseMissing option -> optionalBecauseEmptyString:JsonProvider+OptionalBecauseMissing option -> notOptional:JsonProvider+OptionalBecauseMissing -> JsonProvider+OptionalRecord
     JsonRuntime.CreateRecord([| ("optionalBecauseMissing",
-                                 (optionalBecauseMissing :> obj))
+                                 (optionalBecauseMissing :> obj),
+                                 0)
                                 ("optionalBecauseNull",
-                                 (optionalBecauseNull :> obj))
+                                 (optionalBecauseNull :> obj),
+                                 0)
                                 ("optionalBecauseEmptyString",
-                                 (optionalBecauseEmptyString :> obj))
+                                 (optionalBecauseEmptyString :> obj),
+                                 0)
                                 ("notOptional",
-                                 (notOptional :> obj)) |], "")
+                                 (notOptional :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalRecord
     JsonDocument.Create(jsonValue, "")
@@ -213,21 +241,29 @@ class JsonProvider+OptionalRecord : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RecordProperty : FDR.BaseTypes.IJsonDocument
     new : stringProperty:string -> intProperty:int -> int64Property:int64 -> decimalProperty:decimal -> floatProperty:float -> boolProperty:bool -> dateProperty:System.DateTime -> guidProperty:System.Guid -> JsonProvider+RecordProperty
     JsonRuntime.CreateRecord([| ("stringProperty",
-                                 (stringProperty :> obj))
+                                 (stringProperty :> obj),
+                                 1)
                                 ("intProperty",
-                                 (intProperty :> obj))
+                                 (intProperty :> obj),
+                                 2)
                                 ("int64Property",
-                                 (int64Property :> obj))
+                                 (int64Property :> obj),
+                                 2)
                                 ("decimalProperty",
-                                 (decimalProperty :> obj))
+                                 (decimalProperty :> obj),
+                                 2)
                                 ("floatProperty",
-                                 (floatProperty :> obj))
+                                 (floatProperty :> obj),
+                                 2)
                                 ("boolProperty",
-                                 (boolProperty :> obj))
+                                 (boolProperty :> obj),
+                                 3)
                                 ("dateProperty",
-                                 (dateProperty :> obj))
+                                 (dateProperty :> obj),
+                                 1)
                                 ("guidProperty",
-                                 (guidProperty :> obj)) |], "")
+                                 (guidProperty :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RecordProperty
     JsonDocument.Create(jsonValue, "")
@@ -345,9 +381,12 @@ class JsonProvider+IntOrBooleanOrDateTime : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+NumbersOrBooleanOrHeterogeneousArray : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool option -> record:JsonProvider+OptionalBecauseMissing option -> JsonProvider+NumbersOrBooleanOrHeterogeneousArray
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrHeterogeneousArray
     JsonDocument.Create(jsonValue, "")
@@ -364,9 +403,12 @@ class JsonProvider+NumbersOrBooleanOrHeterogeneousArray : FDR.BaseTypes.IJsonDoc
 
 class JsonProvider+NumbersOrBooleanOrString : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool -> string:string option -> JsonProvider+NumbersOrBooleanOrString
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (string :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((string :> obj),
+                                1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrString
     JsonDocument.Create(jsonValue, "")
@@ -385,7 +427,8 @@ class JsonProvider+NumbersOrBooleanOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+OptionalBecauseMissing : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+OptionalBecauseMissing
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalBecauseMissing
     JsonDocument.Create(jsonValue, "")
@@ -397,9 +440,12 @@ class JsonProvider+OptionalBecauseMissing : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+NumbersOrBooleanOrB : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool option -> record:JsonProvider+OptionalBecauseMissing option -> JsonProvider+NumbersOrBooleanOrB
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrB
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,27 +32,38 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : recordProperty:JsonProvider+RecordProperty -> nullProperty:JsonValue -> emptyStringProperty:JsonValue -> emptyArrayProperty:JsonValue[] -> oneElementArrayProperty:int[] -> multipleElementsArrayProperty:int[] -> arrayOfObjects:JsonProvider+JsonProvider+ArrayOfObject[] -> optionalPrimitives:JsonProvider+JsonProvider+OptionalPrimitive[] -> optionalRecords:JsonProvider+JsonProvider+OptionalRecord[] -> heterogeneousArray:JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray -> heterogeneousRecords:JsonProvider+JsonProvider+HeterogeneousRecord[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("recordProperty",
-                                 (recordProperty :> obj))
+                                 (recordProperty :> obj),
+                                 0)
                                 ("nullProperty",
-                                 (nullProperty :> obj))
+                                 (nullProperty :> obj),
+                                 0)
                                 ("emptyStringProperty",
-                                 (emptyStringProperty :> obj))
+                                 (emptyStringProperty :> obj),
+                                 0)
                                 ("emptyArrayProperty",
-                                 (emptyArrayProperty :> obj))
+                                 (emptyArrayProperty :> obj),
+                                 0)
                                 ("oneElementArrayProperty",
-                                 (oneElementArrayProperty :> obj))
+                                 (oneElementArrayProperty :> obj),
+                                 2)
                                 ("multipleElementsArrayProperty",
-                                 (multipleElementsArrayProperty :> obj))
+                                 (multipleElementsArrayProperty :> obj),
+                                 2)
                                 ("arrayOfObjects",
-                                 (arrayOfObjects :> obj))
+                                 (arrayOfObjects :> obj),
+                                 0)
                                 ("optionalPrimitives",
-                                 (optionalPrimitives :> obj))
+                                 (optionalPrimitives :> obj),
+                                 0)
                                 ("optionalRecords",
-                                 (optionalRecords :> obj))
+                                 (optionalRecords :> obj),
+                                 0)
                                 ("heterogeneousArray",
-                                 (heterogeneousArray :> obj))
+                                 (heterogeneousArray :> obj),
+                                 0)
                                 ("heterogeneousRecords",
-                                 (heterogeneousRecords :> obj)) |], "")
+                                 (heterogeneousRecords :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -94,11 +105,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+ArrayOfObject : FDR.BaseTypes.IJsonDocument
     new : heterogeneousArrayProperty:JsonProvider+NumbersOrBooleanOrString -> heterogeneousProperty:JsonProvider+IntOrBooleanOrDateTime -> heterogeneousOptionalProperty:JsonProvider+IntOrBoolean -> JsonProvider+ArrayOfObject
     JsonRuntime.CreateRecord([| ("heterogeneousArrayProperty",
-                                 (heterogeneousArrayProperty :> obj))
+                                 (heterogeneousArrayProperty :> obj),
+                                 0)
                                 ("heterogeneousProperty",
-                                 (heterogeneousProperty :> obj))
+                                 (heterogeneousProperty :> obj),
+                                 0)
                                 ("heterogeneousOptionalProperty",
-                                 (heterogeneousOptionalProperty :> obj)) |], "")
+                                 (heterogeneousOptionalProperty :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+ArrayOfObject
     JsonDocument.Create(jsonValue, "")
@@ -116,7 +130,8 @@ class JsonProvider+ArrayOfObject : FDR.BaseTypes.IJsonDocument
 class JsonProvider+HeterogeneousRecord : FDR.BaseTypes.IJsonDocument
     new : b:JsonProvider+IntOrBooleanOrArrayOrB -> JsonProvider+HeterogeneousRecord
     JsonRuntime.CreateRecord([| ("b",
-                                 (b :> obj)) |], "")
+                                 (b :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+HeterogeneousRecord
     JsonDocument.Create(jsonValue, "")
@@ -127,10 +142,14 @@ class JsonProvider+HeterogeneousRecord : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray : FDR.BaseTypes.IJsonDocument
     new : number:int -> boolean:bool -> arrays:JsonProvider+JsonProvider+NumbersOrBooleanOrHeterogeneousArray[] -> record:JsonProvider+OptionalBecauseMissing -> JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray
-    JsonRuntime.CreateArray([| (number :> obj)
-                               (boolean :> obj)
-                               (arrays :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((number :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((arrays :> obj),
+                                0)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray
     JsonDocument.Create(jsonValue, "")
@@ -153,15 +172,20 @@ class JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray : FDR.BaseTypes.IJso
 class JsonProvider+OptionalPrimitive : FDR.BaseTypes.IJsonDocument
     new : optionalBecauseMissing:int option -> optionalBecauseNull:int option -> optionalBecauseEmptyString:int option -> notOptional:int -> nullNotOptional:JsonValue -> JsonProvider+OptionalPrimitive
     JsonRuntime.CreateRecord([| ("optionalBecauseMissing",
-                                 (optionalBecauseMissing :> obj))
+                                 (optionalBecauseMissing :> obj),
+                                 2)
                                 ("optionalBecauseNull",
-                                 (optionalBecauseNull :> obj))
+                                 (optionalBecauseNull :> obj),
+                                 2)
                                 ("optionalBecauseEmptyString",
-                                 (optionalBecauseEmptyString :> obj))
+                                 (optionalBecauseEmptyString :> obj),
+                                 2)
                                 ("notOptional",
-                                 (notOptional :> obj))
+                                 (notOptional :> obj),
+                                 1)
                                 ("nullNotOptional",
-                                 (nullNotOptional :> obj)) |], "")
+                                 (nullNotOptional :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalPrimitive
     JsonDocument.Create(jsonValue, "")
@@ -186,13 +210,17 @@ class JsonProvider+OptionalPrimitive : FDR.BaseTypes.IJsonDocument
 class JsonProvider+OptionalRecord : FDR.BaseTypes.IJsonDocument
     new : optionalBecauseMissing:JsonProvider+OptionalBecauseMissing option -> optionalBecauseNull:JsonProvider+OptionalBecauseMissing option -> optionalBecauseEmptyString:JsonProvider+OptionalBecauseMissing option -> notOptional:JsonProvider+OptionalBecauseMissing -> JsonProvider+OptionalRecord
     JsonRuntime.CreateRecord([| ("optionalBecauseMissing",
-                                 (optionalBecauseMissing :> obj))
+                                 (optionalBecauseMissing :> obj),
+                                 0)
                                 ("optionalBecauseNull",
-                                 (optionalBecauseNull :> obj))
+                                 (optionalBecauseNull :> obj),
+                                 0)
                                 ("optionalBecauseEmptyString",
-                                 (optionalBecauseEmptyString :> obj))
+                                 (optionalBecauseEmptyString :> obj),
+                                 0)
                                 ("notOptional",
-                                 (notOptional :> obj)) |], "")
+                                 (notOptional :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalRecord
     JsonDocument.Create(jsonValue, "")
@@ -213,21 +241,29 @@ class JsonProvider+OptionalRecord : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RecordProperty : FDR.BaseTypes.IJsonDocument
     new : stringProperty:string -> intProperty:int -> int64Property:int64 -> decimalProperty:decimal -> floatProperty:float -> boolProperty:bool -> dateProperty:System.DateTime -> guidProperty:System.Guid -> JsonProvider+RecordProperty
     JsonRuntime.CreateRecord([| ("stringProperty",
-                                 (stringProperty :> obj))
+                                 (stringProperty :> obj),
+                                 1)
                                 ("intProperty",
-                                 (intProperty :> obj))
+                                 (intProperty :> obj),
+                                 2)
                                 ("int64Property",
-                                 (int64Property :> obj))
+                                 (int64Property :> obj),
+                                 2)
                                 ("decimalProperty",
-                                 (decimalProperty :> obj))
+                                 (decimalProperty :> obj),
+                                 2)
                                 ("floatProperty",
-                                 (floatProperty :> obj))
+                                 (floatProperty :> obj),
+                                 2)
                                 ("boolProperty",
-                                 (boolProperty :> obj))
+                                 (boolProperty :> obj),
+                                 3)
                                 ("dateProperty",
-                                 (dateProperty :> obj))
+                                 (dateProperty :> obj),
+                                 1)
                                 ("guidProperty",
-                                 (guidProperty :> obj)) |], "")
+                                 (guidProperty :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RecordProperty
     JsonDocument.Create(jsonValue, "")
@@ -345,9 +381,12 @@ class JsonProvider+IntOrBooleanOrDateTime : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+NumbersOrBooleanOrHeterogeneousArray : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool option -> record:JsonProvider+OptionalBecauseMissing option -> JsonProvider+NumbersOrBooleanOrHeterogeneousArray
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrHeterogeneousArray
     JsonDocument.Create(jsonValue, "")
@@ -364,9 +403,12 @@ class JsonProvider+NumbersOrBooleanOrHeterogeneousArray : FDR.BaseTypes.IJsonDoc
 
 class JsonProvider+NumbersOrBooleanOrString : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool -> string:string option -> JsonProvider+NumbersOrBooleanOrString
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (string :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((string :> obj),
+                                1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrString
     JsonDocument.Create(jsonValue, "")
@@ -385,7 +427,8 @@ class JsonProvider+NumbersOrBooleanOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+OptionalBecauseMissing : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+OptionalBecauseMissing
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalBecauseMissing
     JsonDocument.Create(jsonValue, "")
@@ -397,9 +440,12 @@ class JsonProvider+OptionalBecauseMissing : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+NumbersOrBooleanOrB : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool option -> record:JsonProvider+OptionalBecauseMissing option -> JsonProvider+NumbersOrBooleanOrB
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrB
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,optionals.json,False,,,True,False,ValuesOnly.expected
@@ -32,27 +32,38 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : recordProperty:JsonProvider+RecordProperty -> nullProperty:JsonValue -> emptyStringProperty:JsonValue -> emptyArrayProperty:JsonValue[] -> oneElementArrayProperty:int[] -> multipleElementsArrayProperty:int[] -> arrayOfObjects:JsonProvider+JsonProvider+ArrayOfObject[] -> optionalPrimitives:JsonProvider+JsonProvider+OptionalPrimitive[] -> optionalRecords:JsonProvider+JsonProvider+OptionalRecord[] -> heterogeneousArray:JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray -> heterogeneousRecords:JsonProvider+JsonProvider+HeterogeneousRecord[] -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("recordProperty",
-                                 (recordProperty :> obj))
+                                 (recordProperty :> obj),
+                                 0)
                                 ("nullProperty",
-                                 (nullProperty :> obj))
+                                 (nullProperty :> obj),
+                                 0)
                                 ("emptyStringProperty",
-                                 (emptyStringProperty :> obj))
+                                 (emptyStringProperty :> obj),
+                                 0)
                                 ("emptyArrayProperty",
-                                 (emptyArrayProperty :> obj))
+                                 (emptyArrayProperty :> obj),
+                                 0)
                                 ("oneElementArrayProperty",
-                                 (oneElementArrayProperty :> obj))
+                                 (oneElementArrayProperty :> obj),
+                                 2)
                                 ("multipleElementsArrayProperty",
-                                 (multipleElementsArrayProperty :> obj))
+                                 (multipleElementsArrayProperty :> obj),
+                                 2)
                                 ("arrayOfObjects",
-                                 (arrayOfObjects :> obj))
+                                 (arrayOfObjects :> obj),
+                                 0)
                                 ("optionalPrimitives",
-                                 (optionalPrimitives :> obj))
+                                 (optionalPrimitives :> obj),
+                                 0)
                                 ("optionalRecords",
-                                 (optionalRecords :> obj))
+                                 (optionalRecords :> obj),
+                                 0)
                                 ("heterogeneousArray",
-                                 (heterogeneousArray :> obj))
+                                 (heterogeneousArray :> obj),
+                                 0)
                                 ("heterogeneousRecords",
-                                 (heterogeneousRecords :> obj)) |], "")
+                                 (heterogeneousRecords :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -94,11 +105,14 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+ArrayOfObject : FDR.BaseTypes.IJsonDocument
     new : heterogeneousArrayProperty:JsonProvider+NumbersOrBooleanOrString -> heterogeneousProperty:JsonProvider+IntOrBooleanOrDateTime -> heterogeneousOptionalProperty:JsonProvider+IntOrBoolean -> JsonProvider+ArrayOfObject
     JsonRuntime.CreateRecord([| ("heterogeneousArrayProperty",
-                                 (heterogeneousArrayProperty :> obj))
+                                 (heterogeneousArrayProperty :> obj),
+                                 0)
                                 ("heterogeneousProperty",
-                                 (heterogeneousProperty :> obj))
+                                 (heterogeneousProperty :> obj),
+                                 0)
                                 ("heterogeneousOptionalProperty",
-                                 (heterogeneousOptionalProperty :> obj)) |], "")
+                                 (heterogeneousOptionalProperty :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+ArrayOfObject
     JsonDocument.Create(jsonValue, "")
@@ -116,7 +130,8 @@ class JsonProvider+ArrayOfObject : FDR.BaseTypes.IJsonDocument
 class JsonProvider+HeterogeneousRecord : FDR.BaseTypes.IJsonDocument
     new : b:JsonProvider+IntOrBooleanOrArrayOrB -> JsonProvider+HeterogeneousRecord
     JsonRuntime.CreateRecord([| ("b",
-                                 (b :> obj)) |], "")
+                                 (b :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+HeterogeneousRecord
     JsonDocument.Create(jsonValue, "")
@@ -127,10 +142,14 @@ class JsonProvider+HeterogeneousRecord : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray : FDR.BaseTypes.IJsonDocument
     new : number:int -> boolean:bool -> arrays:JsonProvider+JsonProvider+NumbersOrBooleanOrHeterogeneousArray[] -> record:JsonProvider+OptionalBecauseMissing -> JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray
-    JsonRuntime.CreateArray([| (number :> obj)
-                               (boolean :> obj)
-                               (arrays :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((number :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((arrays :> obj),
+                                0)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray
     JsonDocument.Create(jsonValue, "")
@@ -153,15 +172,20 @@ class JsonProvider+IntOrBooleanOrArraysOrHeterogeneousArray : FDR.BaseTypes.IJso
 class JsonProvider+OptionalPrimitive : FDR.BaseTypes.IJsonDocument
     new : optionalBecauseMissing:int option -> optionalBecauseNull:int option -> optionalBecauseEmptyString:int option -> notOptional:int -> nullNotOptional:JsonValue -> JsonProvider+OptionalPrimitive
     JsonRuntime.CreateRecord([| ("optionalBecauseMissing",
-                                 (optionalBecauseMissing :> obj))
+                                 (optionalBecauseMissing :> obj),
+                                 2)
                                 ("optionalBecauseNull",
-                                 (optionalBecauseNull :> obj))
+                                 (optionalBecauseNull :> obj),
+                                 2)
                                 ("optionalBecauseEmptyString",
-                                 (optionalBecauseEmptyString :> obj))
+                                 (optionalBecauseEmptyString :> obj),
+                                 2)
                                 ("notOptional",
-                                 (notOptional :> obj))
+                                 (notOptional :> obj),
+                                 1)
                                 ("nullNotOptional",
-                                 (nullNotOptional :> obj)) |], "")
+                                 (nullNotOptional :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalPrimitive
     JsonDocument.Create(jsonValue, "")
@@ -186,13 +210,17 @@ class JsonProvider+OptionalPrimitive : FDR.BaseTypes.IJsonDocument
 class JsonProvider+OptionalRecord : FDR.BaseTypes.IJsonDocument
     new : optionalBecauseMissing:JsonProvider+OptionalBecauseMissing option -> optionalBecauseNull:JsonProvider+OptionalBecauseMissing option -> optionalBecauseEmptyString:JsonProvider+OptionalBecauseMissing option -> notOptional:JsonProvider+OptionalBecauseMissing -> JsonProvider+OptionalRecord
     JsonRuntime.CreateRecord([| ("optionalBecauseMissing",
-                                 (optionalBecauseMissing :> obj))
+                                 (optionalBecauseMissing :> obj),
+                                 0)
                                 ("optionalBecauseNull",
-                                 (optionalBecauseNull :> obj))
+                                 (optionalBecauseNull :> obj),
+                                 0)
                                 ("optionalBecauseEmptyString",
-                                 (optionalBecauseEmptyString :> obj))
+                                 (optionalBecauseEmptyString :> obj),
+                                 0)
                                 ("notOptional",
-                                 (notOptional :> obj)) |], "")
+                                 (notOptional :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalRecord
     JsonDocument.Create(jsonValue, "")
@@ -213,21 +241,29 @@ class JsonProvider+OptionalRecord : FDR.BaseTypes.IJsonDocument
 class JsonProvider+RecordProperty : FDR.BaseTypes.IJsonDocument
     new : stringProperty:string -> intProperty:int -> int64Property:int64 -> decimalProperty:decimal -> floatProperty:float -> boolProperty:bool -> dateProperty:System.DateTime -> guidProperty:System.Guid -> JsonProvider+RecordProperty
     JsonRuntime.CreateRecord([| ("stringProperty",
-                                 (stringProperty :> obj))
+                                 (stringProperty :> obj),
+                                 1)
                                 ("intProperty",
-                                 (intProperty :> obj))
+                                 (intProperty :> obj),
+                                 2)
                                 ("int64Property",
-                                 (int64Property :> obj))
+                                 (int64Property :> obj),
+                                 2)
                                 ("decimalProperty",
-                                 (decimalProperty :> obj))
+                                 (decimalProperty :> obj),
+                                 2)
                                 ("floatProperty",
-                                 (floatProperty :> obj))
+                                 (floatProperty :> obj),
+                                 2)
                                 ("boolProperty",
-                                 (boolProperty :> obj))
+                                 (boolProperty :> obj),
+                                 3)
                                 ("dateProperty",
-                                 (dateProperty :> obj))
+                                 (dateProperty :> obj),
+                                 1)
                                 ("guidProperty",
-                                 (guidProperty :> obj)) |], "")
+                                 (guidProperty :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+RecordProperty
     JsonDocument.Create(jsonValue, "")
@@ -345,9 +381,12 @@ class JsonProvider+IntOrBooleanOrDateTime : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+NumbersOrBooleanOrHeterogeneousArray : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool option -> record:JsonProvider+OptionalBecauseMissing option -> JsonProvider+NumbersOrBooleanOrHeterogeneousArray
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrHeterogeneousArray
     JsonDocument.Create(jsonValue, "")
@@ -364,9 +403,12 @@ class JsonProvider+NumbersOrBooleanOrHeterogeneousArray : FDR.BaseTypes.IJsonDoc
 
 class JsonProvider+NumbersOrBooleanOrString : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool -> string:string option -> JsonProvider+NumbersOrBooleanOrString
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (string :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((string :> obj),
+                                1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrString
     JsonDocument.Create(jsonValue, "")
@@ -385,7 +427,8 @@ class JsonProvider+NumbersOrBooleanOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+OptionalBecauseMissing : FDR.BaseTypes.IJsonDocument
     new : a:int -> JsonProvider+OptionalBecauseMissing
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+OptionalBecauseMissing
     JsonDocument.Create(jsonValue, "")
@@ -397,9 +440,12 @@ class JsonProvider+OptionalBecauseMissing : FDR.BaseTypes.IJsonDocument
 
 class JsonProvider+NumbersOrBooleanOrB : FDR.BaseTypes.IJsonDocument
     new : numbers:int[] -> boolean:bool option -> record:JsonProvider+OptionalBecauseMissing option -> JsonProvider+NumbersOrBooleanOrB
-    JsonRuntime.CreateArray([| (numbers :> obj)
-                               (boolean :> obj)
-                               (record :> obj) |], "")
+    JsonRuntime.CreateArray([| ((numbers :> obj),
+                                2)
+                               ((boolean :> obj),
+                                3)
+                               ((record :> obj),
+                                0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+NumbersOrBooleanOrB
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True,False,BackwardCompatible.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : ordercontainer:JsonProvider+Ordercontainer -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("ordercontainer",
-                                 (ordercontainer :> obj)) |], "")
+                                 (ordercontainer :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Ordercontainer : FDR.BaseTypes.IJsonDocument
     new : backgrounds:JsonProvider+Backgrounds -> project:JsonProvider+Background -> JsonProvider+Ordercontainer
     JsonRuntime.CreateRecord([| ("backgrounds",
-                                 (backgrounds :> obj))
+                                 (backgrounds :> obj),
+                                 0)
                                 ("project",
-                                 (project :> obj)) |], "")
+                                 (project :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Ordercontainer
     JsonDocument.Create(jsonValue, "")
@@ -61,7 +64,8 @@ class JsonProvider+Ordercontainer : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Background : FDR.BaseTypes.IJsonDocument
     new : title:JsonProvider+Title -> JsonProvider+Background
     JsonRuntime.CreateRecord([| ("title",
-                                 (title :> obj)) |], "")
+                                 (title :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Background
     JsonDocument.Create(jsonValue, "")
@@ -73,7 +77,8 @@ class JsonProvider+Background : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Backgrounds : FDR.BaseTypes.IJsonDocument
     new : background:JsonProvider+Background -> JsonProvider+Backgrounds
     JsonRuntime.CreateRecord([| ("background",
-                                 (background :> obj)) |], "")
+                                 (background :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Backgrounds
     JsonDocument.Create(jsonValue, "")
@@ -85,7 +90,8 @@ class JsonProvider+Backgrounds : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Title : FDR.BaseTypes.IJsonDocument
     new : text:string -> JsonProvider+Title
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj)) |], "")
+                                 (text :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Title
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : ordercontainer:JsonProvider+Ordercontainer -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("ordercontainer",
-                                 (ordercontainer :> obj)) |], "")
+                                 (ordercontainer :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Ordercontainer : FDR.BaseTypes.IJsonDocument
     new : backgrounds:JsonProvider+Backgrounds -> project:JsonProvider+Background -> JsonProvider+Ordercontainer
     JsonRuntime.CreateRecord([| ("backgrounds",
-                                 (backgrounds :> obj))
+                                 (backgrounds :> obj),
+                                 0)
                                 ("project",
-                                 (project :> obj)) |], "")
+                                 (project :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Ordercontainer
     JsonDocument.Create(jsonValue, "")
@@ -61,7 +64,8 @@ class JsonProvider+Ordercontainer : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Background : FDR.BaseTypes.IJsonDocument
     new : title:JsonProvider+Title -> JsonProvider+Background
     JsonRuntime.CreateRecord([| ("title",
-                                 (title :> obj)) |], "")
+                                 (title :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Background
     JsonDocument.Create(jsonValue, "")
@@ -73,7 +77,8 @@ class JsonProvider+Background : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Backgrounds : FDR.BaseTypes.IJsonDocument
     new : background:JsonProvider+Background -> JsonProvider+Backgrounds
     JsonRuntime.CreateRecord([| ("background",
-                                 (background :> obj)) |], "")
+                                 (background :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Backgrounds
     JsonDocument.Create(jsonValue, "")
@@ -85,7 +90,8 @@ class JsonProvider+Backgrounds : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Title : FDR.BaseTypes.IJsonDocument
     new : text:string -> JsonProvider+Title
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj)) |], "")
+                                 (text :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Title
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : ordercontainer:JsonProvider+Ordercontainer -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("ordercontainer",
-                                 (ordercontainer :> obj)) |], "")
+                                 (ordercontainer :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Ordercontainer : FDR.BaseTypes.IJsonDocument
     new : backgrounds:JsonProvider+Backgrounds -> project:JsonProvider+Background -> JsonProvider+Ordercontainer
     JsonRuntime.CreateRecord([| ("backgrounds",
-                                 (backgrounds :> obj))
+                                 (backgrounds :> obj),
+                                 0)
                                 ("project",
-                                 (project :> obj)) |], "")
+                                 (project :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Ordercontainer
     JsonDocument.Create(jsonValue, "")
@@ -61,7 +64,8 @@ class JsonProvider+Ordercontainer : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Background : FDR.BaseTypes.IJsonDocument
     new : title:JsonProvider+Title -> JsonProvider+Background
     JsonRuntime.CreateRecord([| ("title",
-                                 (title :> obj)) |], "")
+                                 (title :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Background
     JsonDocument.Create(jsonValue, "")
@@ -73,7 +77,8 @@ class JsonProvider+Background : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Backgrounds : FDR.BaseTypes.IJsonDocument
     new : background:JsonProvider+Background -> JsonProvider+Backgrounds
     JsonRuntime.CreateRecord([| ("background",
-                                 (background :> obj)) |], "")
+                                 (background :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Backgrounds
     JsonDocument.Create(jsonValue, "")
@@ -85,7 +90,8 @@ class JsonProvider+Backgrounds : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Title : FDR.BaseTypes.IJsonDocument
     new : text:string -> JsonProvider+Title
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj)) |], "")
+                                 (text :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Title
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,projects.json,False,,,True,False,ValuesOnly.expected
@@ -32,7 +32,8 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : ordercontainer:JsonProvider+Ordercontainer -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("ordercontainer",
-                                 (ordercontainer :> obj)) |], "")
+                                 (ordercontainer :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -44,9 +45,11 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Ordercontainer : FDR.BaseTypes.IJsonDocument
     new : backgrounds:JsonProvider+Backgrounds -> project:JsonProvider+Background -> JsonProvider+Ordercontainer
     JsonRuntime.CreateRecord([| ("backgrounds",
-                                 (backgrounds :> obj))
+                                 (backgrounds :> obj),
+                                 0)
                                 ("project",
-                                 (project :> obj)) |], "")
+                                 (project :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Ordercontainer
     JsonDocument.Create(jsonValue, "")
@@ -61,7 +64,8 @@ class JsonProvider+Ordercontainer : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Background : FDR.BaseTypes.IJsonDocument
     new : title:JsonProvider+Title -> JsonProvider+Background
     JsonRuntime.CreateRecord([| ("title",
-                                 (title :> obj)) |], "")
+                                 (title :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Background
     JsonDocument.Create(jsonValue, "")
@@ -73,7 +77,8 @@ class JsonProvider+Background : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Backgrounds : FDR.BaseTypes.IJsonDocument
     new : background:JsonProvider+Background -> JsonProvider+Backgrounds
     JsonRuntime.CreateRecord([| ("background",
-                                 (background :> obj)) |], "")
+                                 (background :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Backgrounds
     JsonDocument.Create(jsonValue, "")
@@ -85,7 +90,8 @@ class JsonProvider+Backgrounds : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Title : FDR.BaseTypes.IJsonDocument
     new : text:string -> JsonProvider+Title
     JsonRuntime.CreateRecord([| ("text",
-                                 (text :> obj)) |], "")
+                                 (text :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Title
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True,False,BackwardCompatible.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : kind:string -> data:JsonProvider+Data -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("kind",
-                                 (kind :> obj))
+                                 (kind :> obj),
+                                 1)
                                 ("data",
-                                 (data :> obj)) |], "")
+                                 (data :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -50,13 +52,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Data : FDR.BaseTypes.IJsonDocument
     new : modhash:JsonValue -> children:JsonProvider+JsonProvider+Child[] -> after:string -> before:JsonValue -> JsonProvider+Data
     JsonRuntime.CreateRecord([| ("modhash",
-                                 (modhash :> obj))
+                                 (modhash :> obj),
+                                 0)
                                 ("children",
-                                 (children :> obj))
+                                 (children :> obj),
+                                 0)
                                 ("after",
-                                 (after :> obj))
+                                 (after :> obj),
+                                 1)
                                 ("before",
-                                 (before :> obj)) |], "")
+                                 (before :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Data
     JsonDocument.Create(jsonValue, "")
@@ -78,9 +84,11 @@ class JsonProvider+Data : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Child : FDR.BaseTypes.IJsonDocument
     new : kind:string -> data:JsonProvider+Data2 -> JsonProvider+Child
     JsonRuntime.CreateRecord([| ("kind",
-                                 (kind :> obj))
+                                 (kind :> obj),
+                                 1)
                                 ("data",
-                                 (data :> obj)) |], "")
+                                 (data :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Child
     JsonDocument.Create(jsonValue, "")
@@ -96,61 +104,89 @@ class JsonProvider+Child : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Data2 : FDR.BaseTypes.IJsonDocument
     new : subredditId:string -> linkTitle:string -> bannedBy:JsonValue -> subreddit:string -> linkAuthor:string -> likes:JsonValue -> replies:JsonValue -> saved:bool -> id:string -> gilded:int -> author:string -> parentId:string -> approvedBy:JsonValue -> body:string -> edited:bool -> authorFlairCssClass:JsonValue -> downs:int -> bodyHtml:string -> linkId:string -> scoreHidden:bool -> name:string -> created:int -> authorFlairText:JsonValue -> linkUrl:string -> createdUtc:int -> ups:int -> numReports:JsonValue -> distinguished:JsonValue -> JsonProvider+Data2
     JsonRuntime.CreateRecord([| ("subreddit_id",
-                                 (subredditId :> obj))
+                                 (subredditId :> obj),
+                                 1)
                                 ("link_title",
-                                 (linkTitle :> obj))
+                                 (linkTitle :> obj),
+                                 1)
                                 ("banned_by",
-                                 (bannedBy :> obj))
+                                 (bannedBy :> obj),
+                                 0)
                                 ("subreddit",
-                                 (subreddit :> obj))
+                                 (subreddit :> obj),
+                                 1)
                                 ("link_author",
-                                 (linkAuthor :> obj))
+                                 (linkAuthor :> obj),
+                                 1)
                                 ("likes",
-                                 (likes :> obj))
+                                 (likes :> obj),
+                                 0)
                                 ("replies",
-                                 (replies :> obj))
+                                 (replies :> obj),
+                                 0)
                                 ("saved",
-                                 (saved :> obj))
+                                 (saved :> obj),
+                                 3)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("gilded",
-                                 (gilded :> obj))
+                                 (gilded :> obj),
+                                 2)
                                 ("author",
-                                 (author :> obj))
+                                 (author :> obj),
+                                 1)
                                 ("parent_id",
-                                 (parentId :> obj))
+                                 (parentId :> obj),
+                                 1)
                                 ("approved_by",
-                                 (approvedBy :> obj))
+                                 (approvedBy :> obj),
+                                 0)
                                 ("body",
-                                 (body :> obj))
+                                 (body :> obj),
+                                 1)
                                 ("edited",
-                                 (edited :> obj))
+                                 (edited :> obj),
+                                 3)
                                 ("author_flair_css_class",
-                                 (authorFlairCssClass :> obj))
+                                 (authorFlairCssClass :> obj),
+                                 0)
                                 ("downs",
-                                 (downs :> obj))
+                                 (downs :> obj),
+                                 2)
                                 ("body_html",
-                                 (bodyHtml :> obj))
+                                 (bodyHtml :> obj),
+                                 1)
                                 ("link_id",
-                                 (linkId :> obj))
+                                 (linkId :> obj),
+                                 1)
                                 ("score_hidden",
-                                 (scoreHidden :> obj))
+                                 (scoreHidden :> obj),
+                                 3)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("created",
-                                 (created :> obj))
+                                 (created :> obj),
+                                 2)
                                 ("author_flair_text",
-                                 (authorFlairText :> obj))
+                                 (authorFlairText :> obj),
+                                 0)
                                 ("link_url",
-                                 (linkUrl :> obj))
+                                 (linkUrl :> obj),
+                                 1)
                                 ("created_utc",
-                                 (createdUtc :> obj))
+                                 (createdUtc :> obj),
+                                 2)
                                 ("ups",
-                                 (ups :> obj))
+                                 (ups :> obj),
+                                 2)
                                 ("num_reports",
-                                 (numReports :> obj))
+                                 (numReports :> obj),
+                                 0)
                                 ("distinguished",
-                                 (distinguished :> obj)) |], "")
+                                 (distinguished :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Data2
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True,False,ValuesAndInlineSchemasHints.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : kind:string -> data:JsonProvider+Data -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("kind",
-                                 (kind :> obj))
+                                 (kind :> obj),
+                                 1)
                                 ("data",
-                                 (data :> obj)) |], "")
+                                 (data :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -50,13 +52,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Data : FDR.BaseTypes.IJsonDocument
     new : modhash:JsonValue -> children:JsonProvider+JsonProvider+Child[] -> after:string -> before:JsonValue -> JsonProvider+Data
     JsonRuntime.CreateRecord([| ("modhash",
-                                 (modhash :> obj))
+                                 (modhash :> obj),
+                                 0)
                                 ("children",
-                                 (children :> obj))
+                                 (children :> obj),
+                                 0)
                                 ("after",
-                                 (after :> obj))
+                                 (after :> obj),
+                                 1)
                                 ("before",
-                                 (before :> obj)) |], "")
+                                 (before :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Data
     JsonDocument.Create(jsonValue, "")
@@ -78,9 +84,11 @@ class JsonProvider+Data : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Child : FDR.BaseTypes.IJsonDocument
     new : kind:string -> data:JsonProvider+Data2 -> JsonProvider+Child
     JsonRuntime.CreateRecord([| ("kind",
-                                 (kind :> obj))
+                                 (kind :> obj),
+                                 1)
                                 ("data",
-                                 (data :> obj)) |], "")
+                                 (data :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Child
     JsonDocument.Create(jsonValue, "")
@@ -96,61 +104,89 @@ class JsonProvider+Child : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Data2 : FDR.BaseTypes.IJsonDocument
     new : subredditId:string -> linkTitle:string -> bannedBy:JsonValue -> subreddit:string -> linkAuthor:string -> likes:JsonValue -> replies:JsonValue -> saved:bool -> id:string -> gilded:int -> author:string -> parentId:string -> approvedBy:JsonValue -> body:string -> edited:bool -> authorFlairCssClass:JsonValue -> downs:int -> bodyHtml:string -> linkId:string -> scoreHidden:bool -> name:string -> created:int -> authorFlairText:JsonValue -> linkUrl:string -> createdUtc:int -> ups:int -> numReports:JsonValue -> distinguished:JsonValue -> JsonProvider+Data2
     JsonRuntime.CreateRecord([| ("subreddit_id",
-                                 (subredditId :> obj))
+                                 (subredditId :> obj),
+                                 1)
                                 ("link_title",
-                                 (linkTitle :> obj))
+                                 (linkTitle :> obj),
+                                 1)
                                 ("banned_by",
-                                 (bannedBy :> obj))
+                                 (bannedBy :> obj),
+                                 0)
                                 ("subreddit",
-                                 (subreddit :> obj))
+                                 (subreddit :> obj),
+                                 1)
                                 ("link_author",
-                                 (linkAuthor :> obj))
+                                 (linkAuthor :> obj),
+                                 1)
                                 ("likes",
-                                 (likes :> obj))
+                                 (likes :> obj),
+                                 0)
                                 ("replies",
-                                 (replies :> obj))
+                                 (replies :> obj),
+                                 0)
                                 ("saved",
-                                 (saved :> obj))
+                                 (saved :> obj),
+                                 3)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("gilded",
-                                 (gilded :> obj))
+                                 (gilded :> obj),
+                                 2)
                                 ("author",
-                                 (author :> obj))
+                                 (author :> obj),
+                                 1)
                                 ("parent_id",
-                                 (parentId :> obj))
+                                 (parentId :> obj),
+                                 1)
                                 ("approved_by",
-                                 (approvedBy :> obj))
+                                 (approvedBy :> obj),
+                                 0)
                                 ("body",
-                                 (body :> obj))
+                                 (body :> obj),
+                                 1)
                                 ("edited",
-                                 (edited :> obj))
+                                 (edited :> obj),
+                                 3)
                                 ("author_flair_css_class",
-                                 (authorFlairCssClass :> obj))
+                                 (authorFlairCssClass :> obj),
+                                 0)
                                 ("downs",
-                                 (downs :> obj))
+                                 (downs :> obj),
+                                 2)
                                 ("body_html",
-                                 (bodyHtml :> obj))
+                                 (bodyHtml :> obj),
+                                 1)
                                 ("link_id",
-                                 (linkId :> obj))
+                                 (linkId :> obj),
+                                 1)
                                 ("score_hidden",
-                                 (scoreHidden :> obj))
+                                 (scoreHidden :> obj),
+                                 3)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("created",
-                                 (created :> obj))
+                                 (created :> obj),
+                                 2)
                                 ("author_flair_text",
-                                 (authorFlairText :> obj))
+                                 (authorFlairText :> obj),
+                                 0)
                                 ("link_url",
-                                 (linkUrl :> obj))
+                                 (linkUrl :> obj),
+                                 1)
                                 ("created_utc",
-                                 (createdUtc :> obj))
+                                 (createdUtc :> obj),
+                                 2)
                                 ("ups",
-                                 (ups :> obj))
+                                 (ups :> obj),
+                                 2)
                                 ("num_reports",
-                                 (numReports :> obj))
+                                 (numReports :> obj),
+                                 0)
                                 ("distinguished",
-                                 (distinguished :> obj)) |], "")
+                                 (distinguished :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Data2
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : kind:string -> data:JsonProvider+Data -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("kind",
-                                 (kind :> obj))
+                                 (kind :> obj),
+                                 1)
                                 ("data",
-                                 (data :> obj)) |], "")
+                                 (data :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -50,13 +52,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Data : FDR.BaseTypes.IJsonDocument
     new : modhash:JsonValue -> children:JsonProvider+JsonProvider+Child[] -> after:string -> before:JsonValue -> JsonProvider+Data
     JsonRuntime.CreateRecord([| ("modhash",
-                                 (modhash :> obj))
+                                 (modhash :> obj),
+                                 0)
                                 ("children",
-                                 (children :> obj))
+                                 (children :> obj),
+                                 0)
                                 ("after",
-                                 (after :> obj))
+                                 (after :> obj),
+                                 1)
                                 ("before",
-                                 (before :> obj)) |], "")
+                                 (before :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Data
     JsonDocument.Create(jsonValue, "")
@@ -78,9 +84,11 @@ class JsonProvider+Data : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Child : FDR.BaseTypes.IJsonDocument
     new : kind:string -> data:JsonProvider+Data2 -> JsonProvider+Child
     JsonRuntime.CreateRecord([| ("kind",
-                                 (kind :> obj))
+                                 (kind :> obj),
+                                 1)
                                 ("data",
-                                 (data :> obj)) |], "")
+                                 (data :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Child
     JsonDocument.Create(jsonValue, "")
@@ -96,61 +104,89 @@ class JsonProvider+Child : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Data2 : FDR.BaseTypes.IJsonDocument
     new : subredditId:string -> linkTitle:string -> bannedBy:JsonValue -> subreddit:string -> linkAuthor:string -> likes:JsonValue -> replies:JsonValue -> saved:bool -> id:string -> gilded:int -> author:string -> parentId:string -> approvedBy:JsonValue -> body:string -> edited:bool -> authorFlairCssClass:JsonValue -> downs:int -> bodyHtml:string -> linkId:string -> scoreHidden:bool -> name:string -> created:int -> authorFlairText:JsonValue -> linkUrl:string -> createdUtc:int -> ups:int -> numReports:JsonValue -> distinguished:JsonValue -> JsonProvider+Data2
     JsonRuntime.CreateRecord([| ("subreddit_id",
-                                 (subredditId :> obj))
+                                 (subredditId :> obj),
+                                 1)
                                 ("link_title",
-                                 (linkTitle :> obj))
+                                 (linkTitle :> obj),
+                                 1)
                                 ("banned_by",
-                                 (bannedBy :> obj))
+                                 (bannedBy :> obj),
+                                 0)
                                 ("subreddit",
-                                 (subreddit :> obj))
+                                 (subreddit :> obj),
+                                 1)
                                 ("link_author",
-                                 (linkAuthor :> obj))
+                                 (linkAuthor :> obj),
+                                 1)
                                 ("likes",
-                                 (likes :> obj))
+                                 (likes :> obj),
+                                 0)
                                 ("replies",
-                                 (replies :> obj))
+                                 (replies :> obj),
+                                 0)
                                 ("saved",
-                                 (saved :> obj))
+                                 (saved :> obj),
+                                 3)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("gilded",
-                                 (gilded :> obj))
+                                 (gilded :> obj),
+                                 2)
                                 ("author",
-                                 (author :> obj))
+                                 (author :> obj),
+                                 1)
                                 ("parent_id",
-                                 (parentId :> obj))
+                                 (parentId :> obj),
+                                 1)
                                 ("approved_by",
-                                 (approvedBy :> obj))
+                                 (approvedBy :> obj),
+                                 0)
                                 ("body",
-                                 (body :> obj))
+                                 (body :> obj),
+                                 1)
                                 ("edited",
-                                 (edited :> obj))
+                                 (edited :> obj),
+                                 3)
                                 ("author_flair_css_class",
-                                 (authorFlairCssClass :> obj))
+                                 (authorFlairCssClass :> obj),
+                                 0)
                                 ("downs",
-                                 (downs :> obj))
+                                 (downs :> obj),
+                                 2)
                                 ("body_html",
-                                 (bodyHtml :> obj))
+                                 (bodyHtml :> obj),
+                                 1)
                                 ("link_id",
-                                 (linkId :> obj))
+                                 (linkId :> obj),
+                                 1)
                                 ("score_hidden",
-                                 (scoreHidden :> obj))
+                                 (scoreHidden :> obj),
+                                 3)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("created",
-                                 (created :> obj))
+                                 (created :> obj),
+                                 2)
                                 ("author_flair_text",
-                                 (authorFlairText :> obj))
+                                 (authorFlairText :> obj),
+                                 0)
                                 ("link_url",
-                                 (linkUrl :> obj))
+                                 (linkUrl :> obj),
+                                 1)
                                 ("created_utc",
-                                 (createdUtc :> obj))
+                                 (createdUtc :> obj),
+                                 2)
                                 ("ups",
-                                 (ups :> obj))
+                                 (ups :> obj),
+                                 2)
                                 ("num_reports",
-                                 (numReports :> obj))
+                                 (numReports :> obj),
+                                 0)
                                 ("distinguished",
-                                 (distinguished :> obj)) |], "")
+                                 (distinguished :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Data2
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,reddit.json,False,,,True,False,ValuesOnly.expected
@@ -32,9 +32,11 @@ class JsonProvider : obj
 class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
     new : kind:string -> data:JsonProvider+Data -> JsonProvider+Root
     JsonRuntime.CreateRecord([| ("kind",
-                                 (kind :> obj))
+                                 (kind :> obj),
+                                 1)
                                 ("data",
-                                 (data :> obj)) |], "")
+                                 (data :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Root
     JsonDocument.Create(jsonValue, "")
@@ -50,13 +52,17 @@ class JsonProvider+Root : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Data : FDR.BaseTypes.IJsonDocument
     new : modhash:JsonValue -> children:JsonProvider+JsonProvider+Child[] -> after:string -> before:JsonValue -> JsonProvider+Data
     JsonRuntime.CreateRecord([| ("modhash",
-                                 (modhash :> obj))
+                                 (modhash :> obj),
+                                 0)
                                 ("children",
-                                 (children :> obj))
+                                 (children :> obj),
+                                 0)
                                 ("after",
-                                 (after :> obj))
+                                 (after :> obj),
+                                 1)
                                 ("before",
-                                 (before :> obj)) |], "")
+                                 (before :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Data
     JsonDocument.Create(jsonValue, "")
@@ -78,9 +84,11 @@ class JsonProvider+Data : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Child : FDR.BaseTypes.IJsonDocument
     new : kind:string -> data:JsonProvider+Data2 -> JsonProvider+Child
     JsonRuntime.CreateRecord([| ("kind",
-                                 (kind :> obj))
+                                 (kind :> obj),
+                                 1)
                                 ("data",
-                                 (data :> obj)) |], "")
+                                 (data :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Child
     JsonDocument.Create(jsonValue, "")
@@ -96,61 +104,89 @@ class JsonProvider+Child : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Data2 : FDR.BaseTypes.IJsonDocument
     new : subredditId:string -> linkTitle:string -> bannedBy:JsonValue -> subreddit:string -> linkAuthor:string -> likes:JsonValue -> replies:JsonValue -> saved:bool -> id:string -> gilded:int -> author:string -> parentId:string -> approvedBy:JsonValue -> body:string -> edited:bool -> authorFlairCssClass:JsonValue -> downs:int -> bodyHtml:string -> linkId:string -> scoreHidden:bool -> name:string -> created:int -> authorFlairText:JsonValue -> linkUrl:string -> createdUtc:int -> ups:int -> numReports:JsonValue -> distinguished:JsonValue -> JsonProvider+Data2
     JsonRuntime.CreateRecord([| ("subreddit_id",
-                                 (subredditId :> obj))
+                                 (subredditId :> obj),
+                                 1)
                                 ("link_title",
-                                 (linkTitle :> obj))
+                                 (linkTitle :> obj),
+                                 1)
                                 ("banned_by",
-                                 (bannedBy :> obj))
+                                 (bannedBy :> obj),
+                                 0)
                                 ("subreddit",
-                                 (subreddit :> obj))
+                                 (subreddit :> obj),
+                                 1)
                                 ("link_author",
-                                 (linkAuthor :> obj))
+                                 (linkAuthor :> obj),
+                                 1)
                                 ("likes",
-                                 (likes :> obj))
+                                 (likes :> obj),
+                                 0)
                                 ("replies",
-                                 (replies :> obj))
+                                 (replies :> obj),
+                                 0)
                                 ("saved",
-                                 (saved :> obj))
+                                 (saved :> obj),
+                                 3)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 1)
                                 ("gilded",
-                                 (gilded :> obj))
+                                 (gilded :> obj),
+                                 2)
                                 ("author",
-                                 (author :> obj))
+                                 (author :> obj),
+                                 1)
                                 ("parent_id",
-                                 (parentId :> obj))
+                                 (parentId :> obj),
+                                 1)
                                 ("approved_by",
-                                 (approvedBy :> obj))
+                                 (approvedBy :> obj),
+                                 0)
                                 ("body",
-                                 (body :> obj))
+                                 (body :> obj),
+                                 1)
                                 ("edited",
-                                 (edited :> obj))
+                                 (edited :> obj),
+                                 3)
                                 ("author_flair_css_class",
-                                 (authorFlairCssClass :> obj))
+                                 (authorFlairCssClass :> obj),
+                                 0)
                                 ("downs",
-                                 (downs :> obj))
+                                 (downs :> obj),
+                                 2)
                                 ("body_html",
-                                 (bodyHtml :> obj))
+                                 (bodyHtml :> obj),
+                                 1)
                                 ("link_id",
-                                 (linkId :> obj))
+                                 (linkId :> obj),
+                                 1)
                                 ("score_hidden",
-                                 (scoreHidden :> obj))
+                                 (scoreHidden :> obj),
+                                 3)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("created",
-                                 (created :> obj))
+                                 (created :> obj),
+                                 2)
                                 ("author_flair_text",
-                                 (authorFlairText :> obj))
+                                 (authorFlairText :> obj),
+                                 0)
                                 ("link_url",
-                                 (linkUrl :> obj))
+                                 (linkUrl :> obj),
+                                 1)
                                 ("created_utc",
-                                 (createdUtc :> obj))
+                                 (createdUtc :> obj),
+                                 2)
                                 ("ups",
-                                 (ups :> obj))
+                                 (ups :> obj),
+                                 2)
                                 ("num_reports",
-                                 (numReports :> obj))
+                                 (numReports :> obj),
+                                 0)
                                 ("distinguished",
-                                 (distinguished :> obj)) |], "")
+                                 (distinguished :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Data2
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True,False,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True,False,BackwardCompatible.expected
@@ -25,51 +25,74 @@ class JsonProvider : obj
 class JsonProvider+Topic : FDR.BaseTypes.IJsonDocument
     new : photo:string -> previewLink:string option -> smallIconHover:string -> largeIcon:string -> video:string option -> universityIds:string[] -> id:int -> universities:JsonProvider+JsonProvider+University[] -> selfServiceCourseId:int option -> shortDescription:string -> shortName:string -> categoryIds:string[] -> visibility:int option -> smallIcon:string -> instructor:string option -> categories:JsonProvider+JsonProvider+Category[] -> name:string -> language:string -> courses:JsonProvider+JsonProvider+Course[] -> universityLogo:string option -> courseIds:int[] -> display:bool -> subtitleLanguagesCsv:string option -> JsonProvider+Topic
     JsonRuntime.CreateRecord([| ("photo",
-                                 (photo :> obj))
+                                 (photo :> obj),
+                                 1)
                                 ("preview_link",
-                                 (previewLink :> obj))
+                                 (previewLink :> obj),
+                                 1)
                                 ("small_icon_hover",
-                                 (smallIconHover :> obj))
+                                 (smallIconHover :> obj),
+                                 1)
                                 ("large_icon",
-                                 (largeIcon :> obj))
+                                 (largeIcon :> obj),
+                                 1)
                                 ("video",
-                                 (video :> obj))
+                                 (video :> obj),
+                                 1)
                                 ("university-ids",
-                                 (universityIds :> obj))
+                                 (universityIds :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("universities",
-                                 (universities :> obj))
+                                 (universities :> obj),
+                                 0)
                                 ("self_service_course_id",
-                                 (selfServiceCourseId :> obj))
+                                 (selfServiceCourseId :> obj),
+                                 2)
                                 ("short_description",
-                                 (shortDescription :> obj))
+                                 (shortDescription :> obj),
+                                 1)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("category-ids",
-                                 (categoryIds :> obj))
+                                 (categoryIds :> obj),
+                                 1)
                                 ("visibility",
-                                 (visibility :> obj))
+                                 (visibility :> obj),
+                                 2)
                                 ("small_icon",
-                                 (smallIcon :> obj))
+                                 (smallIcon :> obj),
+                                 1)
                                 ("instructor",
-                                 (instructor :> obj))
+                                 (instructor :> obj),
+                                 1)
                                 ("categories",
-                                 (categories :> obj))
+                                 (categories :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("language",
-                                 (language :> obj))
+                                 (language :> obj),
+                                 1)
                                 ("courses",
-                                 (courses :> obj))
+                                 (courses :> obj),
+                                 0)
                                 ("university_logo",
-                                 (universityLogo :> obj))
+                                 (universityLogo :> obj),
+                                 1)
                                 ("course-ids",
-                                 (courseIds :> obj))
+                                 (courseIds :> obj),
+                                 2)
                                 ("display",
-                                 (display :> obj))
+                                 (display :> obj),
+                                 3)
                                 ("subtitle_languages_csv",
-                                 (subtitleLanguagesCsv :> obj)) |], "")
+                                 (subtitleLanguagesCsv :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Topic
     JsonDocument.Create(jsonValue, "")
@@ -157,15 +180,20 @@ class JsonProvider+Topic : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Category : FDR.BaseTypes.IJsonDocument
     new : id:int -> name:string -> mailingListId:int option -> shortName:string -> description:string option -> JsonProvider+Category
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("mailing_list_id",
-                                 (mailingListId :> obj))
+                                 (mailingListId :> obj),
+                                 2)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj)) |], "")
+                                 (description :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Category
     JsonDocument.Create(jsonValue, "")
@@ -192,95 +220,140 @@ class JsonProvider+Category : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Course : FDR.BaseTypes.IJsonDocument
     new : gradingPolicyDistinction:string option -> aceTrackPriceDisplay:JsonValue -> signatureTrackCertificateDesignId:JsonValue -> aceSemesterHours:JsonValue -> startDay:int option -> durationString:string option -> signatureTrackLastChanceTime:System.DateTime option -> id:int -> startMonth:int option -> certificateDescription:string option -> startDateString:JsonProvider+StringOrDateTime -> cheggSessionId:JsonValue -> signatureTrackRegularPrice:int option -> gradesReleaseDate:System.DateTime option -> certificatesReady:bool -> signatureTrackPrice:int option -> statementDesignId:int option -> signatureTrackRegistrationOpen:bool -> topicId:int -> eligibleForSignatureTrack:bool -> startDate:System.DateTime option -> record:JsonProvider+Record -> status:bool -> startYear:int option -> signatureTrackCertificateCombinedSignature:JsonValue -> endDate:JsonValue -> notifiedSubscribers:bool -> instructors:int[] -> active:bool -> eligibleForCertificates:bool -> signatureTrackCertificateSignatureBlurb:JsonValue -> deployed:bool -> aceCloseDate:JsonValue -> name:JsonProvider+IntOrString -> textbooks:JsonValue[] -> signatureTrackOpenTime:System.DateTime option -> eligibleForAce:bool option -> gradingPolicyNormal:string option -> aceOpenDate:JsonValue -> homeLink:string option -> creatorId:int option -> proctoredExamCompletionDate:JsonValue -> universityLogo:JsonValue -> signatureTrackCloseTime:System.DateTime option -> authReviewCompletionDate:JsonValue -> JsonProvider+Course
     JsonRuntime.CreateRecord([| ("grading_policy_distinction",
-                                 (gradingPolicyDistinction :> obj))
+                                 (gradingPolicyDistinction :> obj),
+                                 1)
                                 ("ace_track_price_display",
-                                 (aceTrackPriceDisplay :> obj))
+                                 (aceTrackPriceDisplay :> obj),
+                                 0)
                                 ("signature_track_certificate_design_id",
-                                 (signatureTrackCertificateDesignId :> obj))
+                                 (signatureTrackCertificateDesignId :> obj),
+                                 0)
                                 ("ace_semester_hours",
-                                 (aceSemesterHours :> obj))
+                                 (aceSemesterHours :> obj),
+                                 0)
                                 ("start_day",
-                                 (startDay :> obj))
+                                 (startDay :> obj),
+                                 2)
                                 ("duration_string",
-                                 (durationString :> obj))
+                                 (durationString :> obj),
+                                 1)
                                 ("signature_track_last_chance_time",
-                                 (signatureTrackLastChanceTime :> obj))
+                                 (signatureTrackLastChanceTime :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("start_month",
-                                 (startMonth :> obj))
+                                 (startMonth :> obj),
+                                 2)
                                 ("certificate_description",
-                                 (certificateDescription :> obj))
+                                 (certificateDescription :> obj),
+                                 1)
                                 ("start_date_string",
-                                 (startDateString :> obj))
+                                 (startDateString :> obj),
+                                 0)
                                 ("chegg_session_id",
-                                 (cheggSessionId :> obj))
+                                 (cheggSessionId :> obj),
+                                 0)
                                 ("signature_track_regular_price",
-                                 (signatureTrackRegularPrice :> obj))
+                                 (signatureTrackRegularPrice :> obj),
+                                 2)
                                 ("grades_release_date",
-                                 (gradesReleaseDate :> obj))
+                                 (gradesReleaseDate :> obj),
+                                 1)
                                 ("certificates_ready",
-                                 (certificatesReady :> obj))
+                                 (certificatesReady :> obj),
+                                 3)
                                 ("signature_track_price",
-                                 (signatureTrackPrice :> obj))
+                                 (signatureTrackPrice :> obj),
+                                 2)
                                 ("statement_design_id",
-                                 (statementDesignId :> obj))
+                                 (statementDesignId :> obj),
+                                 2)
                                 ("signature_track_registration_open",
-                                 (signatureTrackRegistrationOpen :> obj))
+                                 (signatureTrackRegistrationOpen :> obj),
+                                 3)
                                 ("topic_id",
-                                 (topicId :> obj))
+                                 (topicId :> obj),
+                                 2)
                                 ("eligible_for_signature_track",
-                                 (eligibleForSignatureTrack :> obj))
+                                 (eligibleForSignatureTrack :> obj),
+                                 3)
                                 ("start_date",
-                                 (startDate :> obj))
+                                 (startDate :> obj),
+                                 1)
                                 ("record",
-                                 (record :> obj))
+                                 (record :> obj),
+                                 0)
                                 ("status",
-                                 (status :> obj))
+                                 (status :> obj),
+                                 2)
                                 ("start_year",
-                                 (startYear :> obj))
+                                 (startYear :> obj),
+                                 2)
                                 ("signature_track_certificate_combined_signature",
-                                 (signatureTrackCertificateCombinedSignature :> obj))
+                                 (signatureTrackCertificateCombinedSignature :> obj),
+                                 0)
                                 ("end_date",
-                                 (endDate :> obj))
+                                 (endDate :> obj),
+                                 0)
                                 ("notified_subscribers",
-                                 (notifiedSubscribers :> obj))
+                                 (notifiedSubscribers :> obj),
+                                 3)
                                 ("instructors",
-                                 (instructors :> obj))
+                                 (instructors :> obj),
+                                 2)
                                 ("active",
-                                 (active :> obj))
+                                 (active :> obj),
+                                 3)
                                 ("eligible_for_certificates",
-                                 (eligibleForCertificates :> obj))
+                                 (eligibleForCertificates :> obj),
+                                 3)
                                 ("signature_track_certificate_signature_blurb",
-                                 (signatureTrackCertificateSignatureBlurb :> obj))
+                                 (signatureTrackCertificateSignatureBlurb :> obj),
+                                 0)
                                 ("deployed",
-                                 (deployed :> obj))
+                                 (deployed :> obj),
+                                 3)
                                 ("ace_close_date",
-                                 (aceCloseDate :> obj))
+                                 (aceCloseDate :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 0)
                                 ("textbooks",
-                                 (textbooks :> obj))
+                                 (textbooks :> obj),
+                                 0)
                                 ("signature_track_open_time",
-                                 (signatureTrackOpenTime :> obj))
+                                 (signatureTrackOpenTime :> obj),
+                                 1)
                                 ("eligible_for_ACE",
-                                 (eligibleForAce :> obj))
+                                 (eligibleForAce :> obj),
+                                 3)
                                 ("grading_policy_normal",
-                                 (gradingPolicyNormal :> obj))
+                                 (gradingPolicyNormal :> obj),
+                                 1)
                                 ("ace_open_date",
-                                 (aceOpenDate :> obj))
+                                 (aceOpenDate :> obj),
+                                 0)
                                 ("home_link",
-                                 (homeLink :> obj))
+                                 (homeLink :> obj),
+                                 1)
                                 ("creator_id",
-                                 (creatorId :> obj))
+                                 (creatorId :> obj),
+                                 2)
                                 ("proctored_exam_completion_date",
-                                 (proctoredExamCompletionDate :> obj))
+                                 (proctoredExamCompletionDate :> obj),
+                                 0)
                                 ("university_logo",
-                                 (universityLogo :> obj))
+                                 (universityLogo :> obj),
+                                 0)
                                 ("signature_track_close_time",
-                                 (signatureTrackCloseTime :> obj))
+                                 (signatureTrackCloseTime :> obj),
+                                 1)
                                 ("auth_review_completion_date",
-                                 (authReviewCompletionDate :> obj)) |], "")
+                                 (authReviewCompletionDate :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Course
     JsonDocument.Create(jsonValue, "")
@@ -434,69 +507,101 @@ class JsonProvider+Course : FDR.BaseTypes.IJsonDocument
 class JsonProvider+University : FDR.BaseTypes.IJsonDocument
     new : rectangularLogoSvg:string option -> wordmark:JsonValue -> websiteTwitter:string option -> chinaMirror:int option -> favicon:string option -> websiteFacebook:string option -> logo:string option -> backgroundColor:JsonValue -> id:int -> locationCity:string option -> locationCountry:string option -> locationLat:decimal option -> location:string option -> primaryColor:string option -> abbrName:string -> website:string option -> description:string option -> shortName:string -> landingPageBanner:string option -> mailingListId:JsonValue -> websiteYoutube:string option -> partnerType:int -> banner:string option -> locationState:string option -> name:string -> squareLogo:string option -> squareLogoSource:string option -> squareLogoSvg:string option -> locationLng:decimal option -> homeLink:string option -> classLogo:string option -> display:bool -> JsonProvider+University
     JsonRuntime.CreateRecord([| ("rectangular_logo_svg",
-                                 (rectangularLogoSvg :> obj))
+                                 (rectangularLogoSvg :> obj),
+                                 1)
                                 ("wordmark",
-                                 (wordmark :> obj))
+                                 (wordmark :> obj),
+                                 0)
                                 ("website_twitter",
-                                 (websiteTwitter :> obj))
+                                 (websiteTwitter :> obj),
+                                 1)
                                 ("china_mirror",
-                                 (chinaMirror :> obj))
+                                 (chinaMirror :> obj),
+                                 2)
                                 ("favicon",
-                                 (favicon :> obj))
+                                 (favicon :> obj),
+                                 1)
                                 ("website_facebook",
-                                 (websiteFacebook :> obj))
+                                 (websiteFacebook :> obj),
+                                 1)
                                 ("logo",
-                                 (logo :> obj))
+                                 (logo :> obj),
+                                 1)
                                 ("background_color",
-                                 (backgroundColor :> obj))
+                                 (backgroundColor :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("location_city",
-                                 (locationCity :> obj))
+                                 (locationCity :> obj),
+                                 1)
                                 ("location_country",
-                                 (locationCountry :> obj))
+                                 (locationCountry :> obj),
+                                 1)
                                 ("location_lat",
-                                 (locationLat :> obj))
+                                 (locationLat :> obj),
+                                 2)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("primary_color",
-                                 (primaryColor :> obj))
+                                 (primaryColor :> obj),
+                                 1)
                                 ("abbr_name",
-                                 (abbrName :> obj))
+                                 (abbrName :> obj),
+                                 1)
                                 ("website",
-                                 (website :> obj))
+                                 (website :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("landing_page_banner",
-                                 (landingPageBanner :> obj))
+                                 (landingPageBanner :> obj),
+                                 1)
                                 ("mailing_list_id",
-                                 (mailingListId :> obj))
+                                 (mailingListId :> obj),
+                                 0)
                                 ("website_youtube",
-                                 (websiteYoutube :> obj))
+                                 (websiteYoutube :> obj),
+                                 1)
                                 ("partner_type",
-                                 (partnerType :> obj))
+                                 (partnerType :> obj),
+                                 2)
                                 ("banner",
-                                 (banner :> obj))
+                                 (banner :> obj),
+                                 1)
                                 ("location_state",
-                                 (locationState :> obj))
+                                 (locationState :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("square_logo",
-                                 (squareLogo :> obj))
+                                 (squareLogo :> obj),
+                                 1)
                                 ("square_logo_source",
-                                 (squareLogoSource :> obj))
+                                 (squareLogoSource :> obj),
+                                 1)
                                 ("square_logo_svg",
-                                 (squareLogoSvg :> obj))
+                                 (squareLogoSvg :> obj),
+                                 1)
                                 ("location_lng",
-                                 (locationLng :> obj))
+                                 (locationLng :> obj),
+                                 2)
                                 ("home_link",
-                                 (homeLink :> obj))
+                                 (homeLink :> obj),
+                                 1)
                                 ("class_logo",
-                                 (classLogo :> obj))
+                                 (classLogo :> obj),
+                                 1)
                                 ("display",
-                                 (display :> obj)) |], "")
+                                 (display :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+University
     JsonDocument.Create(jsonValue, "")
@@ -627,27 +732,38 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
     new : gradeDistinction:decimal option -> shareForWork:bool option -> isEnrolledForProctoredExam:bool -> achievementLevel:int option -> signatureTrack:bool -> passedAce:bool -> aceGrade:int -> gradeNormal:decimal option -> verifyCertId:JsonValue -> authenticatedOverall:bool -> withGradeCertId:JsonValue -> JsonProvider+Record
     JsonRuntime.CreateRecord([| ("grade_distinction",
-                                 (gradeDistinction :> obj))
+                                 (gradeDistinction :> obj),
+                                 2)
                                 ("share_for_work",
-                                 (shareForWork :> obj))
+                                 (shareForWork :> obj),
+                                 3)
                                 ("is_enrolled_for_proctored_exam",
-                                 (isEnrolledForProctoredExam :> obj))
+                                 (isEnrolledForProctoredExam :> obj),
+                                 3)
                                 ("achievement_level",
-                                 (achievementLevel :> obj))
+                                 (achievementLevel :> obj),
+                                 2)
                                 ("signature_track",
-                                 (signatureTrack :> obj))
+                                 (signatureTrack :> obj),
+                                 3)
                                 ("passed_ace",
-                                 (passedAce :> obj))
+                                 (passedAce :> obj),
+                                 3)
                                 ("ace_grade",
-                                 (aceGrade :> obj))
+                                 (aceGrade :> obj),
+                                 2)
                                 ("grade_normal",
-                                 (gradeNormal :> obj))
+                                 (gradeNormal :> obj),
+                                 2)
                                 ("verify_cert_id",
-                                 (verifyCertId :> obj))
+                                 (verifyCertId :> obj),
+                                 0)
                                 ("authenticated_overall",
-                                 (authenticatedOverall :> obj))
+                                 (authenticatedOverall :> obj),
+                                 3)
                                 ("with_grade_cert_id",
-                                 (withGradeCertId :> obj)) |], "")
+                                 (withGradeCertId :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True,False,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True,False,ValuesAndInlineSchemasHints.expected
@@ -25,51 +25,74 @@ class JsonProvider : obj
 class JsonProvider+Topic : FDR.BaseTypes.IJsonDocument
     new : photo:string -> previewLink:string option -> smallIconHover:string -> largeIcon:string -> video:string option -> universityIds:string[] -> id:int -> universities:JsonProvider+JsonProvider+University[] -> selfServiceCourseId:int option -> shortDescription:string -> shortName:string -> categoryIds:string[] -> visibility:int option -> smallIcon:string -> instructor:string option -> categories:JsonProvider+JsonProvider+Category[] -> name:string -> language:string -> courses:JsonProvider+JsonProvider+Course[] -> universityLogo:string option -> courseIds:int[] -> display:bool -> subtitleLanguagesCsv:string option -> JsonProvider+Topic
     JsonRuntime.CreateRecord([| ("photo",
-                                 (photo :> obj))
+                                 (photo :> obj),
+                                 1)
                                 ("preview_link",
-                                 (previewLink :> obj))
+                                 (previewLink :> obj),
+                                 1)
                                 ("small_icon_hover",
-                                 (smallIconHover :> obj))
+                                 (smallIconHover :> obj),
+                                 1)
                                 ("large_icon",
-                                 (largeIcon :> obj))
+                                 (largeIcon :> obj),
+                                 1)
                                 ("video",
-                                 (video :> obj))
+                                 (video :> obj),
+                                 1)
                                 ("university-ids",
-                                 (universityIds :> obj))
+                                 (universityIds :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("universities",
-                                 (universities :> obj))
+                                 (universities :> obj),
+                                 0)
                                 ("self_service_course_id",
-                                 (selfServiceCourseId :> obj))
+                                 (selfServiceCourseId :> obj),
+                                 2)
                                 ("short_description",
-                                 (shortDescription :> obj))
+                                 (shortDescription :> obj),
+                                 1)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("category-ids",
-                                 (categoryIds :> obj))
+                                 (categoryIds :> obj),
+                                 1)
                                 ("visibility",
-                                 (visibility :> obj))
+                                 (visibility :> obj),
+                                 2)
                                 ("small_icon",
-                                 (smallIcon :> obj))
+                                 (smallIcon :> obj),
+                                 1)
                                 ("instructor",
-                                 (instructor :> obj))
+                                 (instructor :> obj),
+                                 1)
                                 ("categories",
-                                 (categories :> obj))
+                                 (categories :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("language",
-                                 (language :> obj))
+                                 (language :> obj),
+                                 1)
                                 ("courses",
-                                 (courses :> obj))
+                                 (courses :> obj),
+                                 0)
                                 ("university_logo",
-                                 (universityLogo :> obj))
+                                 (universityLogo :> obj),
+                                 1)
                                 ("course-ids",
-                                 (courseIds :> obj))
+                                 (courseIds :> obj),
+                                 2)
                                 ("display",
-                                 (display :> obj))
+                                 (display :> obj),
+                                 3)
                                 ("subtitle_languages_csv",
-                                 (subtitleLanguagesCsv :> obj)) |], "")
+                                 (subtitleLanguagesCsv :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Topic
     JsonDocument.Create(jsonValue, "")
@@ -157,15 +180,20 @@ class JsonProvider+Topic : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Category : FDR.BaseTypes.IJsonDocument
     new : id:int -> name:string -> mailingListId:int option -> shortName:string -> description:string option -> JsonProvider+Category
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("mailing_list_id",
-                                 (mailingListId :> obj))
+                                 (mailingListId :> obj),
+                                 2)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj)) |], "")
+                                 (description :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Category
     JsonDocument.Create(jsonValue, "")
@@ -192,95 +220,140 @@ class JsonProvider+Category : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Course : FDR.BaseTypes.IJsonDocument
     new : gradingPolicyDistinction:string option -> aceTrackPriceDisplay:JsonValue -> signatureTrackCertificateDesignId:JsonValue -> aceSemesterHours:JsonValue -> startDay:int option -> durationString:string option -> signatureTrackLastChanceTime:System.DateTime option -> id:int -> startMonth:int option -> certificateDescription:string option -> startDateString:JsonProvider+StringOrDateTime -> cheggSessionId:JsonValue -> signatureTrackRegularPrice:int option -> gradesReleaseDate:System.DateTime option -> certificatesReady:bool -> signatureTrackPrice:int option -> statementDesignId:int option -> signatureTrackRegistrationOpen:bool -> topicId:int -> eligibleForSignatureTrack:bool -> startDate:System.DateTime option -> record:JsonProvider+Record -> status:bool -> startYear:int option -> signatureTrackCertificateCombinedSignature:JsonValue -> endDate:JsonValue -> notifiedSubscribers:bool -> instructors:int[] -> active:bool -> eligibleForCertificates:bool -> signatureTrackCertificateSignatureBlurb:JsonValue -> deployed:bool -> aceCloseDate:JsonValue -> name:JsonProvider+IntOrString -> textbooks:JsonValue[] -> signatureTrackOpenTime:System.DateTime option -> eligibleForAce:bool option -> gradingPolicyNormal:string option -> aceOpenDate:JsonValue -> homeLink:string option -> creatorId:int option -> proctoredExamCompletionDate:JsonValue -> universityLogo:JsonValue -> signatureTrackCloseTime:System.DateTime option -> authReviewCompletionDate:JsonValue -> JsonProvider+Course
     JsonRuntime.CreateRecord([| ("grading_policy_distinction",
-                                 (gradingPolicyDistinction :> obj))
+                                 (gradingPolicyDistinction :> obj),
+                                 1)
                                 ("ace_track_price_display",
-                                 (aceTrackPriceDisplay :> obj))
+                                 (aceTrackPriceDisplay :> obj),
+                                 0)
                                 ("signature_track_certificate_design_id",
-                                 (signatureTrackCertificateDesignId :> obj))
+                                 (signatureTrackCertificateDesignId :> obj),
+                                 0)
                                 ("ace_semester_hours",
-                                 (aceSemesterHours :> obj))
+                                 (aceSemesterHours :> obj),
+                                 0)
                                 ("start_day",
-                                 (startDay :> obj))
+                                 (startDay :> obj),
+                                 2)
                                 ("duration_string",
-                                 (durationString :> obj))
+                                 (durationString :> obj),
+                                 1)
                                 ("signature_track_last_chance_time",
-                                 (signatureTrackLastChanceTime :> obj))
+                                 (signatureTrackLastChanceTime :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("start_month",
-                                 (startMonth :> obj))
+                                 (startMonth :> obj),
+                                 2)
                                 ("certificate_description",
-                                 (certificateDescription :> obj))
+                                 (certificateDescription :> obj),
+                                 1)
                                 ("start_date_string",
-                                 (startDateString :> obj))
+                                 (startDateString :> obj),
+                                 0)
                                 ("chegg_session_id",
-                                 (cheggSessionId :> obj))
+                                 (cheggSessionId :> obj),
+                                 0)
                                 ("signature_track_regular_price",
-                                 (signatureTrackRegularPrice :> obj))
+                                 (signatureTrackRegularPrice :> obj),
+                                 2)
                                 ("grades_release_date",
-                                 (gradesReleaseDate :> obj))
+                                 (gradesReleaseDate :> obj),
+                                 1)
                                 ("certificates_ready",
-                                 (certificatesReady :> obj))
+                                 (certificatesReady :> obj),
+                                 3)
                                 ("signature_track_price",
-                                 (signatureTrackPrice :> obj))
+                                 (signatureTrackPrice :> obj),
+                                 2)
                                 ("statement_design_id",
-                                 (statementDesignId :> obj))
+                                 (statementDesignId :> obj),
+                                 2)
                                 ("signature_track_registration_open",
-                                 (signatureTrackRegistrationOpen :> obj))
+                                 (signatureTrackRegistrationOpen :> obj),
+                                 3)
                                 ("topic_id",
-                                 (topicId :> obj))
+                                 (topicId :> obj),
+                                 2)
                                 ("eligible_for_signature_track",
-                                 (eligibleForSignatureTrack :> obj))
+                                 (eligibleForSignatureTrack :> obj),
+                                 3)
                                 ("start_date",
-                                 (startDate :> obj))
+                                 (startDate :> obj),
+                                 1)
                                 ("record",
-                                 (record :> obj))
+                                 (record :> obj),
+                                 0)
                                 ("status",
-                                 (status :> obj))
+                                 (status :> obj),
+                                 2)
                                 ("start_year",
-                                 (startYear :> obj))
+                                 (startYear :> obj),
+                                 2)
                                 ("signature_track_certificate_combined_signature",
-                                 (signatureTrackCertificateCombinedSignature :> obj))
+                                 (signatureTrackCertificateCombinedSignature :> obj),
+                                 0)
                                 ("end_date",
-                                 (endDate :> obj))
+                                 (endDate :> obj),
+                                 0)
                                 ("notified_subscribers",
-                                 (notifiedSubscribers :> obj))
+                                 (notifiedSubscribers :> obj),
+                                 3)
                                 ("instructors",
-                                 (instructors :> obj))
+                                 (instructors :> obj),
+                                 2)
                                 ("active",
-                                 (active :> obj))
+                                 (active :> obj),
+                                 3)
                                 ("eligible_for_certificates",
-                                 (eligibleForCertificates :> obj))
+                                 (eligibleForCertificates :> obj),
+                                 3)
                                 ("signature_track_certificate_signature_blurb",
-                                 (signatureTrackCertificateSignatureBlurb :> obj))
+                                 (signatureTrackCertificateSignatureBlurb :> obj),
+                                 0)
                                 ("deployed",
-                                 (deployed :> obj))
+                                 (deployed :> obj),
+                                 3)
                                 ("ace_close_date",
-                                 (aceCloseDate :> obj))
+                                 (aceCloseDate :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 0)
                                 ("textbooks",
-                                 (textbooks :> obj))
+                                 (textbooks :> obj),
+                                 0)
                                 ("signature_track_open_time",
-                                 (signatureTrackOpenTime :> obj))
+                                 (signatureTrackOpenTime :> obj),
+                                 1)
                                 ("eligible_for_ACE",
-                                 (eligibleForAce :> obj))
+                                 (eligibleForAce :> obj),
+                                 3)
                                 ("grading_policy_normal",
-                                 (gradingPolicyNormal :> obj))
+                                 (gradingPolicyNormal :> obj),
+                                 1)
                                 ("ace_open_date",
-                                 (aceOpenDate :> obj))
+                                 (aceOpenDate :> obj),
+                                 0)
                                 ("home_link",
-                                 (homeLink :> obj))
+                                 (homeLink :> obj),
+                                 1)
                                 ("creator_id",
-                                 (creatorId :> obj))
+                                 (creatorId :> obj),
+                                 2)
                                 ("proctored_exam_completion_date",
-                                 (proctoredExamCompletionDate :> obj))
+                                 (proctoredExamCompletionDate :> obj),
+                                 0)
                                 ("university_logo",
-                                 (universityLogo :> obj))
+                                 (universityLogo :> obj),
+                                 0)
                                 ("signature_track_close_time",
-                                 (signatureTrackCloseTime :> obj))
+                                 (signatureTrackCloseTime :> obj),
+                                 1)
                                 ("auth_review_completion_date",
-                                 (authReviewCompletionDate :> obj)) |], "")
+                                 (authReviewCompletionDate :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Course
     JsonDocument.Create(jsonValue, "")
@@ -434,69 +507,101 @@ class JsonProvider+Course : FDR.BaseTypes.IJsonDocument
 class JsonProvider+University : FDR.BaseTypes.IJsonDocument
     new : rectangularLogoSvg:string option -> wordmark:JsonValue -> websiteTwitter:string option -> chinaMirror:int option -> favicon:string option -> websiteFacebook:string option -> logo:string option -> backgroundColor:JsonValue -> id:int -> locationCity:string option -> locationCountry:string option -> locationLat:decimal option -> location:string option -> primaryColor:string option -> abbrName:string -> website:string option -> description:string option -> shortName:string -> landingPageBanner:string option -> mailingListId:JsonValue -> websiteYoutube:string option -> partnerType:int -> banner:string option -> locationState:string option -> name:string -> squareLogo:string option -> squareLogoSource:string option -> squareLogoSvg:string option -> locationLng:decimal option -> homeLink:string option -> classLogo:string option -> display:bool -> JsonProvider+University
     JsonRuntime.CreateRecord([| ("rectangular_logo_svg",
-                                 (rectangularLogoSvg :> obj))
+                                 (rectangularLogoSvg :> obj),
+                                 1)
                                 ("wordmark",
-                                 (wordmark :> obj))
+                                 (wordmark :> obj),
+                                 0)
                                 ("website_twitter",
-                                 (websiteTwitter :> obj))
+                                 (websiteTwitter :> obj),
+                                 1)
                                 ("china_mirror",
-                                 (chinaMirror :> obj))
+                                 (chinaMirror :> obj),
+                                 2)
                                 ("favicon",
-                                 (favicon :> obj))
+                                 (favicon :> obj),
+                                 1)
                                 ("website_facebook",
-                                 (websiteFacebook :> obj))
+                                 (websiteFacebook :> obj),
+                                 1)
                                 ("logo",
-                                 (logo :> obj))
+                                 (logo :> obj),
+                                 1)
                                 ("background_color",
-                                 (backgroundColor :> obj))
+                                 (backgroundColor :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("location_city",
-                                 (locationCity :> obj))
+                                 (locationCity :> obj),
+                                 1)
                                 ("location_country",
-                                 (locationCountry :> obj))
+                                 (locationCountry :> obj),
+                                 1)
                                 ("location_lat",
-                                 (locationLat :> obj))
+                                 (locationLat :> obj),
+                                 2)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("primary_color",
-                                 (primaryColor :> obj))
+                                 (primaryColor :> obj),
+                                 1)
                                 ("abbr_name",
-                                 (abbrName :> obj))
+                                 (abbrName :> obj),
+                                 1)
                                 ("website",
-                                 (website :> obj))
+                                 (website :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("landing_page_banner",
-                                 (landingPageBanner :> obj))
+                                 (landingPageBanner :> obj),
+                                 1)
                                 ("mailing_list_id",
-                                 (mailingListId :> obj))
+                                 (mailingListId :> obj),
+                                 0)
                                 ("website_youtube",
-                                 (websiteYoutube :> obj))
+                                 (websiteYoutube :> obj),
+                                 1)
                                 ("partner_type",
-                                 (partnerType :> obj))
+                                 (partnerType :> obj),
+                                 2)
                                 ("banner",
-                                 (banner :> obj))
+                                 (banner :> obj),
+                                 1)
                                 ("location_state",
-                                 (locationState :> obj))
+                                 (locationState :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("square_logo",
-                                 (squareLogo :> obj))
+                                 (squareLogo :> obj),
+                                 1)
                                 ("square_logo_source",
-                                 (squareLogoSource :> obj))
+                                 (squareLogoSource :> obj),
+                                 1)
                                 ("square_logo_svg",
-                                 (squareLogoSvg :> obj))
+                                 (squareLogoSvg :> obj),
+                                 1)
                                 ("location_lng",
-                                 (locationLng :> obj))
+                                 (locationLng :> obj),
+                                 2)
                                 ("home_link",
-                                 (homeLink :> obj))
+                                 (homeLink :> obj),
+                                 1)
                                 ("class_logo",
-                                 (classLogo :> obj))
+                                 (classLogo :> obj),
+                                 1)
                                 ("display",
-                                 (display :> obj)) |], "")
+                                 (display :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+University
     JsonDocument.Create(jsonValue, "")
@@ -627,27 +732,38 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
     new : gradeDistinction:decimal option -> shareForWork:bool option -> isEnrolledForProctoredExam:bool -> achievementLevel:int option -> signatureTrack:bool -> passedAce:bool -> aceGrade:int -> gradeNormal:decimal option -> verifyCertId:JsonValue -> authenticatedOverall:bool -> withGradeCertId:JsonValue -> JsonProvider+Record
     JsonRuntime.CreateRecord([| ("grade_distinction",
-                                 (gradeDistinction :> obj))
+                                 (gradeDistinction :> obj),
+                                 2)
                                 ("share_for_work",
-                                 (shareForWork :> obj))
+                                 (shareForWork :> obj),
+                                 3)
                                 ("is_enrolled_for_proctored_exam",
-                                 (isEnrolledForProctoredExam :> obj))
+                                 (isEnrolledForProctoredExam :> obj),
+                                 3)
                                 ("achievement_level",
-                                 (achievementLevel :> obj))
+                                 (achievementLevel :> obj),
+                                 2)
                                 ("signature_track",
-                                 (signatureTrack :> obj))
+                                 (signatureTrack :> obj),
+                                 3)
                                 ("passed_ace",
-                                 (passedAce :> obj))
+                                 (passedAce :> obj),
+                                 3)
                                 ("ace_grade",
-                                 (aceGrade :> obj))
+                                 (aceGrade :> obj),
+                                 2)
                                 ("grade_normal",
-                                 (gradeNormal :> obj))
+                                 (gradeNormal :> obj),
+                                 2)
                                 ("verify_cert_id",
-                                 (verifyCertId :> obj))
+                                 (verifyCertId :> obj),
+                                 0)
                                 ("authenticated_overall",
-                                 (authenticatedOverall :> obj))
+                                 (authenticatedOverall :> obj),
+                                 3)
                                 ("with_grade_cert_id",
-                                 (withGradeCertId :> obj)) |], "")
+                                 (withGradeCertId :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True,False,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True,False,ValuesAndInlineSchemasOverrides.expected
@@ -25,51 +25,74 @@ class JsonProvider : obj
 class JsonProvider+Topic : FDR.BaseTypes.IJsonDocument
     new : photo:string -> previewLink:string option -> smallIconHover:string -> largeIcon:string -> video:string option -> universityIds:string[] -> id:int -> universities:JsonProvider+JsonProvider+University[] -> selfServiceCourseId:int option -> shortDescription:string -> shortName:string -> categoryIds:string[] -> visibility:int option -> smallIcon:string -> instructor:string option -> categories:JsonProvider+JsonProvider+Category[] -> name:string -> language:string -> courses:JsonProvider+JsonProvider+Course[] -> universityLogo:string option -> courseIds:int[] -> display:bool -> subtitleLanguagesCsv:string option -> JsonProvider+Topic
     JsonRuntime.CreateRecord([| ("photo",
-                                 (photo :> obj))
+                                 (photo :> obj),
+                                 1)
                                 ("preview_link",
-                                 (previewLink :> obj))
+                                 (previewLink :> obj),
+                                 1)
                                 ("small_icon_hover",
-                                 (smallIconHover :> obj))
+                                 (smallIconHover :> obj),
+                                 1)
                                 ("large_icon",
-                                 (largeIcon :> obj))
+                                 (largeIcon :> obj),
+                                 1)
                                 ("video",
-                                 (video :> obj))
+                                 (video :> obj),
+                                 1)
                                 ("university-ids",
-                                 (universityIds :> obj))
+                                 (universityIds :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("universities",
-                                 (universities :> obj))
+                                 (universities :> obj),
+                                 0)
                                 ("self_service_course_id",
-                                 (selfServiceCourseId :> obj))
+                                 (selfServiceCourseId :> obj),
+                                 2)
                                 ("short_description",
-                                 (shortDescription :> obj))
+                                 (shortDescription :> obj),
+                                 1)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("category-ids",
-                                 (categoryIds :> obj))
+                                 (categoryIds :> obj),
+                                 1)
                                 ("visibility",
-                                 (visibility :> obj))
+                                 (visibility :> obj),
+                                 2)
                                 ("small_icon",
-                                 (smallIcon :> obj))
+                                 (smallIcon :> obj),
+                                 1)
                                 ("instructor",
-                                 (instructor :> obj))
+                                 (instructor :> obj),
+                                 1)
                                 ("categories",
-                                 (categories :> obj))
+                                 (categories :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("language",
-                                 (language :> obj))
+                                 (language :> obj),
+                                 1)
                                 ("courses",
-                                 (courses :> obj))
+                                 (courses :> obj),
+                                 0)
                                 ("university_logo",
-                                 (universityLogo :> obj))
+                                 (universityLogo :> obj),
+                                 1)
                                 ("course-ids",
-                                 (courseIds :> obj))
+                                 (courseIds :> obj),
+                                 2)
                                 ("display",
-                                 (display :> obj))
+                                 (display :> obj),
+                                 3)
                                 ("subtitle_languages_csv",
-                                 (subtitleLanguagesCsv :> obj)) |], "")
+                                 (subtitleLanguagesCsv :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Topic
     JsonDocument.Create(jsonValue, "")
@@ -157,15 +180,20 @@ class JsonProvider+Topic : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Category : FDR.BaseTypes.IJsonDocument
     new : id:int -> name:string -> mailingListId:int option -> shortName:string -> description:string option -> JsonProvider+Category
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("mailing_list_id",
-                                 (mailingListId :> obj))
+                                 (mailingListId :> obj),
+                                 2)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj)) |], "")
+                                 (description :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Category
     JsonDocument.Create(jsonValue, "")
@@ -192,95 +220,140 @@ class JsonProvider+Category : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Course : FDR.BaseTypes.IJsonDocument
     new : gradingPolicyDistinction:string option -> aceTrackPriceDisplay:JsonValue -> signatureTrackCertificateDesignId:JsonValue -> aceSemesterHours:JsonValue -> startDay:int option -> durationString:string option -> signatureTrackLastChanceTime:System.DateTime option -> id:int -> startMonth:int option -> certificateDescription:string option -> startDateString:JsonProvider+StringOrDateTime -> cheggSessionId:JsonValue -> signatureTrackRegularPrice:int option -> gradesReleaseDate:System.DateTime option -> certificatesReady:bool -> signatureTrackPrice:int option -> statementDesignId:int option -> signatureTrackRegistrationOpen:bool -> topicId:int -> eligibleForSignatureTrack:bool -> startDate:System.DateTime option -> record:JsonProvider+Record -> status:bool -> startYear:int option -> signatureTrackCertificateCombinedSignature:JsonValue -> endDate:JsonValue -> notifiedSubscribers:bool -> instructors:int[] -> active:bool -> eligibleForCertificates:bool -> signatureTrackCertificateSignatureBlurb:JsonValue -> deployed:bool -> aceCloseDate:JsonValue -> name:JsonProvider+IntOrString -> textbooks:JsonValue[] -> signatureTrackOpenTime:System.DateTime option -> eligibleForAce:bool option -> gradingPolicyNormal:string option -> aceOpenDate:JsonValue -> homeLink:string option -> creatorId:int option -> proctoredExamCompletionDate:JsonValue -> universityLogo:JsonValue -> signatureTrackCloseTime:System.DateTime option -> authReviewCompletionDate:JsonValue -> JsonProvider+Course
     JsonRuntime.CreateRecord([| ("grading_policy_distinction",
-                                 (gradingPolicyDistinction :> obj))
+                                 (gradingPolicyDistinction :> obj),
+                                 1)
                                 ("ace_track_price_display",
-                                 (aceTrackPriceDisplay :> obj))
+                                 (aceTrackPriceDisplay :> obj),
+                                 0)
                                 ("signature_track_certificate_design_id",
-                                 (signatureTrackCertificateDesignId :> obj))
+                                 (signatureTrackCertificateDesignId :> obj),
+                                 0)
                                 ("ace_semester_hours",
-                                 (aceSemesterHours :> obj))
+                                 (aceSemesterHours :> obj),
+                                 0)
                                 ("start_day",
-                                 (startDay :> obj))
+                                 (startDay :> obj),
+                                 2)
                                 ("duration_string",
-                                 (durationString :> obj))
+                                 (durationString :> obj),
+                                 1)
                                 ("signature_track_last_chance_time",
-                                 (signatureTrackLastChanceTime :> obj))
+                                 (signatureTrackLastChanceTime :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("start_month",
-                                 (startMonth :> obj))
+                                 (startMonth :> obj),
+                                 2)
                                 ("certificate_description",
-                                 (certificateDescription :> obj))
+                                 (certificateDescription :> obj),
+                                 1)
                                 ("start_date_string",
-                                 (startDateString :> obj))
+                                 (startDateString :> obj),
+                                 0)
                                 ("chegg_session_id",
-                                 (cheggSessionId :> obj))
+                                 (cheggSessionId :> obj),
+                                 0)
                                 ("signature_track_regular_price",
-                                 (signatureTrackRegularPrice :> obj))
+                                 (signatureTrackRegularPrice :> obj),
+                                 2)
                                 ("grades_release_date",
-                                 (gradesReleaseDate :> obj))
+                                 (gradesReleaseDate :> obj),
+                                 1)
                                 ("certificates_ready",
-                                 (certificatesReady :> obj))
+                                 (certificatesReady :> obj),
+                                 3)
                                 ("signature_track_price",
-                                 (signatureTrackPrice :> obj))
+                                 (signatureTrackPrice :> obj),
+                                 2)
                                 ("statement_design_id",
-                                 (statementDesignId :> obj))
+                                 (statementDesignId :> obj),
+                                 2)
                                 ("signature_track_registration_open",
-                                 (signatureTrackRegistrationOpen :> obj))
+                                 (signatureTrackRegistrationOpen :> obj),
+                                 3)
                                 ("topic_id",
-                                 (topicId :> obj))
+                                 (topicId :> obj),
+                                 2)
                                 ("eligible_for_signature_track",
-                                 (eligibleForSignatureTrack :> obj))
+                                 (eligibleForSignatureTrack :> obj),
+                                 3)
                                 ("start_date",
-                                 (startDate :> obj))
+                                 (startDate :> obj),
+                                 1)
                                 ("record",
-                                 (record :> obj))
+                                 (record :> obj),
+                                 0)
                                 ("status",
-                                 (status :> obj))
+                                 (status :> obj),
+                                 2)
                                 ("start_year",
-                                 (startYear :> obj))
+                                 (startYear :> obj),
+                                 2)
                                 ("signature_track_certificate_combined_signature",
-                                 (signatureTrackCertificateCombinedSignature :> obj))
+                                 (signatureTrackCertificateCombinedSignature :> obj),
+                                 0)
                                 ("end_date",
-                                 (endDate :> obj))
+                                 (endDate :> obj),
+                                 0)
                                 ("notified_subscribers",
-                                 (notifiedSubscribers :> obj))
+                                 (notifiedSubscribers :> obj),
+                                 3)
                                 ("instructors",
-                                 (instructors :> obj))
+                                 (instructors :> obj),
+                                 2)
                                 ("active",
-                                 (active :> obj))
+                                 (active :> obj),
+                                 3)
                                 ("eligible_for_certificates",
-                                 (eligibleForCertificates :> obj))
+                                 (eligibleForCertificates :> obj),
+                                 3)
                                 ("signature_track_certificate_signature_blurb",
-                                 (signatureTrackCertificateSignatureBlurb :> obj))
+                                 (signatureTrackCertificateSignatureBlurb :> obj),
+                                 0)
                                 ("deployed",
-                                 (deployed :> obj))
+                                 (deployed :> obj),
+                                 3)
                                 ("ace_close_date",
-                                 (aceCloseDate :> obj))
+                                 (aceCloseDate :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 0)
                                 ("textbooks",
-                                 (textbooks :> obj))
+                                 (textbooks :> obj),
+                                 0)
                                 ("signature_track_open_time",
-                                 (signatureTrackOpenTime :> obj))
+                                 (signatureTrackOpenTime :> obj),
+                                 1)
                                 ("eligible_for_ACE",
-                                 (eligibleForAce :> obj))
+                                 (eligibleForAce :> obj),
+                                 3)
                                 ("grading_policy_normal",
-                                 (gradingPolicyNormal :> obj))
+                                 (gradingPolicyNormal :> obj),
+                                 1)
                                 ("ace_open_date",
-                                 (aceOpenDate :> obj))
+                                 (aceOpenDate :> obj),
+                                 0)
                                 ("home_link",
-                                 (homeLink :> obj))
+                                 (homeLink :> obj),
+                                 1)
                                 ("creator_id",
-                                 (creatorId :> obj))
+                                 (creatorId :> obj),
+                                 2)
                                 ("proctored_exam_completion_date",
-                                 (proctoredExamCompletionDate :> obj))
+                                 (proctoredExamCompletionDate :> obj),
+                                 0)
                                 ("university_logo",
-                                 (universityLogo :> obj))
+                                 (universityLogo :> obj),
+                                 0)
                                 ("signature_track_close_time",
-                                 (signatureTrackCloseTime :> obj))
+                                 (signatureTrackCloseTime :> obj),
+                                 1)
                                 ("auth_review_completion_date",
-                                 (authReviewCompletionDate :> obj)) |], "")
+                                 (authReviewCompletionDate :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Course
     JsonDocument.Create(jsonValue, "")
@@ -434,69 +507,101 @@ class JsonProvider+Course : FDR.BaseTypes.IJsonDocument
 class JsonProvider+University : FDR.BaseTypes.IJsonDocument
     new : rectangularLogoSvg:string option -> wordmark:JsonValue -> websiteTwitter:string option -> chinaMirror:int option -> favicon:string option -> websiteFacebook:string option -> logo:string option -> backgroundColor:JsonValue -> id:int -> locationCity:string option -> locationCountry:string option -> locationLat:decimal option -> location:string option -> primaryColor:string option -> abbrName:string -> website:string option -> description:string option -> shortName:string -> landingPageBanner:string option -> mailingListId:JsonValue -> websiteYoutube:string option -> partnerType:int -> banner:string option -> locationState:string option -> name:string -> squareLogo:string option -> squareLogoSource:string option -> squareLogoSvg:string option -> locationLng:decimal option -> homeLink:string option -> classLogo:string option -> display:bool -> JsonProvider+University
     JsonRuntime.CreateRecord([| ("rectangular_logo_svg",
-                                 (rectangularLogoSvg :> obj))
+                                 (rectangularLogoSvg :> obj),
+                                 1)
                                 ("wordmark",
-                                 (wordmark :> obj))
+                                 (wordmark :> obj),
+                                 0)
                                 ("website_twitter",
-                                 (websiteTwitter :> obj))
+                                 (websiteTwitter :> obj),
+                                 1)
                                 ("china_mirror",
-                                 (chinaMirror :> obj))
+                                 (chinaMirror :> obj),
+                                 2)
                                 ("favicon",
-                                 (favicon :> obj))
+                                 (favicon :> obj),
+                                 1)
                                 ("website_facebook",
-                                 (websiteFacebook :> obj))
+                                 (websiteFacebook :> obj),
+                                 1)
                                 ("logo",
-                                 (logo :> obj))
+                                 (logo :> obj),
+                                 1)
                                 ("background_color",
-                                 (backgroundColor :> obj))
+                                 (backgroundColor :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("location_city",
-                                 (locationCity :> obj))
+                                 (locationCity :> obj),
+                                 1)
                                 ("location_country",
-                                 (locationCountry :> obj))
+                                 (locationCountry :> obj),
+                                 1)
                                 ("location_lat",
-                                 (locationLat :> obj))
+                                 (locationLat :> obj),
+                                 2)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("primary_color",
-                                 (primaryColor :> obj))
+                                 (primaryColor :> obj),
+                                 1)
                                 ("abbr_name",
-                                 (abbrName :> obj))
+                                 (abbrName :> obj),
+                                 1)
                                 ("website",
-                                 (website :> obj))
+                                 (website :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("landing_page_banner",
-                                 (landingPageBanner :> obj))
+                                 (landingPageBanner :> obj),
+                                 1)
                                 ("mailing_list_id",
-                                 (mailingListId :> obj))
+                                 (mailingListId :> obj),
+                                 0)
                                 ("website_youtube",
-                                 (websiteYoutube :> obj))
+                                 (websiteYoutube :> obj),
+                                 1)
                                 ("partner_type",
-                                 (partnerType :> obj))
+                                 (partnerType :> obj),
+                                 2)
                                 ("banner",
-                                 (banner :> obj))
+                                 (banner :> obj),
+                                 1)
                                 ("location_state",
-                                 (locationState :> obj))
+                                 (locationState :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("square_logo",
-                                 (squareLogo :> obj))
+                                 (squareLogo :> obj),
+                                 1)
                                 ("square_logo_source",
-                                 (squareLogoSource :> obj))
+                                 (squareLogoSource :> obj),
+                                 1)
                                 ("square_logo_svg",
-                                 (squareLogoSvg :> obj))
+                                 (squareLogoSvg :> obj),
+                                 1)
                                 ("location_lng",
-                                 (locationLng :> obj))
+                                 (locationLng :> obj),
+                                 2)
                                 ("home_link",
-                                 (homeLink :> obj))
+                                 (homeLink :> obj),
+                                 1)
                                 ("class_logo",
-                                 (classLogo :> obj))
+                                 (classLogo :> obj),
+                                 1)
                                 ("display",
-                                 (display :> obj)) |], "")
+                                 (display :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+University
     JsonDocument.Create(jsonValue, "")
@@ -627,27 +732,38 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
     new : gradeDistinction:decimal option -> shareForWork:bool option -> isEnrolledForProctoredExam:bool -> achievementLevel:int option -> signatureTrack:bool -> passedAce:bool -> aceGrade:int -> gradeNormal:decimal option -> verifyCertId:JsonValue -> authenticatedOverall:bool -> withGradeCertId:JsonValue -> JsonProvider+Record
     JsonRuntime.CreateRecord([| ("grade_distinction",
-                                 (gradeDistinction :> obj))
+                                 (gradeDistinction :> obj),
+                                 2)
                                 ("share_for_work",
-                                 (shareForWork :> obj))
+                                 (shareForWork :> obj),
+                                 3)
                                 ("is_enrolled_for_proctored_exam",
-                                 (isEnrolledForProctoredExam :> obj))
+                                 (isEnrolledForProctoredExam :> obj),
+                                 3)
                                 ("achievement_level",
-                                 (achievementLevel :> obj))
+                                 (achievementLevel :> obj),
+                                 2)
                                 ("signature_track",
-                                 (signatureTrack :> obj))
+                                 (signatureTrack :> obj),
+                                 3)
                                 ("passed_ace",
-                                 (passedAce :> obj))
+                                 (passedAce :> obj),
+                                 3)
                                 ("ace_grade",
-                                 (aceGrade :> obj))
+                                 (aceGrade :> obj),
+                                 2)
                                 ("grade_normal",
-                                 (gradeNormal :> obj))
+                                 (gradeNormal :> obj),
+                                 2)
                                 ("verify_cert_id",
-                                 (verifyCertId :> obj))
+                                 (verifyCertId :> obj),
+                                 0)
                                 ("authenticated_overall",
-                                 (authenticatedOverall :> obj))
+                                 (authenticatedOverall :> obj),
+                                 3)
                                 ("with_grade_cert_id",
-                                 (withGradeCertId :> obj)) |], "")
+                                 (withGradeCertId :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True,False,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Json,topics.json,True,Topic,,True,False,ValuesOnly.expected
@@ -25,51 +25,74 @@ class JsonProvider : obj
 class JsonProvider+Topic : FDR.BaseTypes.IJsonDocument
     new : photo:string -> previewLink:string option -> smallIconHover:string -> largeIcon:string -> video:string option -> universityIds:string[] -> id:int -> universities:JsonProvider+JsonProvider+University[] -> selfServiceCourseId:int option -> shortDescription:string -> shortName:string -> categoryIds:string[] -> visibility:int option -> smallIcon:string -> instructor:string option -> categories:JsonProvider+JsonProvider+Category[] -> name:string -> language:string -> courses:JsonProvider+JsonProvider+Course[] -> universityLogo:string option -> courseIds:int[] -> display:bool -> subtitleLanguagesCsv:string option -> JsonProvider+Topic
     JsonRuntime.CreateRecord([| ("photo",
-                                 (photo :> obj))
+                                 (photo :> obj),
+                                 1)
                                 ("preview_link",
-                                 (previewLink :> obj))
+                                 (previewLink :> obj),
+                                 1)
                                 ("small_icon_hover",
-                                 (smallIconHover :> obj))
+                                 (smallIconHover :> obj),
+                                 1)
                                 ("large_icon",
-                                 (largeIcon :> obj))
+                                 (largeIcon :> obj),
+                                 1)
                                 ("video",
-                                 (video :> obj))
+                                 (video :> obj),
+                                 1)
                                 ("university-ids",
-                                 (universityIds :> obj))
+                                 (universityIds :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("universities",
-                                 (universities :> obj))
+                                 (universities :> obj),
+                                 0)
                                 ("self_service_course_id",
-                                 (selfServiceCourseId :> obj))
+                                 (selfServiceCourseId :> obj),
+                                 2)
                                 ("short_description",
-                                 (shortDescription :> obj))
+                                 (shortDescription :> obj),
+                                 1)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("category-ids",
-                                 (categoryIds :> obj))
+                                 (categoryIds :> obj),
+                                 1)
                                 ("visibility",
-                                 (visibility :> obj))
+                                 (visibility :> obj),
+                                 2)
                                 ("small_icon",
-                                 (smallIcon :> obj))
+                                 (smallIcon :> obj),
+                                 1)
                                 ("instructor",
-                                 (instructor :> obj))
+                                 (instructor :> obj),
+                                 1)
                                 ("categories",
-                                 (categories :> obj))
+                                 (categories :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("language",
-                                 (language :> obj))
+                                 (language :> obj),
+                                 1)
                                 ("courses",
-                                 (courses :> obj))
+                                 (courses :> obj),
+                                 0)
                                 ("university_logo",
-                                 (universityLogo :> obj))
+                                 (universityLogo :> obj),
+                                 1)
                                 ("course-ids",
-                                 (courseIds :> obj))
+                                 (courseIds :> obj),
+                                 2)
                                 ("display",
-                                 (display :> obj))
+                                 (display :> obj),
+                                 3)
                                 ("subtitle_languages_csv",
-                                 (subtitleLanguagesCsv :> obj)) |], "")
+                                 (subtitleLanguagesCsv :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Topic
     JsonDocument.Create(jsonValue, "")
@@ -157,15 +180,20 @@ class JsonProvider+Topic : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Category : FDR.BaseTypes.IJsonDocument
     new : id:int -> name:string -> mailingListId:int option -> shortName:string -> description:string option -> JsonProvider+Category
     JsonRuntime.CreateRecord([| ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("mailing_list_id",
-                                 (mailingListId :> obj))
+                                 (mailingListId :> obj),
+                                 2)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj)) |], "")
+                                 (description :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Category
     JsonDocument.Create(jsonValue, "")
@@ -192,95 +220,140 @@ class JsonProvider+Category : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Course : FDR.BaseTypes.IJsonDocument
     new : gradingPolicyDistinction:string option -> aceTrackPriceDisplay:JsonValue -> signatureTrackCertificateDesignId:JsonValue -> aceSemesterHours:JsonValue -> startDay:int option -> durationString:string option -> signatureTrackLastChanceTime:System.DateTime option -> id:int -> startMonth:int option -> certificateDescription:string option -> startDateString:JsonProvider+StringOrDateTime -> cheggSessionId:JsonValue -> signatureTrackRegularPrice:int option -> gradesReleaseDate:System.DateTime option -> certificatesReady:bool -> signatureTrackPrice:int option -> statementDesignId:int option -> signatureTrackRegistrationOpen:bool -> topicId:int -> eligibleForSignatureTrack:bool -> startDate:System.DateTime option -> record:JsonProvider+Record -> status:bool -> startYear:int option -> signatureTrackCertificateCombinedSignature:JsonValue -> endDate:JsonValue -> notifiedSubscribers:bool -> instructors:int[] -> active:bool -> eligibleForCertificates:bool -> signatureTrackCertificateSignatureBlurb:JsonValue -> deployed:bool -> aceCloseDate:JsonValue -> name:JsonProvider+IntOrString -> textbooks:JsonValue[] -> signatureTrackOpenTime:System.DateTime option -> eligibleForAce:bool option -> gradingPolicyNormal:string option -> aceOpenDate:JsonValue -> homeLink:string option -> creatorId:int option -> proctoredExamCompletionDate:JsonValue -> universityLogo:JsonValue -> signatureTrackCloseTime:System.DateTime option -> authReviewCompletionDate:JsonValue -> JsonProvider+Course
     JsonRuntime.CreateRecord([| ("grading_policy_distinction",
-                                 (gradingPolicyDistinction :> obj))
+                                 (gradingPolicyDistinction :> obj),
+                                 1)
                                 ("ace_track_price_display",
-                                 (aceTrackPriceDisplay :> obj))
+                                 (aceTrackPriceDisplay :> obj),
+                                 0)
                                 ("signature_track_certificate_design_id",
-                                 (signatureTrackCertificateDesignId :> obj))
+                                 (signatureTrackCertificateDesignId :> obj),
+                                 0)
                                 ("ace_semester_hours",
-                                 (aceSemesterHours :> obj))
+                                 (aceSemesterHours :> obj),
+                                 0)
                                 ("start_day",
-                                 (startDay :> obj))
+                                 (startDay :> obj),
+                                 2)
                                 ("duration_string",
-                                 (durationString :> obj))
+                                 (durationString :> obj),
+                                 1)
                                 ("signature_track_last_chance_time",
-                                 (signatureTrackLastChanceTime :> obj))
+                                 (signatureTrackLastChanceTime :> obj),
+                                 1)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("start_month",
-                                 (startMonth :> obj))
+                                 (startMonth :> obj),
+                                 2)
                                 ("certificate_description",
-                                 (certificateDescription :> obj))
+                                 (certificateDescription :> obj),
+                                 1)
                                 ("start_date_string",
-                                 (startDateString :> obj))
+                                 (startDateString :> obj),
+                                 0)
                                 ("chegg_session_id",
-                                 (cheggSessionId :> obj))
+                                 (cheggSessionId :> obj),
+                                 0)
                                 ("signature_track_regular_price",
-                                 (signatureTrackRegularPrice :> obj))
+                                 (signatureTrackRegularPrice :> obj),
+                                 2)
                                 ("grades_release_date",
-                                 (gradesReleaseDate :> obj))
+                                 (gradesReleaseDate :> obj),
+                                 1)
                                 ("certificates_ready",
-                                 (certificatesReady :> obj))
+                                 (certificatesReady :> obj),
+                                 3)
                                 ("signature_track_price",
-                                 (signatureTrackPrice :> obj))
+                                 (signatureTrackPrice :> obj),
+                                 2)
                                 ("statement_design_id",
-                                 (statementDesignId :> obj))
+                                 (statementDesignId :> obj),
+                                 2)
                                 ("signature_track_registration_open",
-                                 (signatureTrackRegistrationOpen :> obj))
+                                 (signatureTrackRegistrationOpen :> obj),
+                                 3)
                                 ("topic_id",
-                                 (topicId :> obj))
+                                 (topicId :> obj),
+                                 2)
                                 ("eligible_for_signature_track",
-                                 (eligibleForSignatureTrack :> obj))
+                                 (eligibleForSignatureTrack :> obj),
+                                 3)
                                 ("start_date",
-                                 (startDate :> obj))
+                                 (startDate :> obj),
+                                 1)
                                 ("record",
-                                 (record :> obj))
+                                 (record :> obj),
+                                 0)
                                 ("status",
-                                 (status :> obj))
+                                 (status :> obj),
+                                 2)
                                 ("start_year",
-                                 (startYear :> obj))
+                                 (startYear :> obj),
+                                 2)
                                 ("signature_track_certificate_combined_signature",
-                                 (signatureTrackCertificateCombinedSignature :> obj))
+                                 (signatureTrackCertificateCombinedSignature :> obj),
+                                 0)
                                 ("end_date",
-                                 (endDate :> obj))
+                                 (endDate :> obj),
+                                 0)
                                 ("notified_subscribers",
-                                 (notifiedSubscribers :> obj))
+                                 (notifiedSubscribers :> obj),
+                                 3)
                                 ("instructors",
-                                 (instructors :> obj))
+                                 (instructors :> obj),
+                                 2)
                                 ("active",
-                                 (active :> obj))
+                                 (active :> obj),
+                                 3)
                                 ("eligible_for_certificates",
-                                 (eligibleForCertificates :> obj))
+                                 (eligibleForCertificates :> obj),
+                                 3)
                                 ("signature_track_certificate_signature_blurb",
-                                 (signatureTrackCertificateSignatureBlurb :> obj))
+                                 (signatureTrackCertificateSignatureBlurb :> obj),
+                                 0)
                                 ("deployed",
-                                 (deployed :> obj))
+                                 (deployed :> obj),
+                                 3)
                                 ("ace_close_date",
-                                 (aceCloseDate :> obj))
+                                 (aceCloseDate :> obj),
+                                 0)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 0)
                                 ("textbooks",
-                                 (textbooks :> obj))
+                                 (textbooks :> obj),
+                                 0)
                                 ("signature_track_open_time",
-                                 (signatureTrackOpenTime :> obj))
+                                 (signatureTrackOpenTime :> obj),
+                                 1)
                                 ("eligible_for_ACE",
-                                 (eligibleForAce :> obj))
+                                 (eligibleForAce :> obj),
+                                 3)
                                 ("grading_policy_normal",
-                                 (gradingPolicyNormal :> obj))
+                                 (gradingPolicyNormal :> obj),
+                                 1)
                                 ("ace_open_date",
-                                 (aceOpenDate :> obj))
+                                 (aceOpenDate :> obj),
+                                 0)
                                 ("home_link",
-                                 (homeLink :> obj))
+                                 (homeLink :> obj),
+                                 1)
                                 ("creator_id",
-                                 (creatorId :> obj))
+                                 (creatorId :> obj),
+                                 2)
                                 ("proctored_exam_completion_date",
-                                 (proctoredExamCompletionDate :> obj))
+                                 (proctoredExamCompletionDate :> obj),
+                                 0)
                                 ("university_logo",
-                                 (universityLogo :> obj))
+                                 (universityLogo :> obj),
+                                 0)
                                 ("signature_track_close_time",
-                                 (signatureTrackCloseTime :> obj))
+                                 (signatureTrackCloseTime :> obj),
+                                 1)
                                 ("auth_review_completion_date",
-                                 (authReviewCompletionDate :> obj)) |], "")
+                                 (authReviewCompletionDate :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Course
     JsonDocument.Create(jsonValue, "")
@@ -434,69 +507,101 @@ class JsonProvider+Course : FDR.BaseTypes.IJsonDocument
 class JsonProvider+University : FDR.BaseTypes.IJsonDocument
     new : rectangularLogoSvg:string option -> wordmark:JsonValue -> websiteTwitter:string option -> chinaMirror:int option -> favicon:string option -> websiteFacebook:string option -> logo:string option -> backgroundColor:JsonValue -> id:int -> locationCity:string option -> locationCountry:string option -> locationLat:decimal option -> location:string option -> primaryColor:string option -> abbrName:string -> website:string option -> description:string option -> shortName:string -> landingPageBanner:string option -> mailingListId:JsonValue -> websiteYoutube:string option -> partnerType:int -> banner:string option -> locationState:string option -> name:string -> squareLogo:string option -> squareLogoSource:string option -> squareLogoSvg:string option -> locationLng:decimal option -> homeLink:string option -> classLogo:string option -> display:bool -> JsonProvider+University
     JsonRuntime.CreateRecord([| ("rectangular_logo_svg",
-                                 (rectangularLogoSvg :> obj))
+                                 (rectangularLogoSvg :> obj),
+                                 1)
                                 ("wordmark",
-                                 (wordmark :> obj))
+                                 (wordmark :> obj),
+                                 0)
                                 ("website_twitter",
-                                 (websiteTwitter :> obj))
+                                 (websiteTwitter :> obj),
+                                 1)
                                 ("china_mirror",
-                                 (chinaMirror :> obj))
+                                 (chinaMirror :> obj),
+                                 2)
                                 ("favicon",
-                                 (favicon :> obj))
+                                 (favicon :> obj),
+                                 1)
                                 ("website_facebook",
-                                 (websiteFacebook :> obj))
+                                 (websiteFacebook :> obj),
+                                 1)
                                 ("logo",
-                                 (logo :> obj))
+                                 (logo :> obj),
+                                 1)
                                 ("background_color",
-                                 (backgroundColor :> obj))
+                                 (backgroundColor :> obj),
+                                 0)
                                 ("id",
-                                 (id :> obj))
+                                 (id :> obj),
+                                 2)
                                 ("location_city",
-                                 (locationCity :> obj))
+                                 (locationCity :> obj),
+                                 1)
                                 ("location_country",
-                                 (locationCountry :> obj))
+                                 (locationCountry :> obj),
+                                 1)
                                 ("location_lat",
-                                 (locationLat :> obj))
+                                 (locationLat :> obj),
+                                 2)
                                 ("location",
-                                 (location :> obj))
+                                 (location :> obj),
+                                 1)
                                 ("primary_color",
-                                 (primaryColor :> obj))
+                                 (primaryColor :> obj),
+                                 1)
                                 ("abbr_name",
-                                 (abbrName :> obj))
+                                 (abbrName :> obj),
+                                 1)
                                 ("website",
-                                 (website :> obj))
+                                 (website :> obj),
+                                 1)
                                 ("description",
-                                 (description :> obj))
+                                 (description :> obj),
+                                 1)
                                 ("short_name",
-                                 (shortName :> obj))
+                                 (shortName :> obj),
+                                 1)
                                 ("landing_page_banner",
-                                 (landingPageBanner :> obj))
+                                 (landingPageBanner :> obj),
+                                 1)
                                 ("mailing_list_id",
-                                 (mailingListId :> obj))
+                                 (mailingListId :> obj),
+                                 0)
                                 ("website_youtube",
-                                 (websiteYoutube :> obj))
+                                 (websiteYoutube :> obj),
+                                 1)
                                 ("partner_type",
-                                 (partnerType :> obj))
+                                 (partnerType :> obj),
+                                 2)
                                 ("banner",
-                                 (banner :> obj))
+                                 (banner :> obj),
+                                 1)
                                 ("location_state",
-                                 (locationState :> obj))
+                                 (locationState :> obj),
+                                 1)
                                 ("name",
-                                 (name :> obj))
+                                 (name :> obj),
+                                 1)
                                 ("square_logo",
-                                 (squareLogo :> obj))
+                                 (squareLogo :> obj),
+                                 1)
                                 ("square_logo_source",
-                                 (squareLogoSource :> obj))
+                                 (squareLogoSource :> obj),
+                                 1)
                                 ("square_logo_svg",
-                                 (squareLogoSvg :> obj))
+                                 (squareLogoSvg :> obj),
+                                 1)
                                 ("location_lng",
-                                 (locationLng :> obj))
+                                 (locationLng :> obj),
+                                 2)
                                 ("home_link",
-                                 (homeLink :> obj))
+                                 (homeLink :> obj),
+                                 1)
                                 ("class_logo",
-                                 (classLogo :> obj))
+                                 (classLogo :> obj),
+                                 1)
                                 ("display",
-                                 (display :> obj)) |], "")
+                                 (display :> obj),
+                                 3) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+University
     JsonDocument.Create(jsonValue, "")
@@ -627,27 +732,38 @@ class JsonProvider+IntOrString : FDR.BaseTypes.IJsonDocument
 class JsonProvider+Record : FDR.BaseTypes.IJsonDocument
     new : gradeDistinction:decimal option -> shareForWork:bool option -> isEnrolledForProctoredExam:bool -> achievementLevel:int option -> signatureTrack:bool -> passedAce:bool -> aceGrade:int -> gradeNormal:decimal option -> verifyCertId:JsonValue -> authenticatedOverall:bool -> withGradeCertId:JsonValue -> JsonProvider+Record
     JsonRuntime.CreateRecord([| ("grade_distinction",
-                                 (gradeDistinction :> obj))
+                                 (gradeDistinction :> obj),
+                                 2)
                                 ("share_for_work",
-                                 (shareForWork :> obj))
+                                 (shareForWork :> obj),
+                                 3)
                                 ("is_enrolled_for_proctored_exam",
-                                 (isEnrolledForProctoredExam :> obj))
+                                 (isEnrolledForProctoredExam :> obj),
+                                 3)
                                 ("achievement_level",
-                                 (achievementLevel :> obj))
+                                 (achievementLevel :> obj),
+                                 2)
                                 ("signature_track",
-                                 (signatureTrack :> obj))
+                                 (signatureTrack :> obj),
+                                 3)
                                 ("passed_ace",
-                                 (passedAce :> obj))
+                                 (passedAce :> obj),
+                                 3)
                                 ("ace_grade",
-                                 (aceGrade :> obj))
+                                 (aceGrade :> obj),
+                                 2)
                                 ("grade_normal",
-                                 (gradeNormal :> obj))
+                                 (gradeNormal :> obj),
+                                 2)
                                 ("verify_cert_id",
-                                 (verifyCertId :> obj))
+                                 (verifyCertId :> obj),
+                                 0)
                                 ("authenticated_overall",
-                                 (authenticatedOverall :> obj))
+                                 (authenticatedOverall :> obj),
+                                 3)
                                 ("with_grade_cert_id",
-                                 (withGradeCertId :> obj)) |], "")
+                                 (withGradeCertId :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> JsonProvider+Record
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True,,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True,,BackwardCompatible.expected
@@ -74,9 +74,11 @@ class XmlProvider+BlahData : FDR.BaseTypes.XmlElement
 class XmlProvider+BlahDataSomethingFoo : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> results:XmlProvider+Results -> XmlProvider+BlahDataSomethingFoo
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("results",
-                                 (results :> obj)) |], "")
+                                 (results :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo
     JsonDocument.Create(jsonValue, "")
@@ -115,9 +117,11 @@ class XmlProvider+BlahDataSomethingFoo2 : FDR.BaseTypes.XmlElement
 class XmlProvider+BlahDataSomethingFoo3 : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> results:XmlProvider+Results2 -> XmlProvider+BlahDataSomethingFoo3
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("results",
-                                 (results :> obj)) |], "")
+                                 (results :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo3
     JsonDocument.Create(jsonValue, "")
@@ -152,9 +156,11 @@ class XmlProvider+BlahDataSomethingFoo4 : FDR.BaseTypes.XmlElement
 class XmlProvider+X : FDR.BaseTypes.IJsonDocument
     new : t:int -> val:string -> XmlProvider+X
     JsonRuntime.CreateRecord([| ("T",
-                                 (t :> obj))
+                                 (t :> obj),
+                                 2)
                                 ("Val",
-                                 (val :> obj)) |], "")
+                                 (val :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+X
     JsonDocument.Create(jsonValue, "")
@@ -171,9 +177,11 @@ class XmlProvider+X : FDR.BaseTypes.IJsonDocument
 class XmlProvider+Results : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> query:string option -> XmlProvider+Results
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("Query",
-                                 (query :> obj)) |], "")
+                                 (query :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+Results
     JsonDocument.Create(jsonValue, "")
@@ -189,9 +197,11 @@ class XmlProvider+Results : FDR.BaseTypes.IJsonDocument
 class XmlProvider+Results2 : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> query:string -> XmlProvider+Results2
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("Query",
-                                 (query :> obj)) |], "")
+                                 (query :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+Results2
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True,,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True,,ValuesAndInlineSchemasHints.expected
@@ -74,9 +74,11 @@ class XmlProvider+BlahData : FDR.BaseTypes.XmlElement
 class XmlProvider+BlahDataSomethingFoo : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> results:XmlProvider+Results -> XmlProvider+BlahDataSomethingFoo
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("results",
-                                 (results :> obj)) |], "")
+                                 (results :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo
     JsonDocument.Create(jsonValue, "")
@@ -115,9 +117,11 @@ class XmlProvider+BlahDataSomethingFoo2 : FDR.BaseTypes.XmlElement
 class XmlProvider+BlahDataSomethingFoo3 : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> results:XmlProvider+Results2 -> XmlProvider+BlahDataSomethingFoo3
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("results",
-                                 (results :> obj)) |], "")
+                                 (results :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo3
     JsonDocument.Create(jsonValue, "")
@@ -152,9 +156,11 @@ class XmlProvider+BlahDataSomethingFoo4 : FDR.BaseTypes.XmlElement
 class XmlProvider+X : FDR.BaseTypes.IJsonDocument
     new : t:int -> val:string -> XmlProvider+X
     JsonRuntime.CreateRecord([| ("T",
-                                 (t :> obj))
+                                 (t :> obj),
+                                 2)
                                 ("Val",
-                                 (val :> obj)) |], "")
+                                 (val :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+X
     JsonDocument.Create(jsonValue, "")
@@ -171,9 +177,11 @@ class XmlProvider+X : FDR.BaseTypes.IJsonDocument
 class XmlProvider+Results : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> query:string option -> XmlProvider+Results
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("Query",
-                                 (query :> obj)) |], "")
+                                 (query :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+Results
     JsonDocument.Create(jsonValue, "")
@@ -189,9 +197,11 @@ class XmlProvider+Results : FDR.BaseTypes.IJsonDocument
 class XmlProvider+Results2 : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> query:string -> XmlProvider+Results2
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("Query",
-                                 (query :> obj)) |], "")
+                                 (query :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+Results2
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True,,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True,,ValuesAndInlineSchemasOverrides.expected
@@ -74,9 +74,11 @@ class XmlProvider+BlahData : FDR.BaseTypes.XmlElement
 class XmlProvider+BlahDataSomethingFoo : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> results:XmlProvider+Results -> XmlProvider+BlahDataSomethingFoo
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("results",
-                                 (results :> obj)) |], "")
+                                 (results :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo
     JsonDocument.Create(jsonValue, "")
@@ -115,9 +117,11 @@ class XmlProvider+BlahDataSomethingFoo2 : FDR.BaseTypes.XmlElement
 class XmlProvider+BlahDataSomethingFoo3 : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> results:XmlProvider+Results2 -> XmlProvider+BlahDataSomethingFoo3
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("results",
-                                 (results :> obj)) |], "")
+                                 (results :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo3
     JsonDocument.Create(jsonValue, "")
@@ -152,9 +156,11 @@ class XmlProvider+BlahDataSomethingFoo4 : FDR.BaseTypes.XmlElement
 class XmlProvider+X : FDR.BaseTypes.IJsonDocument
     new : t:int -> val:string -> XmlProvider+X
     JsonRuntime.CreateRecord([| ("T",
-                                 (t :> obj))
+                                 (t :> obj),
+                                 2)
                                 ("Val",
-                                 (val :> obj)) |], "")
+                                 (val :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+X
     JsonDocument.Create(jsonValue, "")
@@ -171,9 +177,11 @@ class XmlProvider+X : FDR.BaseTypes.IJsonDocument
 class XmlProvider+Results : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> query:string option -> XmlProvider+Results
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("Query",
-                                 (query :> obj)) |], "")
+                                 (query :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+Results
     JsonDocument.Create(jsonValue, "")
@@ -189,9 +197,11 @@ class XmlProvider+Results : FDR.BaseTypes.IJsonDocument
 class XmlProvider+Results2 : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> query:string -> XmlProvider+Results2
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("Query",
-                                 (query :> obj)) |], "")
+                                 (query :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+Results2
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True,,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True,,ValuesOnly.expected
@@ -74,9 +74,11 @@ class XmlProvider+BlahData : FDR.BaseTypes.XmlElement
 class XmlProvider+BlahDataSomethingFoo : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> results:XmlProvider+Results -> XmlProvider+BlahDataSomethingFoo
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("results",
-                                 (results :> obj)) |], "")
+                                 (results :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo
     JsonDocument.Create(jsonValue, "")
@@ -115,9 +117,11 @@ class XmlProvider+BlahDataSomethingFoo2 : FDR.BaseTypes.XmlElement
 class XmlProvider+BlahDataSomethingFoo3 : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> results:XmlProvider+Results2 -> XmlProvider+BlahDataSomethingFoo3
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("results",
-                                 (results :> obj)) |], "")
+                                 (results :> obj),
+                                 0) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo3
     JsonDocument.Create(jsonValue, "")
@@ -152,9 +156,11 @@ class XmlProvider+BlahDataSomethingFoo4 : FDR.BaseTypes.XmlElement
 class XmlProvider+X : FDR.BaseTypes.IJsonDocument
     new : t:int -> val:string -> XmlProvider+X
     JsonRuntime.CreateRecord([| ("T",
-                                 (t :> obj))
+                                 (t :> obj),
+                                 2)
                                 ("Val",
-                                 (val :> obj)) |], "")
+                                 (val :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+X
     JsonDocument.Create(jsonValue, "")
@@ -171,9 +177,11 @@ class XmlProvider+X : FDR.BaseTypes.IJsonDocument
 class XmlProvider+Results : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> query:string option -> XmlProvider+Results
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("Query",
-                                 (query :> obj)) |], "")
+                                 (query :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+Results
     JsonDocument.Create(jsonValue, "")
@@ -189,9 +197,11 @@ class XmlProvider+Results : FDR.BaseTypes.IJsonDocument
 class XmlProvider+Results2 : FDR.BaseTypes.IJsonDocument
     new : somethingSchema:string -> query:string -> XmlProvider+Results2
     JsonRuntime.CreateRecord([| ("Something.Schema",
-                                 (somethingSchema :> obj))
+                                 (somethingSchema :> obj),
+                                 1)
                                 ("Query",
-                                 (query :> obj)) |], "")
+                                 (query :> obj),
+                                 1) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+Results2
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,TypeInference.xml,False,False,,True,,BackwardCompatible.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,TypeInference.xml,False,False,,True,,BackwardCompatible.expected
@@ -65,7 +65,8 @@ class XmlProvider+X : FDR.BaseTypes.XmlElement
 class XmlProvider+JsonLike : FDR.BaseTypes.IJsonDocument
     new : a:int -> XmlProvider+JsonLike
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+JsonLike
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,TypeInference.xml,False,False,,True,,ValuesAndInlineSchemasHints.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,TypeInference.xml,False,False,,True,,ValuesAndInlineSchemasHints.expected
@@ -65,7 +65,8 @@ class XmlProvider+X : FDR.BaseTypes.XmlElement
 class XmlProvider+JsonLike : FDR.BaseTypes.IJsonDocument
     new : a:int -> XmlProvider+JsonLike
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+JsonLike
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,TypeInference.xml,False,False,,True,,ValuesAndInlineSchemasOverrides.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,TypeInference.xml,False,False,,True,,ValuesAndInlineSchemasOverrides.expected
@@ -65,7 +65,8 @@ class XmlProvider+X : FDR.BaseTypes.XmlElement
 class XmlProvider+JsonLike : FDR.BaseTypes.IJsonDocument
     new : a:int -> XmlProvider+JsonLike
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+JsonLike
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,TypeInference.xml,False,False,,True,,ValuesOnly.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,TypeInference.xml,False,False,,True,,ValuesOnly.expected
@@ -65,7 +65,8 @@ class XmlProvider+X : FDR.BaseTypes.XmlElement
 class XmlProvider+JsonLike : FDR.BaseTypes.IJsonDocument
     new : a:int -> XmlProvider+JsonLike
     JsonRuntime.CreateRecord([| ("a",
-                                 (a :> obj)) |], "")
+                                 (a :> obj),
+                                 2) |], "")
 
     new : jsonValue:JsonValue -> XmlProvider+JsonLike
     JsonDocument.Create(jsonValue, "")

--- a/tests/FSharp.Data.Tests/XmlProvider.fs
+++ b/tests/FSharp.Data.Tests/XmlProvider.fs
@@ -1277,7 +1277,7 @@ let ``Inline schemas are disabled by default and are recognized as strings`` () 
     sample[1].Length.String.GetType() |> should equal (typeof<string option>)
     sample[1].Length.Number.GetType() |> should equal (typeof<decimal option>)
     sample[1].String.GetType() |> should equal (typeof<string option>)
-    sample[1].Number.GetType() |> should equal (typeof<bool option>) // (There is probably a little but here. The property should be called Boolean)
+    sample[1].Number.GetType() |> should equal (typeof<bool option>) // (There is probably a little bug here. The property should be called Boolean)
 
 [<Test>]
 let ``"No inference" mode disables type inference`` () =


### PR DESCRIPTION
Before this PR, serializing a value inferred by the json type provider would always write it using its inferred type, regardless of its original primitive json type in the json sample.

Example:
```fsharp
type PT = JsonProvider<""" { "a": "42" } """> // int value in a string primitive type
PT.Root(42).JsonValue.ToString() // correctly inferred as an int

// incorrectly serialized to a json number
val it: string = "{
  "a": 42
}"
```

After this PR:
```fsharp
val it: string = "{
  "a": "42"
}"
```

This partially fixes #1271 

---

_Note: This PR is currently on top of the `fix-json-dictionaries` branch from #1476, itself on top of the `rearrange-project-files branch` from #1475 — I will rebase it on master when the other ones are merged._

EDIT: rebased and ready!