### PR TITLE
bugfix/issue-1509-pre-whitespace-handling

### DIFF
--- a/docs/library/HtmlProvider.fsx
+++ b/docs/library/HtmlProvider.fsx
@@ -66,7 +66,7 @@ The `Load` method allows reading the data from a file or web resource. We could 
 The following sample calls the `Load` method with an URL that points to a live version of the same page on wikipedia.
 *)
 // Download the table for the 2017 F1 calendar from Wikipedia
-let f1Calendar = F1_2017.Load(F1_2017_URL).Tables.``Season calendaredit``
+let f1Calendar = F1_2017.Load(F1_2017_URL).Tables.``Season calendar``
 
 // Look at the top row, being the first race of the calendar
 let firstRow = f1Calendar.Rows |> Seq.head
@@ -146,7 +146,7 @@ let doctorWho = new HtmlProvider<DrWho>()
 
 // Get the average number of viewers for each doctor's series run
 let viewersByDoctor =
-    doctorWho.Tables.``Season 1 (1963-1964) edit``.Rows
+    doctorWho.Tables.``Season 1 (1963-1964)``.Rows
     |> Seq.groupBy (fun season -> season.``Directed by``)
     |> Seq.map (fun (doctor, seasons) ->
         let averaged =

--- a/src/FSharp.Data.Html.Core/HtmlNode.fs
+++ b/src/FSharp.Data.Html.Core/HtmlNode.fs
@@ -134,7 +134,8 @@ type HtmlNode =
 
                 let isPreTag = name = "pre"
 
-                if canAddNewLine && not (onlyText || isPreTag) then newLine 0
+                if canAddNewLine && not (onlyText || isPreTag) then
+                    newLine 0
 
                 append "<"
                 append name

--- a/src/FSharp.Data.Html.Core/HtmlNode.fs
+++ b/src/FSharp.Data.Html.Core/HtmlNode.fs
@@ -132,7 +132,10 @@ type HtmlNode =
                         | HtmlText _ -> true
                         | _ -> false)
 
-                if canAddNewLine && not onlyText then newLine 0
+                let isPreTag = name = "pre"
+
+                if canAddNewLine && not (onlyText || isPreTag) then newLine 0
+
                 append "<"
                 append name
 
@@ -150,14 +153,14 @@ type HtmlNode =
                     appendEndTag name
                 else
                     append ">"
-                    if not onlyText then newLine 2
+                    if not (onlyText || isPreTag) then newLine 2
                     let mutable canAddNewLine = false
 
                     for element in elements do
                         serialize sb (indentation + 2) canAddNewLine element
                         canAddNewLine <- true
 
-                    if not onlyText then newLine 0
+                    if not (onlyText || isPreTag) then newLine 0
                     appendEndTag name
             | HtmlText str -> append str
             | HtmlComment str ->

--- a/tests/FSharp.Data.Core.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Core.Tests/HtmlParser.fs
@@ -858,6 +858,18 @@ let ``Drops whitespace outside pre``() =
     result |> should equal expected
 
 [<Test>]
+let ``Maintain whitespace inside pre tag through round-trip``() =
+    let html = """<pre>
+<span>Line 1</span>
+<span>Line 2</span>
+<span>Line 3</span></pre>"""
+
+    let result = HtmlDocument.Parse(html).ToString()
+
+    let expected = html
+    result |> should equal expected
+
+[<Test>]
 let ``Can parse national rail mobile site correctly``() =
     HtmlDocument.Load "UKDepartures.html"
     |> HtmlDocument.descendantsNamed false [ "li" ]


### PR DESCRIPTION
Skip new-line inside of `pre`