### PR TITLE
feature/json-control-indentation-spaces

### DIFF
--- a/src/FSharp.Data.Json.Core/JsonValue.fs
+++ b/src/FSharp.Data.Json.Core/JsonValue.fs
@@ -60,7 +60,7 @@ type JsonValue =
             str
 
     /// Serializes the JsonValue to the specified System.IO.TextWriter.
-    member x.WriteTo(w: TextWriter, saveOptions, ?indentationSpaces : int) =
+    member x.WriteTo(w: TextWriter, saveOptions, ?indentationSpaces: int) =
         let indentationSpaces = defaultArg indentationSpaces 2
 
         let newLine =
@@ -141,16 +141,15 @@ type JsonValue =
                     | '\\' -> w.Write "\\\\"
                     | _ -> w.Write c
 
-    member x.ToString(saveOptions, ?indentationSpaces : int) =
+    member x.ToString(saveOptions, ?indentationSpaces: int) =
         let w = new StringWriter(CultureInfo.InvariantCulture)
         x.WriteTo(w, saveOptions, ?indentationSpaces = indentationSpaces)
         w.GetStringBuilder().ToString()
 
-    member x.ToString(?indentationSpaces : int) =
+    member x.ToString(?indentationSpaces: int) =
         x.ToString(JsonSaveOptions.None, ?indentationSpaces = indentationSpaces)
 
-    override x.ToString() =
-        x.ToString(JsonSaveOptions.None)
+    override x.ToString() = x.ToString(JsonSaveOptions.None)
 
 /// <exclude />
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/src/FSharp.Data.Json.Core/JsonValue.fs
+++ b/src/FSharp.Data.Json.Core/JsonValue.fs
@@ -60,7 +60,8 @@ type JsonValue =
             str
 
     /// Serializes the JsonValue to the specified System.IO.TextWriter.
-    member x.WriteTo(w: TextWriter, saveOptions) =
+    member x.WriteTo(w: TextWriter, saveOptions, ?indentationSpaces : int) =
+        let indentationSpaces = defaultArg indentationSpaces 2
 
         let newLine =
             if saveOptions = JsonSaveOptions.None then
@@ -96,11 +97,11 @@ type JsonValue =
                 for i = 0 to properties.Length - 1 do
                     let k, v = properties.[i]
                     if i > 0 then comma ()
-                    newLine indentation 2
+                    newLine indentation indentationSpaces
                     w.Write "\""
                     JsonValue.JsonStringEncodeTo w k
                     w.Write propSep
-                    serialize (indentation + 2) v
+                    serialize (indentation + indentationSpaces) v
 
                 newLine indentation 0
                 w.Write "}"
@@ -109,8 +110,8 @@ type JsonValue =
 
                 for i = 0 to elements.Length - 1 do
                     if i > 0 then comma ()
-                    newLine indentation 2
-                    serialize (indentation + 2) elements.[i]
+                    newLine indentation indentationSpaces
+                    serialize (indentation + indentationSpaces) elements.[i]
 
                 if elements.Length > 0 then newLine indentation 0
                 w.Write "]"
@@ -140,12 +141,16 @@ type JsonValue =
                     | '\\' -> w.Write "\\\\"
                     | _ -> w.Write c
 
-    member x.ToString saveOptions =
+    member x.ToString(saveOptions, ?indentationSpaces : int) =
         let w = new StringWriter(CultureInfo.InvariantCulture)
-        x.WriteTo(w, saveOptions)
+        x.WriteTo(w, saveOptions, ?indentationSpaces = indentationSpaces)
         w.GetStringBuilder().ToString()
 
-    override x.ToString() = x.ToString(JsonSaveOptions.None)
+    member x.ToString(?indentationSpaces : int) =
+        x.ToString(JsonSaveOptions.None, ?indentationSpaces = indentationSpaces)
+
+    override x.ToString() =
+        x.ToString(JsonSaveOptions.None)
 
 /// <exclude />
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/tests/FSharp.Data.Core.Tests/JsonValue.fs
+++ b/tests/FSharp.Data.Core.Tests/JsonValue.fs
@@ -42,11 +42,11 @@ let ``Can parse document with iso date``() =
     j?anniversary.AsDateTime() |> should equal (new DateTime(2009, 05, 19, 14, 39, 22, 500, DateTimeKind.Local))
     j?anniversary.AsDateTime().Kind |> should equal DateTimeKind.Local
 
-let withCulture (cultureName: string) = 
+let withCulture (cultureName: string) =
     let originalCulture = CultureInfo.CurrentCulture;
     CultureInfo.CurrentCulture <- CultureInfo cultureName
-    { new IDisposable with 
-        member _.Dispose() = 
+    { new IDisposable with
+        member _.Dispose() =
             CultureInfo.CurrentCulture <- originalCulture }
 
 [<Test>]
@@ -139,7 +139,7 @@ let ``Can parse time span in different culture``() =
     j?duration.AsTimeSpan CultureInfo.CurrentCulture |> should equal (TimeSpan(1, 3, 16, 50, 500))
 
 [<Test>]
-let ``Can parse UTF-32 unicode characters`` () = 
+let ``Can parse UTF-32 unicode characters`` () =
   let j = JsonValue.Parse """{ "value": "\U00010343\U00010330\U0001033F\U00010339\U0001033B" }"""
   j?value.AsString() |> should equal "\U00010343\U00010330\U0001033F\U00010339\U0001033B"
 
@@ -318,6 +318,26 @@ let ``Pretty printing works``() =
 }""")
 
 [<Test>]
+let ``Pretty printing with specified indentation works``() =
+    let text = """{"items":[{"id":"Open"},null,{"id":25}],"x":{"y":2},"z":[]}"""
+    let json = JsonValue.Parse text
+    json.ToString(indentationSpaces = 3) |> normalize |> should equal (normalize """{
+   "items": [
+      {
+         "id": "Open"
+      },
+      null,
+      {
+         "id": 25
+      }
+   ],
+   "x": {
+      "y": 2
+   },
+   "z": []
+}""")
+
+[<Test>]
 let ``Can parse various JSON documents``() =
     let IsFloatNear (l : float) (r : float) =
         if r < 16. * Double.Epsilon then
@@ -467,7 +487,7 @@ let ``Can parse various JSON documents``() =
         Assert.Fail <| failures.ToString ()
 
 [<Test>]
-let ``Basic special characters encoded correctly`` () = 
+let ``Basic special characters encoded correctly`` () =
   let input = " \"quoted\" and \'quoted\' and \r\n and \uABCD "
   let w = new IO.StringWriter()
   JsonValue.JsonStringEncodeTo w input
@@ -475,7 +495,7 @@ let ``Basic special characters encoded correctly`` () =
   (w.GetStringBuilder().ToString()) |> should equal expected
 
 [<Test>]
-let ``Encoding of simple string is valid JSON`` () = 
+let ``Encoding of simple string is valid JSON`` () =
   let input = "sample \"json\" with \t\r\n \' quotes etc."
   let w = new IO.StringWriter()
   JsonValue.JsonStringEncodeTo w input


### PR DESCRIPTION
Allow user to control indentation when serializing JSON.

```fsharp
let text = """{"items":[{"id":"Open"},null,{"id":25}],"x":{"y":2},"z":[]}"""
let json = JsonValue.Parse text
json.ToString(indentationSpaces = 3)
```

An optional argument is used to keep things backward compatible. 