### PR TITLE
FSharp.Data.Html suggested change to enable people to use the html parser without hiding representation without having to hack the code itself.

### DIFF
--- a/src/FSharp.Data.Html.Core/FSharp.Data.Html.Core.fsproj
+++ b/src/FSharp.Data.Html.Core/FSharp.Data.Html.Core.fsproj
@@ -9,6 +9,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <!-- always have tailcalls on for design time compiler add-in to allow repo to compile in DEBUG, see https://github.com/fsprojects/FSharp.Data/issues/1410 -->
     <Tailcalls>true</Tailcalls>
+    <DefineConstants>$(DefineConstants);HIDE_REPRESENTATION</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HtmlCssSelectors.fs" />

--- a/src/FSharp.Data.Html.Core/HtmlActivePatterns.fs
+++ b/src/FSharp.Data.Html.Core/HtmlActivePatterns.fs
@@ -1,6 +1,7 @@
 namespace FSharp.Data
-
+#if HIDE_REPRESENTATION
 [<AutoOpen>]
+#endif
 module HtmlActivePatterns =
     let (|HtmlElement|HtmlText|HtmlComment|HtmlCData|) (node: HtmlNode) =
         match node with

--- a/src/FSharp.Data.Html.Core/HtmlNode.fs
+++ b/src/FSharp.Data.Html.Core/HtmlNode.fs
@@ -13,8 +13,9 @@ open System.Text
 /// </namespacedoc>
 ///
 type HtmlAttribute =
-
+#if HIDE_REPRESENTATION
     internal
+#endif
     | HtmlAttribute of name: string * value: string
 
     /// <summary>
@@ -29,8 +30,9 @@ type HtmlAttribute =
 [<RequireQualifiedAccess>]
 /// Represents an HTML node. The names of elements are always normalized to lowercase
 type HtmlNode =
-
+#if HIDE_REPRESENTATION
     internal
+#endif
     | HtmlElement of name: string * attributes: HtmlAttribute list * elements: HtmlNode list
     | HtmlText of content: string
     | HtmlComment of content: string
@@ -190,7 +192,9 @@ type HtmlNode =
 [<StructuredFormatDisplay("{_Print}")>]
 /// Represents an HTML document
 type HtmlDocument =
+#if HIDE_REPRESENTATION
     internal
+#endif
     | HtmlDocument of docType: string * elements: HtmlNode list
 
     /// <summary>

--- a/src/FSharp.Data.Html.Core/HtmlRuntime.fs
+++ b/src/FSharp.Data.Html.Core/HtmlRuntime.fs
@@ -7,7 +7,9 @@ open FSharp.Data
 open FSharp.Data.HtmlExtensions
 open FSharp.Data.Runtime
 open FSharp.Data.Runtime.StructuralTypes
-
+#if !HIDE_REPRESENTATION
+open FSharp.Data.HtmlActivePatterns
+#endif
 #nowarn "10001"
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
I'm looking to use the html parsing DSL without the encumbering that active pattern brings in terms of using those to "avoid breaking changes" in the DU definitions, costing in terms of tooling and ways to do the matching using it.

For now, this is just so people can make their own build by flipping a tag in the fsproj, but we may consider having something similar to https://github.com/fsprojects/FSharp.Data.SqlClient/blob/c6e48a47eb1d64c7de7596bae3cb50a548592357/src/SqlClient/DataTable.fs#L10 as default, and provide the same package with "HIddenRepresentation" suffix to the nuget package name, for those that feel their code will be more resilient to this library changing things.

related: #1227, #1102, https://github.com/fsharp/fslang-suggestions/issues/1341