### PR TITLE
Csv Column Inference ignores newline character

### DIFF
--- a/src/FSharp.Data.Csv.Core/CsvInference.fs
+++ b/src/FSharp.Data.Csv.Core/CsvInference.fs
@@ -151,7 +151,7 @@ let internal parseHeaders headers numberOfColumns schema unitsOfMeasureProvider 
         if String.IsNullOrWhiteSpace schema then
             Array.zeroCreate headers.Length
         else
-            use reader = new StringReader(schema)
+            use reader = new StringReader(schema.Replace("\n", ""))
 
             let schemaStr =
                 CsvReader.readCsvFile reader "," '"'


### PR DESCRIPTION
Changed the string reader in the `parseHeaders` function to erase newline characters before it runs inferences using the input schema.

This will resolve the issue: https://github.com/fsprojects/FSharp.Data/issues/952 .

A test to check this change is added. The test passes.