### PR TITLE
Small memory and performance optimization: Less nested seq-wrapping on recursive functions

### DIFF
--- a/src/FSharp.Data.Csv.Core/CsvRuntime.fs
+++ b/src/FSharp.Data.Csv.Core/CsvRuntime.fs
@@ -70,7 +70,7 @@ module internal CsvReader =
             | Char '\n' -> readLines lineNumber
             | current ->
                 seq {
-                    yield 
+                    yield
                         readLine [] (StringBuilder()) current
                         |> List.rev
                         |> Array.ofList,

--- a/src/FSharp.Data.Csv.Core/CsvRuntime.fs
+++ b/src/FSharp.Data.Csv.Core/CsvRuntime.fs
@@ -64,20 +64,22 @@ module internal CsvReader =
 
         /// Reads multiple lines from the input, skipping newline characters
         let rec readLines lineNumber =
-            seq {
-                match reader.Read() with
-                | -1 -> ()
-                | Char '\r'
-                | Char '\n' -> yield! readLines lineNumber
-                | current ->
-                    yield
-                        readLine [] (StringBuilder()) current
-                        |> List.rev
-                        |> Array.ofList,
-                        lineNumber
+            match reader.Read() with
+            | -1 -> Seq.empty
+            | Char '\r'
+            | Char '\n' -> readLines lineNumber
+            | current ->
+                let r1 = 
+                    readLine [] (StringBuilder()) current
+                    |> List.rev
+                    |> Array.ofList,
+                    lineNumber
 
-                    yield! readLines (lineNumber + 1)
-            }
+                let r2 = readLines (lineNumber + 1)
+                seq {
+                    yield r1
+                    yield! r2
+                }
 
         readLines 0
 

--- a/src/FSharp.Data.Csv.Core/CsvRuntime.fs
+++ b/src/FSharp.Data.Csv.Core/CsvRuntime.fs
@@ -69,17 +69,14 @@ module internal CsvReader =
             | Char '\r'
             | Char '\n' -> readLines lineNumber
             | current ->
-                let r1 =
-                    readLine [] (StringBuilder()) current
-                    |> List.rev
-                    |> Array.ofList,
-                    lineNumber
-
-                let r2 = readLines (lineNumber + 1)
-
                 seq {
-                    yield r1
-                    yield! r2
+                    yield 
+                        readLine [] (StringBuilder()) current
+                        |> List.rev
+                        |> Array.ofList,
+                        lineNumber
+
+                    yield! readLines (lineNumber + 1)
                 }
 
         readLines 0

--- a/src/FSharp.Data.Csv.Core/CsvRuntime.fs
+++ b/src/FSharp.Data.Csv.Core/CsvRuntime.fs
@@ -69,13 +69,14 @@ module internal CsvReader =
             | Char '\r'
             | Char '\n' -> readLines lineNumber
             | current ->
-                let r1 = 
+                let r1 =
                     readLine [] (StringBuilder()) current
                     |> List.rev
                     |> Array.ofList,
                     lineNumber
 
                 let r2 = readLines (lineNumber + 1)
+
                 seq {
                     yield r1
                     yield! r2

--- a/src/FSharp.Data.Html.Core/HtmlParser.fs
+++ b/src/FSharp.Data.Html.Core/HtmlParser.fs
@@ -19,12 +19,18 @@ module private TextParser =
     [<return: Struct>]
     let (|EndOfFile|_|) (c: char) =
         let value = c |> int
-        if (value = -1 || value = 65535) then ValueSome c else ValueNone
+
+        if (value = -1 || value = 65535) then
+            ValueSome c
+        else
+            ValueNone
 
     [<return: Struct>]
     let (|Whitespace|_|) = toPattern Char.IsWhiteSpace
+
     [<return: Struct>]
     let (|LetterDigit|_|) = toPattern Char.IsLetterOrDigit
+
     [<return: Struct>]
     let (|Letter|_|) = toPattern Char.IsLetter
 

--- a/src/FSharp.Data.Html.Core/HtmlParser.fs
+++ b/src/FSharp.Data.Html.Core/HtmlParser.fs
@@ -14,14 +14,18 @@ open System.Collections.Generic
 
 module private TextParser =
 
-    let toPattern f c = if f c then Some c else None
+    let toPattern f c = if f c then ValueSome c else ValueNone
 
+    [<return: Struct>]
     let (|EndOfFile|_|) (c: char) =
         let value = c |> int
-        if (value = -1 || value = 65535) then Some c else None
+        if (value = -1 || value = 65535) then ValueSome c else ValueNone
 
+    [<return: Struct>]
     let (|Whitespace|_|) = toPattern Char.IsWhiteSpace
+    [<return: Struct>]
     let (|LetterDigit|_|) = toPattern Char.IsLetterOrDigit
+    [<return: Struct>]
     let (|Letter|_|) = toPattern Char.IsLetter
 
 // --------------------------------------------------------------------------------------

--- a/src/FSharp.Data.Runtime.Utilities/NameUtils.fs
+++ b/src/FSharp.Data.Runtime.Utilities/NameUtils.fs
@@ -52,12 +52,9 @@ let nicePascalName (s: string) =
             | Upper _ -> consume from true (i + 1)
             | Lower _ -> consume from false (i + 1)
             | _ ->
-                let r1 = struct (from, i)
-                let r2 = restart (i + 1)
-
                 seq {
-                    yield r1
-                    yield! r2
+                    yield struct (from, i)
+                    yield! restart (i + 1)
                 }
         // Consume are letters of the same kind (either all lower or all upper)
         and consume from takeUpper i =
@@ -65,20 +62,14 @@ let nicePascalName (s: string) =
             | false, Lower _ -> consume from takeUpper (i + 1)
             | true, Upper _ -> consume from takeUpper (i + 1)
             | true, Lower _ ->
-                let r1 = struct (from, (i - 1))
-                let r2 = restart (i - 1)
-
                 seq {
-                    yield r1
-                    yield! r2
+                    yield struct (from, (i - 1))
+                    yield! restart (i - 1)
                 }
             | _ ->
-                let r1 = struct (from, i)
-                let r2 = restart i
-
                 seq {
-                    yield r1
-                    yield! r2
+                    yield struct (from, i)
+                    yield! restart i
                 }
 
         // Split string into segments and turn them to PascalCase

--- a/src/FSharp.Data.Runtime.Utilities/NameUtils.fs
+++ b/src/FSharp.Data.Runtime.Utilities/NameUtils.fs
@@ -52,9 +52,11 @@ let nicePascalName (s: string) =
             | Upper _ -> consume from true (i + 1)
             | Lower _ -> consume from false (i + 1)
             | _ ->
+                let r1 = struct (from, i)
+                let r2 = restart (i + 1)
                 seq {
-                    yield from, i
-                    yield! restart (i + 1)
+                    yield r1
+                    yield! r2
                 }
         // Consume are letters of the same kind (either all lower or all upper)
         and consume from takeUpper i =
@@ -62,14 +64,14 @@ let nicePascalName (s: string) =
             | false, Lower _ -> consume from takeUpper (i + 1)
             | true, Upper _ -> consume from takeUpper (i + 1)
             | true, Lower _ ->
-                let r1 = from, (i - 1)
+                let r1 = struct (from, (i - 1))
                 let r2 = restart (i - 1)
                 seq {
                     yield r1
                     yield! r2
                 }
             | _ ->
-                let r1 = from, i
+                let r1 = struct (from, i)
                 let r2 = restart i
                 seq {
                     yield r1

--- a/src/FSharp.Data.Runtime.Utilities/NameUtils.fs
+++ b/src/FSharp.Data.Runtime.Utilities/NameUtils.fs
@@ -54,6 +54,7 @@ let nicePascalName (s: string) =
             | _ ->
                 let r1 = struct (from, i)
                 let r2 = restart (i + 1)
+
                 seq {
                     yield r1
                     yield! r2
@@ -66,6 +67,7 @@ let nicePascalName (s: string) =
             | true, Lower _ ->
                 let r1 = struct (from, (i - 1))
                 let r2 = restart (i - 1)
+
                 seq {
                     yield r1
                     yield! r2
@@ -73,6 +75,7 @@ let nicePascalName (s: string) =
             | _ ->
                 let r1 = struct (from, i)
                 let r2 = restart i
+
                 seq {
                     yield r1
                     yield! r2


### PR DESCRIPTION

Small memory and performance optimization: 

- Less nested seq-wrapping on recursive functions

As a side note:
There are some cases where FSharp.Data does some manual recursive string-parsing-functions. More could be done on those: If we'd accept a new dependency to System.Memory on .NET Standard 2.0 version, we'd get `.AsSpan` and `ReadOnlySpan<char>` which could be used to gain speed and save memory (especially on .NET Standard 2.1 where those are available out-of-the-box and System.Memory reference is not needed).
