### PR TITLE
New option for JSON serialization (#1482)

### DIFF
--- a/src/FSharp.Data.Json.Core/JsonValue.fs
+++ b/src/FSharp.Data.Json.Core/JsonValue.fs
@@ -108,7 +108,7 @@ type JsonValue =
                 w.Write "["
 
                 for i = 0 to elements.Length - 1 do
-                    comma ()
+                    if i > 0 then comma ()
                     newLine indentation 2
                     serialize (indentation + 2) elements.[i]
 

--- a/src/FSharp.Data.Json.Core/JsonValue.fs
+++ b/src/FSharp.Data.Json.Core/JsonValue.fs
@@ -26,6 +26,11 @@ type JsonSaveOptions =
     /// Print the JsonValue in one line in a compact way
     | DisableFormatting = 1
 
+    /// Print the JsonValue in one line in a compact way,
+    /// but place a single space after every comma
+    /// https://github.com/fsprojects/FSharp.Data/issues/1482
+    | CompactSpaceAfterComma = 2
+
 /// Represents a JSON value. Large numbers that do not fit in the
 /// Decimal type are represented using the Float case, while
 /// smaller numbers are represented as decimals to avoid precision loss.
@@ -67,6 +72,13 @@ type JsonValue =
 
         let propSep = if saveOptions = JsonSaveOptions.None then "\": " else "\":"
 
+        let comma () =
+            match saveOptions with
+            | JsonSaveOptions.None -> w.Write ","
+            | JsonSaveOptions.DisableFormatting -> w.Write ","
+            | JsonSaveOptions.CompactSpaceAfterComma -> w.Write ", "
+            | _ -> failwith "Invalid JsonSaveOptions"
+
         let rec serialize indentation =
             function
             | Null -> w.Write "null"
@@ -83,7 +95,7 @@ type JsonValue =
 
                 for i = 0 to properties.Length - 1 do
                     let k, v = properties.[i]
-                    if i > 0 then w.Write ","
+                    if i > 0 then comma ()
                     newLine indentation 2
                     w.Write "\""
                     JsonValue.JsonStringEncodeTo w k
@@ -96,7 +108,7 @@ type JsonValue =
                 w.Write "["
 
                 for i = 0 to elements.Length - 1 do
-                    if i > 0 then w.Write ","
+                    comma ()
                     newLine indentation 2
                     serialize (indentation + 2) elements.[i]
 


### PR DESCRIPTION
This PR resolves https://github.com/fsprojects/FSharp.Data/issues/1482.

* Add a new case in `JsonSaveOptions`
* Updated serialization method `WriteTo`
* Passed the tests


https://github.com/bonjune/FSharp.Data/blob/39da6c2d6a841baee019cd03439ad9240b5b91c7/src/FSharp.Data.Json.Core/JsonValue.fs#L20-L32