### PR TITLE
Add vscode devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+    "name": "Existing Dockerfile",
+    "build": {
+        // Sets the run context to one level up instead of the .devcontainer folder.
+        "context": "..",
+        // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+        "dockerfile": "../Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.vscode-docker",
+                "ms-dotnettools.csdevkit",
+                "Ionide.Ionide-fsharp",
+                "Ionide.Ionide-Paket",
+                "shardulm94.trailing-spaces",
+                "esbenp.prettier-vscode",
+                "DavidAnson.vscode-markdownlint",
+                "yzhang.markdown-all-in-one"
+            ]
+        }
+    }
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Uncomment the next line to run commands after the container is created.
+    // "postCreateCommand": "cat /etc/os-release",
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "devcontainer"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:7.0-bookworm-slim
+
+ENV WORKDIR="/app" \
+    USER="vscode"
+
+WORKDIR $WORKDIR
+
+COPY --chown=${USER}:${USER} . ${WORKDIR}
+
+COPY --chown=${USERNAME}:${USERNAME} docker-entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+
+RUN dotnet tool restore && \
+    dotnet paket restore && \
+    dotnet restore

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+dotnet tool restore
+dotnet paket restore
+dotnet restore
+
+
+# Exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.203",
-    "rollForward": "major"
+      "version": "7.0.200",
+      "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Rationale

It should be very simple to set up a working development environment for the project. This pull request will lower the barrier to contribution from new developers as well as make it easier to replicate any errors or oddities that might occur.

VSCode's `devcontainer` feature is the closest to a turn-key solution I've found for creating portable and easy-to-setup developer environments. Github users can either choose to set up a Github codespace to work remotely in the cloud or pull down the repo and boot up the devcontainer environment in vscode.
