### PR TITLE
Update tests to .NET 8

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,13 +9,13 @@
       ]
     },
     "fake-cli": {
-      "version": "5.22.0",
+      "version": "6.1.3",
       "commands": [
         "fake"
       ]
     },
     "paket": {
-      "version": "7.1.5",
+      "version": "8.0.3",
       "commands": [
         "paket"
       ]

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -12,10 +12,14 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup .NET Core 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.203
+        dotnet-version: 6.0.425
+    - name: Setup .NET Core 8
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.400
     - name: Restore .NET local tools
       run: dotnet tool restore
     - name: Restore packages
@@ -32,10 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup .NET Core 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.203
+        dotnet-version: 6.0.425
+    - name: Setup .NET Core 8
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.400
     - name: Restore .NET local tools
       run: dotnet tool restore
     - name: Restore packages

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.203
+        dotnet-version: 8.0.400
     - name: Restore .NET local tools
       run: dotnet tool restore
     - name: Restore packages

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -1,322 +1,325 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Prevent dotnet template engine to parse this file -->
-  <!--/-:cnd:noEmit-->
-  <PropertyGroup>
-    <!-- make MSBuild track this file for incremental builds. -->
-    <!-- ref https://blogs.msdn.microsoft.com/msbuild/2005/09/26/how-to-ensure-changes-to-a-custom-target-file-prompt-a-rebuild/ -->
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+	<!-- Prevent dotnet template engine to parse this file -->
+	<!--/-:cnd:noEmit-->
+	<PropertyGroup>
+		<!-- make MSBuild track this file for incremental builds. -->
+		<!-- ref https://blogs.msdn.microsoft.com/msbuild/2005/09/26/how-to-ensure-changes-to-a-custom-target-file-prompt-a-rebuild/ -->
+		<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
-    <DetectedMSBuildVersion>$(MSBuildVersion)</DetectedMSBuildVersion>
-    <DetectedMSBuildVersion Condition="'$(MSBuildVersion)' == ''">15.0.0</DetectedMSBuildVersion>
-    <MSBuildSupportsHashing>false</MSBuildSupportsHashing>
-    <MSBuildSupportsHashing Condition=" '$(DetectedMSBuildVersion)' &gt; '15.8.0' ">true</MSBuildSupportsHashing>
-    <!-- Mark that this target file has been loaded.  -->
-    <IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>
-    <PaketToolsPath>$(MSBuildThisFileDirectory)</PaketToolsPath>
-    <PaketRootPath>$(MSBuildThisFileDirectory)..\</PaketRootPath>
-    <PaketRestoreCacheFile>$(PaketRootPath)paket-files\paket.restore.cached</PaketRestoreCacheFile>
-    <PaketLockFilePath>$(PaketRootPath)paket.lock</PaketLockFilePath>
-    <PaketBootstrapperStyle>classic</PaketBootstrapperStyle>
-    <PaketBootstrapperStyle Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">proj</PaketBootstrapperStyle>
-    <PaketExeImage>assembly</PaketExeImage>
-    <PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
-    <MonoPath Condition="'$(MonoPath)' == '' AND Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
-    <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
+		<DetectedMSBuildVersion>$(MSBuildVersion)</DetectedMSBuildVersion>
+		<DetectedMSBuildVersion Condition="'$(MSBuildVersion)' == ''">15.0.0</DetectedMSBuildVersion>
+		<MSBuildSupportsHashing>false</MSBuildSupportsHashing>
+		<MSBuildSupportsHashing Condition=" '$(DetectedMSBuildVersion)' &gt; '15.8.0' ">true</MSBuildSupportsHashing>
+		<!-- Mark that this target file has been loaded.  -->
+		<IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>
+		<PaketToolsPath>$(MSBuildThisFileDirectory)</PaketToolsPath>
+		<PaketRootPath>$(MSBuildThisFileDirectory)..\</PaketRootPath>
+		<PaketRestoreCacheFile>$(PaketRootPath)paket-files\paket.restore.cached</PaketRestoreCacheFile>
+		<PaketLockFilePath>$(PaketRootPath)paket.lock</PaketLockFilePath>
+		<PaketBootstrapperStyle>classic</PaketBootstrapperStyle>
+		<PaketBootstrapperStyle Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">proj</PaketBootstrapperStyle>
+		<PaketExeImage>assembly</PaketExeImage>
+		<PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
+		<MonoPath Condition="'$(MonoPath)' == '' AND Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
+		<MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
 
-    <!-- PaketBootStrapper  -->
-    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
-    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
-    <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
+		<!-- PaketBootStrapper  -->
+		<PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+		<PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+		<PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
 
-    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-    <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+		<PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+		<PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
 
-    <!-- Disable automagic references for F# DotNet SDK -->
-    <!-- This will not do anything for other project types -->
-    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+		<!-- Disable automagic references for F# DotNet SDK -->
+		<!-- This will not do anything for other project types -->
+		<!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
+		<DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+		<DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
-    <!-- Disable Paket restore under NCrunch build -->
-    <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
+		<!-- Disable Paket restore under NCrunch build -->
+		<PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
 
-    <!-- Disable test for CLI tool completely - overrideable via properties in projects or via environment variables -->
-    <PaketDisableCliTest Condition=" '$(PaketDisableCliTest)' == '' ">False</PaketDisableCliTest>
+		<!-- Disable test for CLI tool completely - overrideable via properties in projects or via environment variables -->
+		<PaketDisableCliTest Condition=" '$(PaketDisableCliTest)' == '' ">False</PaketDisableCliTest>
 
-    <PaketIntermediateOutputPath Condition=" '$(PaketIntermediateOutputPath)' == '' ">$(BaseIntermediateOutputPath.TrimEnd('\').TrimEnd('\/'))</PaketIntermediateOutputPath>
-  </PropertyGroup>
+		<PaketIntermediateOutputPath Condition=" '$(PaketIntermediateOutputPath)' == '' ">$(BaseIntermediateOutputPath.TrimEnd('\').TrimEnd('\/'))</PaketIntermediateOutputPath>
+	</PropertyGroup>
 
-  <!-- Resolve how paket should be called -->
-  <!-- Current priority is: local (1: repo root, 2: .paket folder) => 3: as CLI tool => as bootstrapper (4: proj Bootstrapper style, 5: BootstrapperExeDir) => 6: global path variable -->
-  <Target Name="SetPaketCommand" >
-    <!-- Test if paket is available in the standard locations. If so, that takes priority. Case 1/2 - non-windows specific -->
-    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-      <!-- no windows, try native paket as default, root => tool -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
-    </PropertyGroup>
+	<!-- Resolve how paket should be called -->
+	<!-- Current priority is: local (1: repo root, 2: .paket folder) => 3: as CLI tool => as bootstrapper (4: proj Bootstrapper style, 5: BootstrapperExeDir) => 6: global path variable -->
+	<Target Name="SetPaketCommand" >
+		<!-- Test if paket is available in the standard locations. If so, that takes priority. Case 1/2 - non-windows specific -->
+		<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+			<!-- no windows, try native paket as default, root => tool -->
+			<PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+			<PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+		</PropertyGroup>
 
-    <!-- Test if paket is available in the standard locations. If so, that takes priority. Case 2/2 - same across platforms -->
-    <PropertyGroup>
-      <!-- root => tool -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-    </PropertyGroup>
+		<!-- Test if paket is available in the standard locations. If so, that takes priority. Case 2/2 - same across platforms -->
+		<PropertyGroup>
+			<!-- root => tool -->
+			<PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+			<PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+		</PropertyGroup>
 
-    <!-- If paket hasn't be found in standard locations, test for CLI tool usage. -->
-    <!-- First test: Is CLI configured to be used in "dotnet-tools.json"? - can result in a false negative; only a positive outcome is reliable. -->
-    <PropertyGroup Condition=" '$(PaketExePath)' == '' ">
-      <_DotnetToolsJson Condition="Exists('$(PaketRootPath)/.config/dotnet-tools.json')">$([System.IO.File]::ReadAllText("$(PaketRootPath)/.config/dotnet-tools.json"))</_DotnetToolsJson>
-      <_ConfigContainsPaket Condition=" '$(_DotnetToolsJson)' != ''">$(_DotnetToolsJson.Contains('"paket"'))</_ConfigContainsPaket>
-      <_ConfigContainsPaket Condition=" '$(_ConfigContainsPaket)' == ''">false</_ConfigContainsPaket>
-    </PropertyGroup>
+		<!-- If paket hasn't be found in standard locations, test for CLI tool usage. -->
+		<!-- First test: Is CLI configured to be used in "dotnet-tools.json"? - can result in a false negative; only a positive outcome is reliable. -->
+		<PropertyGroup Condition=" '$(PaketExePath)' == '' ">
+			<_DotnetToolsJson Condition="Exists('$(PaketRootPath)/.config/dotnet-tools.json')">$([System.IO.File]::ReadAllText("$(PaketRootPath)/.config/dotnet-tools.json"))</_DotnetToolsJson>
+			<_ConfigContainsPaket Condition=" '$(_DotnetToolsJson)' != ''">$(_DotnetToolsJson.Contains('"paket"'))</_ConfigContainsPaket>
+			<_ConfigContainsPaket Condition=" '$(_ConfigContainsPaket)' == ''">false</_ConfigContainsPaket>
+		</PropertyGroup>
 
-    <!-- Second test: Call 'dotnet paket' and see if it returns without an error. Mute all the output. Only run if previous test failed and the test has not been disabled. -->
-    <!-- WARNING: This method can lead to processes hanging forever, and should be used as little as possible. See https://github.com/fsprojects/Paket/issues/3705 for details. -->
-    <Exec Condition=" '$(PaketExePath)' == '' AND !$(PaketDisableCliTest) AND !$(_ConfigContainsPaket)" Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
-      <Output TaskParameter="ExitCode" PropertyName="LocalPaketToolExitCode" />
-    </Exec>
+		<!-- Second test: Call 'dotnet paket' and see if it returns without an error. Mute all the output. Only run if previous test failed and the test has not been disabled. -->
+		<!-- WARNING: This method can lead to processes hanging forever, and should be used as little as possible. See https://github.com/fsprojects/Paket/issues/3705 for details. -->
+		<Exec Condition=" '$(PaketExePath)' == '' AND !$(PaketDisableCliTest) AND !$(_ConfigContainsPaket)" Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
+			<Output TaskParameter="ExitCode" PropertyName="LocalPaketToolExitCode" />
+		</Exec>
 
-    <!-- If paket is installed as CLI use that. Again, only if paket haven't already been found in standard locations. -->
-    <PropertyGroup Condition=" '$(PaketExePath)' == '' AND ($(_ConfigContainsPaket) OR '$(LocalPaketToolExitCode)' == '0') ">
-      <_PaketCommand>dotnet paket</_PaketCommand>
-    </PropertyGroup>
+		<!-- If paket is installed as CLI use that. Again, only if paket haven't already been found in standard locations. -->
+		<PropertyGroup Condition=" '$(PaketExePath)' == '' AND ($(_ConfigContainsPaket) OR '$(LocalPaketToolExitCode)' == '0') ">
+			<_PaketCommand>dotnet paket</_PaketCommand>
+		</PropertyGroup>
 
-    <!-- If neither local files nor CLI tool can be found, final attempt is searching for boostrapper config before falling back to global path variable. -->
-    <PropertyGroup Condition=" '$(PaketExePath)' == '' AND '$(_PaketCommand)' == '' ">
-      <!-- Test for bootstrapper setup -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket</PaketExePath>
+		<!-- If neither local files nor CLI tool can be found, final attempt is searching for boostrapper config before falling back to global path variable. -->
+		<PropertyGroup Condition=" '$(PaketExePath)' == '' AND '$(_PaketCommand)' == '' ">
+			<!-- Test for bootstrapper setup -->
+			<PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+			<PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket</PaketExePath>
 
-      <!-- If all else fails, use global path approach. -->
-      <PaketExePath Condition=" '$(PaketExePath)' == ''">paket</PaketExePath>
-    </PropertyGroup>
+			<!-- If all else fails, use global path approach. -->
+			<PaketExePath Condition=" '$(PaketExePath)' == ''">paket</PaketExePath>
+		</PropertyGroup>
 
-    <!-- If not using CLI, setup correct execution command. -->
-    <PropertyGroup Condition=" '$(_PaketCommand)' == '' ">
-      <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
-      <_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</_PaketCommand>
-      <_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</_PaketCommand>
-      <_PaketCommand Condition=" '$(_PaketCommand)' == '' ">"$(PaketExePath)"</_PaketCommand>
-    </PropertyGroup>
+		<!-- If not using CLI, setup correct execution command. -->
+		<PropertyGroup Condition=" '$(_PaketCommand)' == '' ">
+			<_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
+			<_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</_PaketCommand>
+			<_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</_PaketCommand>
+			<_PaketCommand Condition=" '$(_PaketCommand)' == '' ">"$(PaketExePath)"</_PaketCommand>
+		</PropertyGroup>
 
-    <!-- The way to get a property to be available outside the target is to use this task. -->
-    <CreateProperty Value="$(_PaketCommand)">
-      <Output TaskParameter="Value" PropertyName="PaketCommand"/>
-    </CreateProperty>
+		<!-- The way to get a property to be available outside the target is to use this task. -->
+		<CreateProperty Value="$(_PaketCommand)">
+			<Output TaskParameter="Value" PropertyName="PaketCommand"/>
+		</CreateProperty>
 
-  </Target>
+	</Target>
 
-  <Target Name="PaketBootstrapping" Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">
-    <MSBuild Projects="$(PaketToolsPath)paket.bootstrapper.proj" Targets="Restore" />
-  </Target>
+	<Target Name="PaketBootstrapping" Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">
+		<MSBuild Projects="$(PaketToolsPath)paket.bootstrapper.proj" Targets="Restore" />
+	</Target>
 
-  <!-- Official workaround for https://docs.microsoft.com/en-us/visualstudio/msbuild/getfilehash-task?view=vs-2019 -->
-  <UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
-  <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
-  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="SetPaketCommand;PaketBootstrapping">
+	<!-- Official workaround for https://docs.microsoft.com/en-us/visualstudio/msbuild/getfilehash-task?view=vs-2019 -->
+	<UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
+	<UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
+	<Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="SetPaketCommand;PaketBootstrapping">
 
-    <!-- Step 1 Check if lockfile is properly restored (if the hash of the lockfile and the cache-file match) -->
-    <PropertyGroup>
-      <PaketRestoreRequired>true</PaketRestoreRequired>
-      <NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
-      <CacheFilesExist>false</CacheFilesExist>
-      <CacheFilesExist Condition=" Exists('$(PaketRestoreCacheFile)') And Exists('$(PaketLockFilePath)') ">true</CacheFilesExist>
-    </PropertyGroup>
+		<!-- Step 1 Check if lockfile is properly restored (if the hash of the lockfile and the cache-file match) -->
+		<PropertyGroup>
+			<PaketRestoreRequired>true</PaketRestoreRequired>
+			<NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
+			<CacheFilesExist>false</CacheFilesExist>
+			<CacheFilesExist Condition=" Exists('$(PaketRestoreCacheFile)') And Exists('$(PaketLockFilePath)') ">true</CacheFilesExist>
+		</PropertyGroup>
 
-    <!-- Read the hash of the lockfile -->
-    <GetFileHash Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' " Files="$(PaketLockFilePath)" Algorithm="SHA256" HashEncoding="hex" >
-      <Output TaskParameter="Hash" PropertyName="PaketRestoreLockFileHash" />
-    </GetFileHash>
-    <!-- Read the hash of the cache, which is json, but a very simple key value object -->
-    <PropertyGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
-        <PaketRestoreCachedContents>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedContents>
-    </PropertyGroup>
-    <ItemGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
-        <!-- Parse our simple 'paket.restore.cached' json ...-->
-        <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
-        <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
-            Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
-          <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
-          <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
-        </PaketRestoreCachedKeyValue>
-    </ItemGroup>
-    <PropertyGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
-        <!-- Retrieve the hashes we are interested in -->
-        <PackagesDownloadedHash Condition=" '%(PaketRestoreCachedKeyValue.Key)' == 'packagesDownloadedHash' ">%(PaketRestoreCachedKeyValue.Value)</PackagesDownloadedHash>
-        <ProjectsRestoredHash Condition=" '%(PaketRestoreCachedKeyValue.Key)' == 'projectsRestoredHash' ">%(PaketRestoreCachedKeyValue.Value)</ProjectsRestoredHash>
-    </PropertyGroup>
+		<!-- Read the hash of the lockfile -->
+		<GetFileHash Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' " Files="$(PaketLockFilePath)" Algorithm="SHA256" HashEncoding="hex" >
+			<Output TaskParameter="Hash" PropertyName="PaketRestoreLockFileHash" />
+		</GetFileHash>
+		<!-- Read the hash of the cache, which is json, but a very simple key value object -->
+		<PropertyGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
+			<PaketRestoreCachedContents>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedContents>
+		</PropertyGroup>
+		<ItemGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
+			<!-- Parse our simple 'paket.restore.cached' json ...-->
+			<PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
+			<!-- Keep Key, Value ItemGroup-->
+			<PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
+				Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
+				<Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
+				<Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
+			</PaketRestoreCachedKeyValue>
+		</ItemGroup>
+		<PropertyGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
+			<!-- Retrieve the hashes we are interested in -->
+			<PackagesDownloadedHash Condition=" '%(PaketRestoreCachedKeyValue.Key)' == 'packagesDownloadedHash' ">%(PaketRestoreCachedKeyValue.Value)</PackagesDownloadedHash>
+			<ProjectsRestoredHash Condition=" '%(PaketRestoreCachedKeyValue.Key)' == 'projectsRestoredHash' ">%(PaketRestoreCachedKeyValue.Value)</ProjectsRestoredHash>
+		</PropertyGroup>
 
-    <PropertyGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
-      <!-- If the restore file doesn't exist we need to restore, otherwise only if hashes don't match -->
-      <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(ProjectsRestoredHash)' ">false</PaketRestoreRequired>
-      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
-    </PropertyGroup>
+		<PropertyGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
+			<!-- If the restore file doesn't exist we need to restore, otherwise only if hashes don't match -->
+			<PaketRestoreRequired>true</PaketRestoreRequired>
+			<PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(ProjectsRestoredHash)' ">false</PaketRestoreRequired>
+			<PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
+		</PropertyGroup>
 
-	<!--
+		<!--
 		This value should match the version in the props generated by paket
 		If they differ, this means we need to do a restore in order to ensure correct dependencies
 	-->
-    <PropertyGroup Condition="'$(PaketPropsVersion)' != '6.0.0' ">
-      <PaketRestoreRequired>true</PaketRestoreRequired>
-    </PropertyGroup>
+		<PropertyGroup Condition="'$(PaketPropsVersion)' != '6.0.0' ">
+			<PaketRestoreRequired>true</PaketRestoreRequired>
+		</PropertyGroup>
 
-    <!-- Do a global restore if required -->
-    <Warning Text="This version of MSBuild (we assume '$(DetectedMSBuildVersion)' or older) doesn't support GetFileHash, so paket fast restore is disabled." Condition=" '$(MSBuildSupportsHashing)' != 'true' " />
-    <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we always call the bootstrapper" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" />
-    <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
-    <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
-    <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
+		<!-- Do a global restore if required -->
+		<Warning Text="This version of MSBuild (we assume '$(DetectedMSBuildVersion)' or older) doesn't support GetFileHash, so paket fast restore is disabled." Condition=" '$(MSBuildSupportsHashing)' != 'true' " />
+		<Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we always call the bootstrapper" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" />
+		<Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
+		<Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
+		<Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
 
-    <!-- Step 2 Detect project specific changes -->
-    <ItemGroup>
-      <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>
-      <!-- Don't include all frameworks when msbuild explicitly asks for a single one -->
-      <MyTargetFrameworks Condition="'$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
-      <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(PaketIntermediateOutputPath)\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
-    </ItemGroup>
+		<!-- Step 2 Detect project specific changes -->
+		<ItemGroup>
+			<MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>
+			<!-- Don't include all frameworks when msbuild explicitly asks for a single one -->
+			<MyTargetFrameworks Condition="'$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
+			<PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(PaketIntermediateOutputPath)\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
+		</ItemGroup>
 
-    <PropertyGroup>
-      <PaketReferencesCachedFilePath>$(PaketIntermediateOutputPath)\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
-      <!-- MyProject.fsproj.paket.references has the highest precedence -->
-      <PaketOriginalReferencesFilePath>$(MSBuildProjectFullPath).paket.references</PaketOriginalReferencesFilePath>
-      <!-- MyProject.paket.references -->
-      <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
-      <!-- paket.references -->
-      <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
+		<PropertyGroup>
+			<PaketReferencesCachedFilePath>$(PaketIntermediateOutputPath)\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
+			<!-- MyProject.fsproj.paket.references has the highest precedence -->
+			<PaketOriginalReferencesFilePath>$(MSBuildProjectFullPath).paket.references</PaketOriginalReferencesFilePath>
+			<!-- MyProject.paket.references -->
+			<PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
+			<!-- paket.references -->
+			<PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
 
-      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
-      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
-      <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
-    </PropertyGroup>
+			<DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+			<DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
+			<PaketRestoreRequired>true</PaketRestoreRequired>
+			<PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
+		</PropertyGroup>
 
-    <!-- Step 2 a Detect changes in references file -->
-    <PropertyGroup Condition="Exists('$(PaketOriginalReferencesFilePath)') AND Exists('$(PaketReferencesCachedFilePath)') ">
-      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketReferencesCachedFilePath)'))</PaketRestoreCachedHash>
-      <PaketRestoreReferencesFileHash>$([System.IO.File]::ReadAllText('$(PaketOriginalReferencesFilePath)'))</PaketRestoreReferencesFileHash>
-      <PaketRestoreRequiredReason>references-file</PaketRestoreRequiredReason>
-      <PaketRestoreRequired Condition=" '$(PaketRestoreReferencesFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
-    </PropertyGroup>
+		<!-- Step 2 a Detect changes in references file -->
+		<PropertyGroup Condition="Exists('$(PaketOriginalReferencesFilePath)') AND Exists('$(PaketReferencesCachedFilePath)') ">
+			<PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketReferencesCachedFilePath)'))</PaketRestoreCachedHash>
+			<PaketRestoreReferencesFileHash>$([System.IO.File]::ReadAllText('$(PaketOriginalReferencesFilePath)'))</PaketRestoreReferencesFileHash>
+			<PaketRestoreRequiredReason>references-file</PaketRestoreRequiredReason>
+			<PaketRestoreRequired Condition=" '$(PaketRestoreReferencesFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
+		</PropertyGroup>
 
-    <PropertyGroup Condition="!Exists('$(PaketOriginalReferencesFilePath)') AND !Exists('$(PaketReferencesCachedFilePath)') ">
-      <!-- If both don't exist there is nothing to do. -->
-      <PaketRestoreRequired>false</PaketRestoreRequired>
-    </PropertyGroup>
+		<PropertyGroup Condition="!Exists('$(PaketOriginalReferencesFilePath)') AND !Exists('$(PaketReferencesCachedFilePath)') ">
+			<!-- If both don't exist there is nothing to do. -->
+			<PaketRestoreRequired>false</PaketRestoreRequired>
+		</PropertyGroup>
 
-    <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
-    <PropertyGroup Condition=" '$(DoAllResolvedFilesExist)' != 'true' ">
-      <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)' or '$(TargetFrameworks)' files @(PaketResolvedFilePaths)</PaketRestoreRequiredReason>
-    </PropertyGroup>
+		<!-- Step 2 b detect relevant changes in project file (new targetframework) -->
+		<PropertyGroup Condition=" '$(DoAllResolvedFilesExist)' != 'true' ">
+			<PaketRestoreRequired>true</PaketRestoreRequired>
+			<PaketRestoreRequiredReason>target-framework '$(TargetFramework)' or '$(TargetFrameworks)' files @(PaketResolvedFilePaths)</PaketRestoreRequiredReason>
+		</PropertyGroup>
 
-    <!-- Step 3 Restore project specific stuff if required -->
-    <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
-    <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)'" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' " />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --output-path "$(PaketIntermediateOutputPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --output-path "$(PaketIntermediateOutputPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
+		<!-- Step 3 Restore project specific stuff if required -->
+		<Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
+		<Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)'" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' " />
+		<Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --output-path "$(PaketIntermediateOutputPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
+		<Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --output-path "$(PaketIntermediateOutputPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
 
-    <!-- This shouldn't actually happen, but just to be sure. -->
-    <PropertyGroup>
-      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
-      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
-    </PropertyGroup>
-    <Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+		<!-- This shouldn't actually happen, but just to be sure. -->
+		<PropertyGroup>
+			<DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+			<DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
+		</PropertyGroup>
+		<Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
-    <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
-    <ReadLinesFromFile Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" >
-      <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
-    </ReadLinesFromFile>
+		<!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
+		<ReadLinesFromFile Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" >
+			<Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
+		</ReadLinesFromFile>
 
-    <ItemGroup Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketReferencesFileLines)' != '' " >
-      <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
-        <Splits>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',').Length)</Splits>
-        <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
-        <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
-        <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
-        <CopyLocal Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 6">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
-        <OmitContent Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 7">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[6])</OmitContent>
-        <ImportTargets Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 8">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[7])</ImportTargets>
-      </PaketReferencesFileLinesInfo>
-      <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
-        <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
-        <PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
-        <ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.CopyLocal) == 'false' or %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
-        <ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.OmitContent) == 'true'">$(ExcludeAssets);contentFiles</ExcludeAssets>
-        <ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.ImportTargets) == 'false'">$(ExcludeAssets);build;buildMultitargeting;buildTransitive</ExcludeAssets>
-        <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
-        <AllowExplicitVersion>true</AllowExplicitVersion>
-      </PackageReference>
-    </ItemGroup>
+		<ItemGroup Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketReferencesFileLines)' != '' " >
+			<PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
+				<Splits>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',').Length)</Splits>
+				<PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
+				<PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+				<AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
+				<CopyLocal Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 6">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
+				<OmitContent Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 7">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[6])</OmitContent>
+				<ImportTargets Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 8">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[7])</ImportTargets>
+				<Aliases Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 9">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[8])</Aliases>
+			</PaketReferencesFileLinesInfo>
+			<PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
+				<Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+				<PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
+				<ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.CopyLocal) == 'false' or %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
+				<ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.OmitContent) == 'true'">$(ExcludeAssets);contentFiles</ExcludeAssets>
+				<ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.ImportTargets) == 'false'">$(ExcludeAssets);build;buildMultitargeting;buildTransitive</ExcludeAssets>
+				<Aliases Condition=" %(PaketReferencesFileLinesInfo.Aliases) != ''">%(PaketReferencesFileLinesInfo.Aliases)</Aliases>
+				<Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
+				<AllowExplicitVersion>true</AllowExplicitVersion>
 
-    <PropertyGroup>
-      <PaketCliToolFilePath>$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).paket.clitools</PaketCliToolFilePath>
-    </PropertyGroup>
+			</PackageReference>
+		</ItemGroup>
 
-    <ReadLinesFromFile File="$(PaketCliToolFilePath)" >
-      <Output TaskParameter="Lines" ItemName="PaketCliToolFileLines"/>
-    </ReadLinesFromFile>
+		<PropertyGroup>
+			<PaketCliToolFilePath>$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).paket.clitools</PaketCliToolFilePath>
+		</PropertyGroup>
 
-    <ItemGroup Condition=" '@(PaketCliToolFileLines)' != '' " >
-      <PaketCliToolFileLinesInfo Include="@(PaketCliToolFileLines)" >
-        <PackageName>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[0])</PackageName>
-        <PackageVersion>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[1])</PackageVersion>
-      </PaketCliToolFileLinesInfo>
-      <DotNetCliToolReference Include="%(PaketCliToolFileLinesInfo.PackageName)">
-        <Version>%(PaketCliToolFileLinesInfo.PackageVersion)</Version>
-      </DotNetCliToolReference>
-    </ItemGroup>
+		<ReadLinesFromFile File="$(PaketCliToolFilePath)" >
+			<Output TaskParameter="Lines" ItemName="PaketCliToolFileLines"/>
+		</ReadLinesFromFile>
 
-    <!-- Disabled for now until we know what to do with runtime deps - https://github.com/fsprojects/Paket/issues/2964
+		<ItemGroup Condition=" '@(PaketCliToolFileLines)' != '' " >
+			<PaketCliToolFileLinesInfo Include="@(PaketCliToolFileLines)" >
+				<PackageName>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[0])</PackageName>
+				<PackageVersion>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[1])</PackageVersion>
+			</PaketCliToolFileLinesInfo>
+			<DotNetCliToolReference Include="%(PaketCliToolFileLinesInfo.PackageName)">
+				<Version>%(PaketCliToolFileLinesInfo.PackageVersion)</Version>
+			</DotNetCliToolReference>
+		</ItemGroup>
+
+		<!-- Disabled for now until we know what to do with runtime deps - https://github.com/fsprojects/Paket/issues/2964
     <PropertyGroup>
       <RestoreConfigFile>$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).NuGet.Config</RestoreConfigFile>
     </PropertyGroup> -->
 
-  </Target>
+	</Target>
 
-  <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
-    <PropertyGroup>
-      <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
-    </PropertyGroup>
-  </Target>
+	<Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
+		<PropertyGroup>
+			<ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
+		</PropertyGroup>
+	</Target>
 
-  <Target Name="PaketOverrideNuspec" DependsOnTargets="SetPaketCommand" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
-    <ItemGroup>
-      <_NuspecFilesNewLocation Include="$(PaketIntermediateOutputPath)\$(Configuration)\*.nuspec"/>
-      <MSBuildMajorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[0])" />
-      <MSBuildMinorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[1])" />
-    </ItemGroup>
+	<Target Name="PaketOverrideNuspec" DependsOnTargets="SetPaketCommand" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
+		<ItemGroup>
+			<_NuspecFilesNewLocation Include="$(PaketIntermediateOutputPath)\$(Configuration)\*.nuspec"/>
+			<MSBuildMajorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[0])" />
+			<MSBuildMinorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[1])" />
+		</ItemGroup>
 
-    <PropertyGroup>
-      <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
-      <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
-      <UseMSBuild16_10_Pack>false</UseMSBuild16_10_Pack>
-      <UseMSBuild16_10_Pack Condition=" '@(MSBuildMajorVersion)' >= '16' AND '@(MSBuildMinorVersion)' > '10' ">true</UseMSBuild16_10_Pack>
-      <UseMSBuild16_0_Pack>false</UseMSBuild16_0_Pack>
-      <UseMSBuild16_0_Pack Condition=" '@(MSBuildMajorVersion)' >= '16' AND (! $(UseMSBuild16_10_Pack)) ">true</UseMSBuild16_0_Pack>
-      <UseMSBuild15_9_Pack>false</UseMSBuild15_9_Pack>
-      <UseMSBuild15_9_Pack Condition=" '@(MSBuildMajorVersion)' == '15' AND '@(MSBuildMinorVersion)' > '8' ">true</UseMSBuild15_9_Pack>
-      <UseMSBuild15_8_Pack>false</UseMSBuild15_8_Pack>
-      <UseMSBuild15_8_Pack Condition=" '$(NuGetToolVersion)' != '4.0.0' AND (! $(UseMSBuild15_9_Pack)) AND (! $(UseMSBuild16_0_Pack)) AND (! $(UseMSBuild16_10_Pack)) ">true</UseMSBuild15_8_Pack>
-      <UseNuGet4_Pack>false</UseNuGet4_Pack>
-      <UseNuGet4_Pack Condition=" (! $(UseMSBuild15_8_Pack)) AND (! $(UseMSBuild15_9_Pack)) AND (! $(UseMSBuild16_0_Pack)) AND (! $(UseMSBuild16_10_Pack)) ">true</UseNuGet4_Pack>
-      <AdjustedNuspecOutputPath>$(PaketIntermediateOutputPath)\$(Configuration)</AdjustedNuspecOutputPath>
-      <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(PaketIntermediateOutputPath)</AdjustedNuspecOutputPath>
-    </PropertyGroup>
+		<PropertyGroup>
+			<PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
+			<ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
+			<UseMSBuild16_10_Pack>false</UseMSBuild16_10_Pack>
+			<UseMSBuild16_10_Pack Condition=" '@(MSBuildMajorVersion)' >= '16' AND '@(MSBuildMinorVersion)' > '10' ">true</UseMSBuild16_10_Pack>
+			<UseMSBuild16_0_Pack>false</UseMSBuild16_0_Pack>
+			<UseMSBuild16_0_Pack Condition=" '@(MSBuildMajorVersion)' >= '16' AND (! $(UseMSBuild16_10_Pack)) ">true</UseMSBuild16_0_Pack>
+			<UseMSBuild15_9_Pack>false</UseMSBuild15_9_Pack>
+			<UseMSBuild15_9_Pack Condition=" '@(MSBuildMajorVersion)' == '15' AND '@(MSBuildMinorVersion)' > '8' ">true</UseMSBuild15_9_Pack>
+			<UseMSBuild15_8_Pack>false</UseMSBuild15_8_Pack>
+			<UseMSBuild15_8_Pack Condition=" '$(NuGetToolVersion)' != '4.0.0' AND (! $(UseMSBuild15_9_Pack)) AND (! $(UseMSBuild16_0_Pack)) AND (! $(UseMSBuild16_10_Pack)) ">true</UseMSBuild15_8_Pack>
+			<UseNuGet4_Pack>false</UseNuGet4_Pack>
+			<UseNuGet4_Pack Condition=" (! $(UseMSBuild15_8_Pack)) AND (! $(UseMSBuild15_9_Pack)) AND (! $(UseMSBuild16_0_Pack)) AND (! $(UseMSBuild16_10_Pack)) ">true</UseNuGet4_Pack>
+			<AdjustedNuspecOutputPath>$(PaketIntermediateOutputPath)\$(Configuration)</AdjustedNuspecOutputPath>
+			<AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(PaketIntermediateOutputPath)</AdjustedNuspecOutputPath>
+		</PropertyGroup>
 
-    <ItemGroup>
-      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.$(PackageVersion.Split(`+`)[0]).nuspec"/>
-    </ItemGroup>
+		<ItemGroup>
+			<_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.$(PackageVersion.Split(`+`)[0]).nuspec"/>
+		</ItemGroup>
 
-    <Error Text="Error Because of PAKET_ERROR_ON_MSBUILD_EXEC (not calling fix-nuspecs)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' " />
-    <Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' />
-    <Error Condition="@(_NuspecFiles) == ''" Text='Could not find nuspec files in "$(AdjustedNuspecOutputPath)" (Version: "$(PackageVersion)"), therefore we cannot call "paket fix-nuspecs" and have to error out!' />
+		<Error Text="Error Because of PAKET_ERROR_ON_MSBUILD_EXEC (not calling fix-nuspecs)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' " />
+		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' />
+		<Error Condition="@(_NuspecFiles) == ''" Text='Could not find nuspec files in "$(AdjustedNuspecOutputPath)" (Version: "$(PackageVersion)"), therefore we cannot call "paket fix-nuspecs" and have to error out!' />
 
-    <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
-      <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>
+		<ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
+			<Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
+		</ConvertToAbsolutePath>
 
     <!-- Call Pack -->
     <PackTask Condition="$(UseMSBuild16_10_Pack)"
@@ -368,190 +371,190 @@
               Readme="$(PackageReadmeFile)"
               NoDefaultExcludes="$(NoDefaultExcludes)"/>
 
-    <PackTask Condition="$(UseMSBuild16_0_Pack)"
-              PackItem="$(PackProjectInputFile)"
-              PackageFiles="@(_PackageFiles)"
-              PackageFilesToExclude="@(_PackageFilesToExclude)"
-              PackageVersion="$(PackageVersion)"
-              PackageId="$(PackageId)"
-              Title="$(Title)"
-              Authors="$(Authors)"
-              Description="$(Description)"
-              Copyright="$(Copyright)"
-              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
-              LicenseUrl="$(PackageLicenseUrl)"
-              ProjectUrl="$(PackageProjectUrl)"
-              IconUrl="$(PackageIconUrl)"
-              ReleaseNotes="$(PackageReleaseNotes)"
-              Tags="$(PackageTags)"
-              DevelopmentDependency="$(DevelopmentDependency)"
-              BuildOutputInPackage="@(_BuildOutputInPackage)"
-              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
-              SymbolPackageFormat="$(SymbolPackageFormat)"
-              TargetFrameworks="@(_TargetFrameworks)"
-              AssemblyName="$(AssemblyName)"
-              PackageOutputPath="$(PackageOutputAbsolutePath)"
-              IncludeSymbols="$(IncludeSymbols)"
-              IncludeSource="$(IncludeSource)"
-              PackageTypes="$(PackageType)"
-              IsTool="$(IsTool)"
-              RepositoryUrl="$(RepositoryUrl)"
-              RepositoryType="$(RepositoryType)"
-              RepositoryBranch="$(RepositoryBranch)"
-              RepositoryCommit="$(RepositoryCommit)"
-              SourceFiles="@(_SourceFiles->Distinct())"
-              NoPackageAnalysis="$(NoPackageAnalysis)"
-              MinClientVersion="$(MinClientVersion)"
-              Serviceable="$(Serviceable)"
-              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
-              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
-              IncludeBuildOutput="$(IncludeBuildOutput)"
-              BuildOutputFolders="$(BuildOutputTargetFolder)"
-              ContentTargetFolders="$(ContentTargetFolders)"
-              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
-              NuspecFile="$(NuspecFileAbsolutePath)"
-              NuspecBasePath="$(NuspecBasePath)"
-              NuspecProperties="$(NuspecProperties)"
-              PackageLicenseFile="$(PackageLicenseFile)"
-              PackageLicenseExpression="$(PackageLicenseExpression)"
-              PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)"
-              NoDefaultExcludes="$(NoDefaultExcludes)" />
+		<PackTask Condition="$(UseMSBuild16_0_Pack)"
+				  PackItem="$(PackProjectInputFile)"
+				  PackageFiles="@(_PackageFiles)"
+				  PackageFilesToExclude="@(_PackageFilesToExclude)"
+				  PackageVersion="$(PackageVersion)"
+				  PackageId="$(PackageId)"
+				  Title="$(Title)"
+				  Authors="$(Authors)"
+				  Description="$(Description)"
+				  Copyright="$(Copyright)"
+				  RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+				  LicenseUrl="$(PackageLicenseUrl)"
+				  ProjectUrl="$(PackageProjectUrl)"
+				  IconUrl="$(PackageIconUrl)"
+				  ReleaseNotes="$(PackageReleaseNotes)"
+				  Tags="$(PackageTags)"
+				  DevelopmentDependency="$(DevelopmentDependency)"
+				  BuildOutputInPackage="@(_BuildOutputInPackage)"
+				  TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+				  SymbolPackageFormat="$(SymbolPackageFormat)"
+				  TargetFrameworks="@(_TargetFrameworks)"
+				  AssemblyName="$(AssemblyName)"
+				  PackageOutputPath="$(PackageOutputAbsolutePath)"
+				  IncludeSymbols="$(IncludeSymbols)"
+				  IncludeSource="$(IncludeSource)"
+				  PackageTypes="$(PackageType)"
+				  IsTool="$(IsTool)"
+				  RepositoryUrl="$(RepositoryUrl)"
+				  RepositoryType="$(RepositoryType)"
+				  RepositoryBranch="$(RepositoryBranch)"
+				  RepositoryCommit="$(RepositoryCommit)"
+				  SourceFiles="@(_SourceFiles->Distinct())"
+				  NoPackageAnalysis="$(NoPackageAnalysis)"
+				  MinClientVersion="$(MinClientVersion)"
+				  Serviceable="$(Serviceable)"
+				  FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
+				  ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+				  NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+				  IncludeBuildOutput="$(IncludeBuildOutput)"
+				  BuildOutputFolders="$(BuildOutputTargetFolder)"
+				  ContentTargetFolders="$(ContentTargetFolders)"
+				  RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+				  NuspecFile="$(NuspecFileAbsolutePath)"
+				  NuspecBasePath="$(NuspecBasePath)"
+				  NuspecProperties="$(NuspecProperties)"
+				  PackageLicenseFile="$(PackageLicenseFile)"
+				  PackageLicenseExpression="$(PackageLicenseExpression)"
+				  PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)"
+				  NoDefaultExcludes="$(NoDefaultExcludes)" />
 
-    <PackTask Condition="$(UseMSBuild15_9_Pack)"
-              PackItem="$(PackProjectInputFile)"
-              PackageFiles="@(_PackageFiles)"
-              PackageFilesToExclude="@(_PackageFilesToExclude)"
-              PackageVersion="$(PackageVersion)"
-              PackageId="$(PackageId)"
-              Title="$(Title)"
-              Authors="$(Authors)"
-              Description="$(Description)"
-              Copyright="$(Copyright)"
-              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
-              LicenseUrl="$(PackageLicenseUrl)"
-              ProjectUrl="$(PackageProjectUrl)"
-              IconUrl="$(PackageIconUrl)"
-              ReleaseNotes="$(PackageReleaseNotes)"
-              Tags="$(PackageTags)"
-              DevelopmentDependency="$(DevelopmentDependency)"
-              BuildOutputInPackage="@(_BuildOutputInPackage)"
-              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
-              SymbolPackageFormat="$(SymbolPackageFormat)"
-              TargetFrameworks="@(_TargetFrameworks)"
-              AssemblyName="$(AssemblyName)"
-              PackageOutputPath="$(PackageOutputAbsolutePath)"
-              IncludeSymbols="$(IncludeSymbols)"
-              IncludeSource="$(IncludeSource)"
-              PackageTypes="$(PackageType)"
-              IsTool="$(IsTool)"
-              RepositoryUrl="$(RepositoryUrl)"
-              RepositoryType="$(RepositoryType)"
-              RepositoryBranch="$(RepositoryBranch)"
-              RepositoryCommit="$(RepositoryCommit)"
-              SourceFiles="@(_SourceFiles->Distinct())"
-              NoPackageAnalysis="$(NoPackageAnalysis)"
-              MinClientVersion="$(MinClientVersion)"
-              Serviceable="$(Serviceable)"
-              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
-              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
-              IncludeBuildOutput="$(IncludeBuildOutput)"
-              BuildOutputFolder="$(BuildOutputTargetFolder)"
-              ContentTargetFolders="$(ContentTargetFolders)"
-              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
-              NuspecFile="$(NuspecFileAbsolutePath)"
-              NuspecBasePath="$(NuspecBasePath)"
-              NuspecProperties="$(NuspecProperties)"/>
+		<PackTask Condition="$(UseMSBuild15_9_Pack)"
+				  PackItem="$(PackProjectInputFile)"
+				  PackageFiles="@(_PackageFiles)"
+				  PackageFilesToExclude="@(_PackageFilesToExclude)"
+				  PackageVersion="$(PackageVersion)"
+				  PackageId="$(PackageId)"
+				  Title="$(Title)"
+				  Authors="$(Authors)"
+				  Description="$(Description)"
+				  Copyright="$(Copyright)"
+				  RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+				  LicenseUrl="$(PackageLicenseUrl)"
+				  ProjectUrl="$(PackageProjectUrl)"
+				  IconUrl="$(PackageIconUrl)"
+				  ReleaseNotes="$(PackageReleaseNotes)"
+				  Tags="$(PackageTags)"
+				  DevelopmentDependency="$(DevelopmentDependency)"
+				  BuildOutputInPackage="@(_BuildOutputInPackage)"
+				  TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+				  SymbolPackageFormat="$(SymbolPackageFormat)"
+				  TargetFrameworks="@(_TargetFrameworks)"
+				  AssemblyName="$(AssemblyName)"
+				  PackageOutputPath="$(PackageOutputAbsolutePath)"
+				  IncludeSymbols="$(IncludeSymbols)"
+				  IncludeSource="$(IncludeSource)"
+				  PackageTypes="$(PackageType)"
+				  IsTool="$(IsTool)"
+				  RepositoryUrl="$(RepositoryUrl)"
+				  RepositoryType="$(RepositoryType)"
+				  RepositoryBranch="$(RepositoryBranch)"
+				  RepositoryCommit="$(RepositoryCommit)"
+				  SourceFiles="@(_SourceFiles->Distinct())"
+				  NoPackageAnalysis="$(NoPackageAnalysis)"
+				  MinClientVersion="$(MinClientVersion)"
+				  Serviceable="$(Serviceable)"
+				  FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
+				  ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+				  NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+				  IncludeBuildOutput="$(IncludeBuildOutput)"
+				  BuildOutputFolder="$(BuildOutputTargetFolder)"
+				  ContentTargetFolders="$(ContentTargetFolders)"
+				  RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+				  NuspecFile="$(NuspecFileAbsolutePath)"
+				  NuspecBasePath="$(NuspecBasePath)"
+				  NuspecProperties="$(NuspecProperties)"/>
 
-    <PackTask Condition="$(UseMSBuild15_8_Pack)"
-              PackItem="$(PackProjectInputFile)"
-              PackageFiles="@(_PackageFiles)"
-              PackageFilesToExclude="@(_PackageFilesToExclude)"
-              PackageVersion="$(PackageVersion)"
-              PackageId="$(PackageId)"
-              Title="$(Title)"
-              Authors="$(Authors)"
-              Description="$(Description)"
-              Copyright="$(Copyright)"
-              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
-              LicenseUrl="$(PackageLicenseUrl)"
-              ProjectUrl="$(PackageProjectUrl)"
-              IconUrl="$(PackageIconUrl)"
-              ReleaseNotes="$(PackageReleaseNotes)"
-              Tags="$(PackageTags)"
-              DevelopmentDependency="$(DevelopmentDependency)"
-              BuildOutputInPackage="@(_BuildOutputInPackage)"
-              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
-              TargetFrameworks="@(_TargetFrameworks)"
-              AssemblyName="$(AssemblyName)"
-              PackageOutputPath="$(PackageOutputAbsolutePath)"
-              IncludeSymbols="$(IncludeSymbols)"
-              IncludeSource="$(IncludeSource)"
-              PackageTypes="$(PackageType)"
-              IsTool="$(IsTool)"
-              RepositoryUrl="$(RepositoryUrl)"
-              RepositoryType="$(RepositoryType)"
-              RepositoryBranch="$(RepositoryBranch)"
-              RepositoryCommit="$(RepositoryCommit)"
-              SourceFiles="@(_SourceFiles->Distinct())"
-              NoPackageAnalysis="$(NoPackageAnalysis)"
-              MinClientVersion="$(MinClientVersion)"
-              Serviceable="$(Serviceable)"
-              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
-              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
-              IncludeBuildOutput="$(IncludeBuildOutput)"
-              BuildOutputFolder="$(BuildOutputTargetFolder)"
-              ContentTargetFolders="$(ContentTargetFolders)"
-              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
-              NuspecFile="$(NuspecFileAbsolutePath)"
-              NuspecBasePath="$(NuspecBasePath)"
-              NuspecProperties="$(NuspecProperties)"/>
+		<PackTask Condition="$(UseMSBuild15_8_Pack)"
+				  PackItem="$(PackProjectInputFile)"
+				  PackageFiles="@(_PackageFiles)"
+				  PackageFilesToExclude="@(_PackageFilesToExclude)"
+				  PackageVersion="$(PackageVersion)"
+				  PackageId="$(PackageId)"
+				  Title="$(Title)"
+				  Authors="$(Authors)"
+				  Description="$(Description)"
+				  Copyright="$(Copyright)"
+				  RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+				  LicenseUrl="$(PackageLicenseUrl)"
+				  ProjectUrl="$(PackageProjectUrl)"
+				  IconUrl="$(PackageIconUrl)"
+				  ReleaseNotes="$(PackageReleaseNotes)"
+				  Tags="$(PackageTags)"
+				  DevelopmentDependency="$(DevelopmentDependency)"
+				  BuildOutputInPackage="@(_BuildOutputInPackage)"
+				  TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+				  TargetFrameworks="@(_TargetFrameworks)"
+				  AssemblyName="$(AssemblyName)"
+				  PackageOutputPath="$(PackageOutputAbsolutePath)"
+				  IncludeSymbols="$(IncludeSymbols)"
+				  IncludeSource="$(IncludeSource)"
+				  PackageTypes="$(PackageType)"
+				  IsTool="$(IsTool)"
+				  RepositoryUrl="$(RepositoryUrl)"
+				  RepositoryType="$(RepositoryType)"
+				  RepositoryBranch="$(RepositoryBranch)"
+				  RepositoryCommit="$(RepositoryCommit)"
+				  SourceFiles="@(_SourceFiles->Distinct())"
+				  NoPackageAnalysis="$(NoPackageAnalysis)"
+				  MinClientVersion="$(MinClientVersion)"
+				  Serviceable="$(Serviceable)"
+				  FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
+				  ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+				  NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+				  IncludeBuildOutput="$(IncludeBuildOutput)"
+				  BuildOutputFolder="$(BuildOutputTargetFolder)"
+				  ContentTargetFolders="$(ContentTargetFolders)"
+				  RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+				  NuspecFile="$(NuspecFileAbsolutePath)"
+				  NuspecBasePath="$(NuspecBasePath)"
+				  NuspecProperties="$(NuspecProperties)"/>
 
-    <PackTask Condition="$(UseNuGet4_Pack)"
-              PackItem="$(PackProjectInputFile)"
-              PackageFiles="@(_PackageFiles)"
-              PackageFilesToExclude="@(_PackageFilesToExclude)"
-              PackageVersion="$(PackageVersion)"
-              PackageId="$(PackageId)"
-              Title="$(Title)"
-              Authors="$(Authors)"
-              Description="$(Description)"
-              Copyright="$(Copyright)"
-              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
-              LicenseUrl="$(PackageLicenseUrl)"
-              ProjectUrl="$(PackageProjectUrl)"
-              IconUrl="$(PackageIconUrl)"
-              ReleaseNotes="$(PackageReleaseNotes)"
-              Tags="$(PackageTags)"
-              TargetPathsToAssemblies="@(_TargetPathsToAssemblies->'%(FinalOutputPath)')"
-              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
-              TargetFrameworks="@(_TargetFrameworks)"
-              AssemblyName="$(AssemblyName)"
-              PackageOutputPath="$(PackageOutputAbsolutePath)"
-              IncludeSymbols="$(IncludeSymbols)"
-              IncludeSource="$(IncludeSource)"
-              PackageTypes="$(PackageType)"
-              IsTool="$(IsTool)"
-              RepositoryUrl="$(RepositoryUrl)"
-              RepositoryType="$(RepositoryType)"
-              RepositoryBranch="$(RepositoryBranch)"
-              RepositoryCommit="$(RepositoryCommit)"
-              SourceFiles="@(_SourceFiles->Distinct())"
-              NoPackageAnalysis="$(NoPackageAnalysis)"
-              MinClientVersion="$(MinClientVersion)"
-              Serviceable="$(Serviceable)"
-              AssemblyReferences="@(_References)"
-              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
-              IncludeBuildOutput="$(IncludeBuildOutput)"
-              BuildOutputFolder="$(BuildOutputTargetFolder)"
-              ContentTargetFolders="$(ContentTargetFolders)"
-              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
-              NuspecFile="$(NuspecFileAbsolutePath)"
-              NuspecBasePath="$(NuspecBasePath)"
-              NuspecProperties="$(NuspecProperties)"/>
-  </Target>
-  <!--/+:cnd:noEmit-->
+		<PackTask Condition="$(UseNuGet4_Pack)"
+				  PackItem="$(PackProjectInputFile)"
+				  PackageFiles="@(_PackageFiles)"
+				  PackageFilesToExclude="@(_PackageFilesToExclude)"
+				  PackageVersion="$(PackageVersion)"
+				  PackageId="$(PackageId)"
+				  Title="$(Title)"
+				  Authors="$(Authors)"
+				  Description="$(Description)"
+				  Copyright="$(Copyright)"
+				  RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+				  LicenseUrl="$(PackageLicenseUrl)"
+				  ProjectUrl="$(PackageProjectUrl)"
+				  IconUrl="$(PackageIconUrl)"
+				  ReleaseNotes="$(PackageReleaseNotes)"
+				  Tags="$(PackageTags)"
+				  TargetPathsToAssemblies="@(_TargetPathsToAssemblies->'%(FinalOutputPath)')"
+				  TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+				  TargetFrameworks="@(_TargetFrameworks)"
+				  AssemblyName="$(AssemblyName)"
+				  PackageOutputPath="$(PackageOutputAbsolutePath)"
+				  IncludeSymbols="$(IncludeSymbols)"
+				  IncludeSource="$(IncludeSource)"
+				  PackageTypes="$(PackageType)"
+				  IsTool="$(IsTool)"
+				  RepositoryUrl="$(RepositoryUrl)"
+				  RepositoryType="$(RepositoryType)"
+				  RepositoryBranch="$(RepositoryBranch)"
+				  RepositoryCommit="$(RepositoryCommit)"
+				  SourceFiles="@(_SourceFiles->Distinct())"
+				  NoPackageAnalysis="$(NoPackageAnalysis)"
+				  MinClientVersion="$(MinClientVersion)"
+				  Serviceable="$(Serviceable)"
+				  AssemblyReferences="@(_References)"
+				  ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+				  NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+				  IncludeBuildOutput="$(IncludeBuildOutput)"
+				  BuildOutputFolder="$(BuildOutputTargetFolder)"
+				  ContentTargetFolders="$(ContentTargetFolders)"
+				  RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+				  NuspecFile="$(NuspecFileAbsolutePath)"
+				  NuspecBasePath="$(NuspecBasePath)"
+				  NuspecProperties="$(NuspecProperties)"/>
+	</Target>
+	<!--/+:cnd:noEmit-->
 </Project>

--- a/build.fsx
+++ b/build.fsx
@@ -111,12 +111,16 @@ Target.create "CleanInternetCaches" (fun _ ->
 
 Target.create "Build" (fun _ ->
     "FSharp.Data.sln"
-    |> DotNet.build (fun o -> { o with Configuration = DotNet.BuildConfiguration.Release }))
+    |> DotNet.build (fun o ->
+        { o with
+            Configuration = DotNet.BuildConfiguration.Release
+            MSBuildParams = { o.MSBuildParams with DisableInternalBinLog = true } }))
 
 Target.create "RunTests" (fun _ ->
     let setParams (o: DotNet.TestOptions) =
         { o with
             Configuration = DotNet.BuildConfiguration.Release
+            MSBuildParams = { o.MSBuildParams with DisableInternalBinLog = true }
             Logger =
                 if isCI then
                     Some "GitHubActions"
@@ -149,7 +153,10 @@ Target.create "Pack" (fun _ ->
             { p with
                 Configuration = DotNet.BuildConfiguration.Release
                 OutputPath = Some "bin"
-                MSBuildParams = { p.MSBuildParams with Properties = properties } })
+                MSBuildParams =
+                    { p.MSBuildParams with
+                        Properties = properties
+                        DisableInternalBinLog = true } })
         "FSharp.Data.sln")
 
 // --------------------------------------------------------------------------------------

--- a/docs/data/2017_F1.htm
+++ b/docs/data/2017_F1.htm
@@ -114,7 +114,7 @@ Support series:
 <li class="toclevel-2 tocsection-4"><a href="#Mid-season_changes"><span class="tocnumber">1.3</span> <span class="toctext">Mid-season changes</span></a></li>
 </ul>
 </li>
-<li class="toclevel-1 tocsection-5"><a href="#Season_calendar"><span class="tocnumber">2</span> <span class="toctext">Season calendar</span></a>
+<li class="toclevel-1 tocsection-5"><a href="#Calendar"><span class="tocnumber">2</span> <span class="toctext">Season calendar</span></a>
 <ul>
 <li class="toclevel-2 tocsection-6"><a href="#Calendar_changes"><span class="tocnumber">2.1</span> <span class="toctext">Calendar changes</span></a></li>
 </ul>
@@ -386,7 +386,7 @@ Support series:
 <li>In the week before the <a href="/wiki/2017_Malaysian_Grand_Prix" title="2017 Malaysian Grand Prix">Malaysian Grand Prix</a>, <a href="/wiki/Daniil_Kvyat" title="Daniil Kvyat">Daniil Kvyat</a> was stood down by <a href="/wiki/Scuderia_Toro_Rosso" title="Scuderia Toro Rosso">Toro Rosso</a>, making way for GP2 Series champion <a href="/wiki/Pierre_Gasly" title="Pierre Gasly">Pierre Gasly</a>.<sup id="cite_ref-62" class="reference"><a href="#cite_note-62">[58]</a></sup> Kvyat will return to the team for the <a href="/wiki/2017_United_States_Grand_Prix" title="2017 United States Grand Prix">United States Grand Prix</a>.<sup id="cite_ref-63" class="reference"><a href="#cite_note-63">[59]</a></sup></li>
 <li><a href="/wiki/Carlos_Sainz_Jr." title="Carlos Sainz Jr.">Carlos Sainz Jr.</a> left Toro Rosso after the <a href="/wiki/2017_Japanese_Grand_Prix" title="2017 Japanese Grand Prix">Japanese Grand Prix</a>. He is scheduled to move to <a href="/wiki/Renault_in_Formula_One" title="Renault in Formula One">Renault</a>, where he is planned to replace <a href="/wiki/Jolyon_Palmer" title="Jolyon Palmer">Jolyon Palmer</a>.<sup id="cite_ref-RenaultSainz17_39-1" class="reference"><a href="#cite_note-RenaultSainz17-39">[35]</a></sup></li>
 </ul>
-<h2><span class="mw-headline" id="Season_calendar">Season calendar</span></h2>
+<h2><span class="mw-headline" id="Calendar">Season calendar</span></h2>
 <div class="thumb tright">
 <div class="thumbinner" style="width:292px;"><a href="/wiki/File:Formula_1_all_over_the_world-2017.svg" class="image"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Formula_1_all_over_the_world-2017.svg/290px-Formula_1_all_over_the_world-2017.svg.png" width="290" height="128" class="thumbimage" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Formula_1_all_over_the_world-2017.svg/435px-Formula_1_all_over_the_world-2017.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Formula_1_all_over_the_world-2017.svg/580px-Formula_1_all_over_the_world-2017.svg.png 2x" data-file-width="940" data-file-height="415" /></a>
 <div class="thumbcaption">

--- a/docs/library/HtmlProvider.fsx
+++ b/docs/library/HtmlProvider.fsx
@@ -66,7 +66,7 @@ The `Load` method allows reading the data from a file or web resource. We could 
 The following sample calls the `Load` method with an URL that points to a live version of the same page on wikipedia.
 *)
 // Download the table for the 2017 F1 calendar from Wikipedia
-let f1Calendar = F1_2017.Load(F1_2017_URL).Tables.``Season calendar``
+let f1Calendar = F1_2017.Load(F1_2017_URL).Tables.Calendar
 
 // Look at the top row, being the first race of the calendar
 let firstRow = f1Calendar.Rows |> Seq.head

--- a/docs/library/JsonProvider.fsx
+++ b/docs/library/JsonProvider.fsx
@@ -306,7 +306,7 @@ let doc = WorldBank.GetSample()
 (** Note that we can also load the data directly from the web both in the `Load` method and in
 the type provider sample parameter, and there's an asynchronous `AsyncLoad` method available too: *)
 let wbReq =
-    "http://api.worldbank.org/country/cz/indicator/"
+    "https://api.worldbank.org/country/cz/indicator/"
     + "GC.DOD.TOTL.GD.ZS?format=json"
 
 let docAsync = WorldBank.AsyncLoad(wbReq)

--- a/docs/library/JsonValue.fsx
+++ b/docs/library/JsonValue.fsx
@@ -147,7 +147,7 @@ let value = JsonValue.Load(__SOURCE_DIRECTORY__ + "../../data/WorldBank.json")
 asynchronous version available too: *)
 
 let wbReq =
-    "http://api.worldbank.org/country/cz/indicator/"
+    "https://api.worldbank.org/country/cz/indicator/"
     + "GC.DOD.TOTL.GD.ZS?format=json"
 
 let valueAsync = JsonValue.AsyncLoad(wbReq)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.203",
+    "version": "8.0.400",
     "rollForward": "major"
   }
 }

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,4 +1,4 @@
-frameworks: net6.0, netstandard2.0
+frameworks: net8.0, netstandard2.0
 source https://api.nuget.org/v3/index.json
 
 # These are for TPSDK testing of TPDTCs against .NET Core App 2.0, to make sure references can be found in a known packages/... location.
@@ -20,33 +20,33 @@ group Fake
     source https://api.nuget.org/v3/index.json
     storage: none
 
-    nuget Fake.Testing.Common          5.20.3
-    nuget Fake.Net.Http                5.20.3
-    nuget Fake.IO.FileSystem           5.20.3
-    nuget Fake.Core.CommandLineParsing 5.20.3
-    nuget Fake.Core.Environment        5.20.3
-    nuget Fake.Core.FakeVar            5.20.3
-    nuget Fake.Core.SemVer             5.20.3
-    nuget Fake.Core.String             5.20.3
-    nuget Fake.Core.Context            5.20.3
-    nuget Fake.Core.Trace              5.20.3
-    nuget Fake.Core.Tasks              5.20.3
-    nuget Fake.Core.Target             5.20.3
-    nuget Fake.Core.ReleaseNotes       5.20.3
-    nuget Fake.DotNet.AssemblyInfoFile 5.20.3
-    nuget Fake.DotNet.Cli              5.20.3
-    nuget Fake.DotNet.Testing.NUnit    5.20.3
-    nuget Fake.DotNet.NuGet            5.20.3
-    nuget Fake.DotNet.MsBuild          5.20.3
-    nuget Fake.Tools.Git               5.20.3
-	nuget Fake.DotNet.Paket            5.20.3
-	nuget Microsoft.Build              16.9
-	nuget Microsoft.Build.Framework    16.9
-	nuget Microsoft.Build.Tasks.Core   16.9
-	nuget Microsoft.Build.Utilities.Core   16.9
+    nuget Fake.Testing.Common          6.1.3
+    nuget Fake.Net.Http                6.1.3
+    nuget Fake.IO.FileSystem           6.1.3
+    nuget Fake.Core.CommandLineParsing 6.1.3
+    nuget Fake.Core.Environment        6.1.3
+    nuget Fake.Core.FakeVar            6.1.3
+    nuget Fake.Core.SemVer             6.1.3
+    nuget Fake.Core.String             6.1.3
+    nuget Fake.Core.Context            6.1.3
+    nuget Fake.Core.Trace              6.1.3
+    nuget Fake.Core.Tasks              6.1.3
+    nuget Fake.Core.Target             6.1.3
+    nuget Fake.Core.ReleaseNotes       6.1.3
+    nuget Fake.DotNet.AssemblyInfoFile 6.1.3
+    nuget Fake.DotNet.Cli              6.1.3
+    nuget Fake.DotNet.Testing.NUnit    6.1.3
+    nuget Fake.DotNet.NuGet            6.1.3
+    nuget Fake.DotNet.MsBuild          6.1.3
+    nuget Fake.Tools.Git               6.1.3
+	nuget Fake.DotNet.Paket            6.1.3
+	nuget Microsoft.Build              17.11.4
+	nuget Microsoft.Build.Framework    17.11.4
+	nuget Microsoft.Build.Tasks.Core   17.11.4
+	nuget Microsoft.Build.Utilities.Core   17.11.4
 
 group Test
-    frameworks: net6.0
+    frameworks: net8.0
     source https://api.nuget.org/v3/index.json
 
     nuget FSharp.Core 6.0.1

--- a/paket.lock
+++ b/paket.lock
@@ -1,32 +1,32 @@
-RESTRICTION: || (== net6.0) (== netstandard2.0)
+RESTRICTION: || (== net8.0) (== netstandard2.0)
 NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (6.0.1)
     Microsoft.Build.Tasks.Git (1.0) - copy_local: true
     Microsoft.NETCore.App (2.2.8)
-      Microsoft.NETCore.DotNetHostPolicy (>= 2.2.8) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
-      Microsoft.NETCore.Platforms (>= 2.2.4) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
-      Microsoft.NETCore.Targets (>= 2.0) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
-      NETStandard.Library (>= 2.0.3) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
-    Microsoft.NETCore.DotNetAppHost (6.0.8) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
-    Microsoft.NETCore.DotNetHostPolicy (6.0.8) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+      Microsoft.NETCore.DotNetHostPolicy (>= 2.2.8) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+      Microsoft.NETCore.Platforms (>= 2.2.4) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+      Microsoft.NETCore.Targets (>= 2.0) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+      NETStandard.Library (>= 2.0.3) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+    Microsoft.NETCore.DotNetAppHost (6.0.8) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+    Microsoft.NETCore.DotNetHostPolicy (6.0.8) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
       Microsoft.NETCore.DotNetHostResolver (>= 6.0.8)
-    Microsoft.NETCore.DotNetHostResolver (6.0.8) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+    Microsoft.NETCore.DotNetHostResolver (6.0.8) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
       Microsoft.NETCore.DotNetAppHost (>= 6.0.8)
-    Microsoft.NETCore.Platforms (6.0.5) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
-    Microsoft.NETCore.Targets (5.0) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+    Microsoft.NETCore.Platforms (6.0.5) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+    Microsoft.NETCore.Targets (5.0) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
     Microsoft.SourceLink.Common (1.0) - copy_local: true
     Microsoft.SourceLink.GitHub (1.0) - copy_local: true
       Microsoft.Build.Tasks.Git (>= 1.0)
       Microsoft.SourceLink.Common (>= 1.0)
-    NETStandard.Library (2.0.3) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
+    NETStandard.Library (2.0.3) - restriction: || (== net8.0) (&& (== netstandard2.0) (>= netcoreapp2.2))
       Microsoft.NETCore.Platforms (>= 1.1)
     NETStandard.Library.NETFramework (2.0.0-preview2-25405-01)
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.SDK
-    src/ProvidedTypes.fs (48abfa531a90a42a7f62a7cbfd0027741e83b9da)
-    src/ProvidedTypes.fsi (48abfa531a90a42a7f62a7cbfd0027741e83b9da)
-    tests/ProvidedTypesTesting.fs (48abfa531a90a42a7f62a7cbfd0027741e83b9da)
+    src/ProvidedTypes.fs (3a9510e466cb8ab04e0b86841dc777994909f881)
+    src/ProvidedTypes.fsi (3a9510e466cb8ab04e0b86841dc777994909f881)
+    tests/ProvidedTypesTesting.fs (3a9510e466cb8ab04e0b86841dc777994909f881)
 GROUP Fake
 STORAGE: NONE
 NUGET
@@ -35,307 +35,286 @@ NUGET
       FSharp.Core (>= 4.0.0.1) - restriction: >= net45
       FSharp.Core (>= 4.2.3) - restriction: && (< net45) (>= netstandard2.0)
       Microsoft.Win32.Registry (>= 4.7) - restriction: && (< net45) (>= netstandard2.0)
-    Fake.Core.CommandLineParsing (5.20.3)
+    Fake.Core.CommandLineParsing (6.1.3)
       FParsec (>= 1.1.1) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Context (5.20.3)
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Environment (5.20.3)
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.FakeVar (5.20.3)
-      Fake.Core.Context (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Process (5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-      System.Collections.Immutable (>= 1.7.1) - restriction: >= netstandard2.0
-    Fake.Core.ReleaseNotes (5.20.3)
-      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.SemVer (5.20.3)
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.String (5.20.3)
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Target (5.20.3)
-      Fake.Core.CommandLineParsing (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Context (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Control.Reactive (>= 4.4.2) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Tasks (5.20.3)
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Trace (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Xml (5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.DotNet.AssemblyInfoFile (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.DotNet.Cli (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.DotNet.MSBuild (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.DotNet.NuGet (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.Context (6.1.3)
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.Environment (6.1.3)
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.FakeVar (6.1.3)
+      Fake.Core.Context (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.Process (6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+      System.Collections.Immutable (>= 8.0) - restriction: >= netstandard2.0
+    Fake.Core.ReleaseNotes (6.1.3)
+      Fake.Core.SemVer (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.SemVer (6.1.3)
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.String (6.1.3)
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.Target (6.1.3)
+      Fake.Core.CommandLineParsing (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Context (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Control.Reactive (>= 5.0.2) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.Tasks (6.1.3)
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.Trace (6.1.3)
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Core.Xml (6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.DotNet.AssemblyInfoFile (6.1.3)
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.DotNet.Cli (6.1.3)
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.DotNet.MSBuild (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.DotNet.NuGet (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
       Mono.Posix.NETStandard (>= 1.0) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 12.0.3) - restriction: >= netstandard2.0
-    Fake.DotNet.MSBuild (5.20.3)
+      Newtonsoft.Json (>= 13.0.3) - restriction: >= netstandard2.0
+    Fake.DotNet.MSBuild (6.1.3)
       BlackFox.VsWhere (>= 1.1) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-      MSBuild.StructuredLogger (>= 2.1.176) - restriction: >= netstandard2.0
-    Fake.DotNet.NuGet (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Tasks (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Xml (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Net.Http (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 12.0.3) - restriction: >= netstandard2.0
-      NuGet.Protocol (>= 5.6) - restriction: >= netstandard2.0
-    Fake.DotNet.Paket (5.20.3)
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.DotNet.Cli (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.DotNet.Testing.NUnit (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Testing.Common (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.IO.FileSystem (5.20.3)
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Net.Http (5.20.3)
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Testing.Common (5.20.3)
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Tools.Git (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+      MSBuild.StructuredLogger (>= 2.1.815) - restriction: >= netstandard2.0
+    Fake.DotNet.NuGet (6.1.3)
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.SemVer (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Tasks (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Xml (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Net.Http (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+      Newtonsoft.Json (>= 13.0.3) - restriction: >= netstandard2.0
+      NuGet.Protocol (>= 6.10.1) - restriction: >= netstandard2.0
+    Fake.DotNet.Paket (6.1.3)
+      Fake.Core.Process (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.DotNet.Cli (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.DotNet.Testing.NUnit (6.1.3)
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Testing.Common (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.IO.FileSystem (6.1.3)
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Net.Http (6.1.3)
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Testing.Common (6.1.3)
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
+    Fake.Tools.Git (6.1.3)
+      Fake.Core.Environment (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.SemVer (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 6.1.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 6.1.3) - restriction: >= netstandard2.0
+      FSharp.Core (>= 8.0.301) - restriction: >= netstandard2.0
     FParsec (1.1.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.3.4) - restriction: || (>= net45) (>= netstandard2.0)
       System.ValueTuple (>= 4.4) - restriction: >= net45
     FSharp.Control.Reactive (5.0.5) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       System.Reactive (>= 5.0 < 6.0) - restriction: >= netstandard2.0
-    FSharp.Core (6.0.5) - restriction: >= netstandard2.0
-    Microsoft.Bcl.AsyncInterfaces (6.0) - restriction: || (&& (>= net461) (>= netcoreapp2.1)) (>= net472) (&& (>= netcoreapp2.1) (< netcoreapp3.1))
-      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (>= netstandard2.0) (< netstandard2.1))
-    Microsoft.Build (16.9)
-      Microsoft.Build.Framework (>= 16.9) - restriction: || (>= net472) (>= netcoreapp2.1)
-      Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
-      Microsoft.Win32.Registry (>= 4.3) - restriction: >= netcoreapp2.1
-      System.Collections.Immutable (>= 5.0) - restriction: || (>= net472) (>= netcoreapp2.1)
-      System.Memory (>= 4.5.4) - restriction: || (>= net472) (>= netcoreapp2.1)
-      System.Reflection.Metadata (>= 1.6) - restriction: >= netcoreapp2.1
-      System.Security.Principal.Windows (>= 4.7) - restriction: >= netcoreapp2.1
-      System.Text.Encoding.CodePages (>= 4.0.1) - restriction: >= netcoreapp2.1
-      System.Text.Json (>= 4.7) - restriction: || (>= net472) (>= netcoreapp2.1)
-      System.Threading.Tasks.Dataflow (>= 4.9) - restriction: || (>= net472) (>= netcoreapp2.1)
-    Microsoft.Build.Framework (16.9)
-      System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
-    Microsoft.Build.Tasks.Core (16.9)
-      Microsoft.Build.Framework (>= 16.9) - restriction: >= netstandard2.0
-      Microsoft.Build.Utilities.Core (>= 16.9) - restriction: >= netstandard2.0
-      Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
-      Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net472) (>= netstandard2.0)
-      System.CodeDom (>= 4.4) - restriction: && (< net472) (>= netstandard2.0)
-      System.Collections.Immutable (>= 5.0) - restriction: >= netstandard2.0
-      System.Reflection.Metadata (>= 1.6) - restriction: && (< net472) (>= netstandard2.0)
-      System.Reflection.TypeExtensions (>= 4.1) - restriction: && (< net472) (>= netstandard2.0)
-      System.Resources.Extensions (>= 4.6) - restriction: >= netstandard2.0
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< net472) (>= netstandard2.0)
-      System.Security.Cryptography.Pkcs (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
-      System.Security.Cryptography.Xml (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
-      System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
-      System.Threading.Tasks.Dataflow (>= 4.9) - restriction: >= netstandard2.0
-    Microsoft.Build.Utilities.Core (16.9)
-      Microsoft.Build.Framework (>= 16.9) - restriction: >= netstandard2.0
-      Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
-      Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net472) (>= netstandard2.0)
-      System.Collections.Immutable (>= 5.0) - restriction: >= netstandard2.0
-      System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
-      System.Text.Encoding.CodePages (>= 4.0.1) - restriction: && (< net472) (>= netstandard2.0)
-    Microsoft.NETCore.Platforms (6.0.5) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.2) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.5) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.1) (>= netcoreapp3.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net462) (>= netstandard2.0)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp2.1) (< netcoreapp3.0))
-    Microsoft.NETCore.Targets (5.0) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.2) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.5) (>= netstandard2.0)) (&& (< net45) (>= net462) (>= netstandard2.0)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    Microsoft.VisualStudio.Setup.Configuration.Interop (3.3.2180) - restriction: >= net472
-    Microsoft.Win32.Registry (5.0) - restriction: || (&& (< net45) (>= netstandard2.0)) (&& (< net472) (>= netstandard2.0)) (>= netcoreapp2.1)
+    FSharp.Core (8.0.400) - restriction: >= netstandard2.0
+    Microsoft.Bcl.AsyncInterfaces (8.0) - restriction: >= net472
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net462) (&& (>= netstandard2.0) (< netstandard2.1))
+    Microsoft.Build (17.11.4)
+      Microsoft.Build.Framework (>= 17.11.4) - restriction: || (>= net472) (>= net8.0)
+      Microsoft.IO.Redist (>= 6.0) - restriction: >= net472
+      Microsoft.NET.StringTools (>= 17.11.4) - restriction: || (>= net472) (>= net8.0)
+      System.Collections.Immutable (>= 8.0) - restriction: || (>= net472) (>= net8.0)
+      System.Configuration.ConfigurationManager (>= 8.0) - restriction: || (>= net472) (>= net8.0)
+      System.Memory (>= 4.5.5) - restriction: >= net472
+      System.Reflection.Metadata (>= 8.0) - restriction: || (>= net472) (>= net8.0)
+      System.Reflection.MetadataLoadContext (>= 8.0) - restriction: || (>= net472) (>= net8.0)
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: >= net472
+      System.Security.Principal.Windows (>= 5.0) - restriction: >= net472
+      System.Text.Json (>= 8.0.3) - restriction: >= net472
+      System.Threading.Tasks.Dataflow (>= 8.0) - restriction: >= net472
+    Microsoft.Build.Framework (17.11.4)
+      Microsoft.Win32.Registry (>= 5.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.Memory (>= 4.5.5) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+      System.Security.Principal.Windows (>= 5.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+    Microsoft.Build.Tasks.Core (17.11.4)
+      Microsoft.Build.Framework (>= 17.11.4) - restriction: >= netstandard2.0
+      Microsoft.Build.Utilities.Core (>= 17.11.4) - restriction: >= netstandard2.0
+      Microsoft.IO.Redist (>= 6.0) - restriction: >= net472
+      Microsoft.NET.StringTools (>= 17.11.4) - restriction: >= netstandard2.0
+      Microsoft.Win32.Registry (>= 5.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.CodeDom (>= 8.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net8.0)
+      System.Collections.Immutable (>= 8.0) - restriction: >= netstandard2.0
+      System.Configuration.ConfigurationManager (>= 8.0) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.5) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+      System.Reflection.Metadata (>= 8.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.Resources.Extensions (>= 8.0) - restriction: >= netstandard2.0
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+      System.Security.Cryptography.Pkcs (>= 8.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net8.0)
+      System.Security.Cryptography.Xml (>= 8.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net8.0)
+      System.Security.Principal.Windows (>= 5.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.Text.Encoding.CodePages (>= 7.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.Threading.Tasks.Dataflow (>= 8.0) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+    Microsoft.Build.Utilities.Core (17.11.4)
+      Microsoft.Build.Framework (>= 17.11.4) - restriction: >= netstandard2.0
+      Microsoft.IO.Redist (>= 6.0) - restriction: >= net472
+      Microsoft.NET.StringTools (>= 17.11.4) - restriction: >= netstandard2.0
+      Microsoft.Win32.Registry (>= 5.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.Collections.Immutable (>= 8.0) - restriction: >= netstandard2.0
+      System.Configuration.ConfigurationManager (>= 8.0) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.5) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+      System.Security.Principal.Windows (>= 5.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.Text.Encoding.CodePages (>= 7.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+    Microsoft.IO.Redist (6.0.1) - restriction: >= net472
+      System.Buffers (>= 4.5.1) - restriction: >= net472
+      System.Memory (>= 4.5.4) - restriction: >= net472
+    Microsoft.NET.StringTools (17.11.4) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.5) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+    Microsoft.NETCore.Platforms (6.0.5) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= net8.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+    Microsoft.NETCore.Targets (5.0) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81))
+    Microsoft.Win32.Registry (5.0) - restriction: || (&& (< net45) (>= netstandard2.0)) (&& (< net472) (< net8.0) (>= netstandard2.0))
       System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= uap10.1)
       System.Security.AccessControl (>= 5.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Security.Principal.Windows (>= 5.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    Microsoft.Win32.SystemEvents (6.0.1) - restriction: >= netcoreapp3.1
     Mono.Posix.NETStandard (1.0) - restriction: >= netstandard2.0
-    MSBuild.StructuredLogger (2.1.507) - restriction: >= netstandard2.0
-      Microsoft.Build (>= 16.4) - restriction: >= netstandard2.0
-      Microsoft.Build.Framework (>= 16.4) - restriction: >= netstandard2.0
-      Microsoft.Build.Tasks.Core (>= 16.4) - restriction: >= netstandard2.0
-      Microsoft.Build.Utilities.Core (>= 16.4) - restriction: >= netstandard2.0
-    Newtonsoft.Json (13.0.1) - restriction: >= netstandard2.0
-    NuGet.Common (6.3) - restriction: >= netstandard2.0
-      NuGet.Frameworks (>= 6.3) - restriction: >= netstandard2.0
-    NuGet.Configuration (6.3) - restriction: >= netstandard2.0
-      NuGet.Common (>= 6.3) - restriction: >= netstandard2.0
+    MSBuild.StructuredLogger (2.1.815) - restriction: >= netstandard2.0
+      Microsoft.Build.Framework (>= 16.10) - restriction: >= netstandard2.0
+      Microsoft.Build.Utilities.Core (>= 16.10) - restriction: >= netstandard2.0
+    Newtonsoft.Json (13.0.3) - restriction: >= netstandard2.0
+    NuGet.Common (6.11) - restriction: >= netstandard2.0
+      NuGet.Frameworks (>= 6.11) - restriction: >= netstandard2.0
+    NuGet.Configuration (6.11) - restriction: >= netstandard2.0
+      NuGet.Common (>= 6.11) - restriction: >= netstandard2.0
       System.Security.Cryptography.ProtectedData (>= 4.4) - restriction: && (< net472) (>= netstandard2.0)
-    NuGet.Frameworks (6.3) - restriction: >= netstandard2.0
-    NuGet.Packaging (6.3) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 13.0.1) - restriction: >= netstandard2.0
-      NuGet.Configuration (>= 6.3) - restriction: >= netstandard2.0
-      NuGet.Versioning (>= 6.3) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Cng (>= 5.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net5.0)
-      System.Security.Cryptography.Pkcs (>= 5.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net5.0)
-    NuGet.Protocol (6.3) - restriction: >= netstandard2.0
-      NuGet.Packaging (>= 6.3) - restriction: >= netstandard2.0
-    NuGet.Versioning (6.3) - restriction: >= netstandard2.0
-    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (>= netcoreapp2.1) (< netstandard1.1)) (&& (>= monoandroid) (>= netcoreapp2.1) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp2.1) (< netstandard1.1)) (&& (< monoandroid) (>= netcoreapp2.1) (< netstandard2.0)) (&& (>= monotouch) (>= netcoreapp2.1)) (&& (>= net45) (>= netcoreapp2.1) (< netstandard2.0)) (&& (>= net461) (>= netcoreapp2.1)) (&& (>= net461) (>= netstandard2.1)) (&& (< net461) (< net6.0) (>= netstandard2.0)) (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (>= net472) (&& (< net6.0) (>= netstandard2.1)) (&& (< netcoreapp2.0) (>= netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.1)) (&& (>= netcoreapp2.1) (< netstandard1.1) (>= win8)) (&& (>= netcoreapp2.1) (< netstandard2.0) (>= wpa81)) (&& (>= netcoreapp2.1) (>= xamarinios)) (&& (>= netcoreapp2.1) (>= xamarinmac)) (&& (>= netcoreapp2.1) (>= xamarintvos)) (&& (>= netcoreapp2.1) (>= xamarinwatchos))
-    System.CodeDom (6.0) - restriction: && (< net472) (>= netstandard2.0)
-    System.Collections.Immutable (6.0) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
-      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Drawing.Common (6.0) - restriction: >= netcoreapp3.1
-      Microsoft.Win32.SystemEvents (>= 6.0) - restriction: >= netcoreapp3.1
-    System.Formats.Asn1 (6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp3.0) (< xamarintvos) (< xamarinwatchos)) (>= netstandard2.1)
-      System.Buffers (>= 4.5.1) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
-    System.IO (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.5) (>= netstandard2.0)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Memory (4.5.5) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (>= net472) (&& (< net6.0) (>= netstandard2.0)) (>= netcoreapp2.1)
+    NuGet.Frameworks (6.11) - restriction: >= netstandard2.0
+    NuGet.Packaging (6.11) - restriction: >= netstandard2.0
+      Newtonsoft.Json (>= 13.0.3) - restriction: >= netstandard2.0
+      NuGet.Configuration (>= 6.11) - restriction: >= netstandard2.0
+      NuGet.Versioning (>= 6.11) - restriction: >= netstandard2.0
+      System.Security.Cryptography.Pkcs (>= 6.0.4) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net5.0)
+    NuGet.Protocol (6.11) - restriction: >= netstandard2.0
+      NuGet.Packaging (>= 6.11) - restriction: >= netstandard2.0
+      System.Text.Json (>= 7.0.3) - restriction: || (>= net472) (&& (< net5.0) (>= netstandard2.0))
+    NuGet.Versioning (6.11) - restriction: >= netstandard2.0
+    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.3) (>= netstandard2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= net462) (>= netstandard2.1)) (&& (< net462) (< net6.0) (>= netstandard2.0)) (&& (< net462) (>= netstandard2.0) (< netstandard2.1)) (>= net472) (&& (< net6.0) (>= netstandard2.1)) (&& (>= net8.0) (< netstandard2.1)) (&& (< net8.0) (>= netstandard2.0) (>= xamarintvos)) (&& (< net8.0) (>= netstandard2.0) (>= xamarinwatchos)) (&& (< net8.0) (>= xamarinios)) (&& (< net8.0) (>= xamarinmac))
+    System.CodeDom (8.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net8.0)
+    System.Collections.Immutable (8.0) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net462) (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0))
+    System.Configuration.ConfigurationManager (8.0) - restriction: >= netstandard2.0
+      System.Diagnostics.EventLog (>= 8.0) - restriction: >= net7.0
+      System.Security.Cryptography.ProtectedData (>= 8.0) - restriction: || (&& (< net462) (>= netstandard2.0)) (>= net6.0)
+    System.Diagnostics.EventLog (8.0) - restriction: || (&& (>= net472) (>= net7.0)) (>= net8.0)
+    System.Formats.Asn1 (8.0.1) - restriction: || (&& (< net462) (>= netstandard2.0)) (&& (>= net8.0) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp3.0) (< xamarintvos) (< xamarinwatchos)) (>= netstandard2.1)
+      System.Buffers (>= 4.5.1) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+    System.Memory (4.5.5) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net462) (>= netstandard2.0)) (&& (< net462) (>= netstandard2.0) (< netstandard2.1)) (>= net472) (&& (< net6.0) (>= net8.0)) (&& (< net6.0) (>= netstandard2.0)) (&& (>= net8.0) (< netstandard2.1)) (&& (< net8.0) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1))
       System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Numerics.Vectors (>= 4.5) - restriction: >= net461
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    System.Numerics.Vectors (4.5) - restriction: || (&& (>= net461) (>= netcoreapp2.1)) (>= net472) (&& (>= netcoreapp2.1) (< netcoreapp3.1))
+    System.Numerics.Vectors (4.5) - restriction: >= net472
     System.Reactive (5.0) - restriction: >= netstandard2.0
       System.Runtime.InteropServices.WindowsRuntime (>= 4.3) - restriction: && (< net472) (< netcoreapp3.1) (>= netstandard2.0)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net472) (&& (< netcoreapp3.1) (>= netstandard2.0)) (>= uap10.1)
-    System.Reflection (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Reflection.Metadata (6.0.1) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= netcoreapp2.1)
-      System.Collections.Immutable (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Reflection.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Reflection.TypeExtensions (4.7) - restriction: && (< net472) (>= netstandard2.0)
-    System.Resources.Extensions (6.0) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
-    System.Runtime (4.3.1) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.5) (>= netstandard2.0)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net462) (< net472) (>= netstandard2.0)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
+    System.Reflection.Metadata (8.0) - restriction: >= netstandard2.0
+      System.Collections.Immutable (>= 8.0) - restriction: || (>= net462) (>= netstandard2.0)
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+    System.Reflection.MetadataLoadContext (8.0) - restriction: || (>= net472) (>= net8.0)
+      System.Collections.Immutable (>= 8.0) - restriction: || (>= net462) (>= netstandard2.0)
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Reflection.Metadata (>= 8.0) - restriction: || (>= net462) (>= netstandard2.0)
+    System.Resources.Extensions (8.0) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+    System.Runtime (4.3.1) - restriction: && (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Runtime.CompilerServices.Unsafe (6.0) - restriction: || (>= net472) (>= netcoreapp2.1)
-    System.Runtime.Handles (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.InteropServices (4.3) - restriction: && (< net472) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
+    System.Runtime.CompilerServices.Unsafe (6.0) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net472) (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0)) (&& (< net8.0) (>= netstandard2.0))
     System.Runtime.InteropServices.WindowsRuntime (4.3) - restriction: && (< net472) (< netcoreapp3.1) (>= netstandard2.0)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.AccessControl (6.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= netcoreapp2.1)
+    System.Security.AccessControl (6.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (< net8.0) (>= netcoreapp2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= net461) (< net472) (>= netstandard2.0)) (&& (< net462) (< net6.0) (>= netstandard2.0)) (&& (< net6.0) (>= net8.0)) (&& (< net8.0) (>= netcoreapp2.1)) (&& (< net8.0) (>= netstandard2.0) (>= xamarintvos)) (&& (< net8.0) (>= netstandard2.0) (>= xamarinwatchos)) (&& (< net8.0) (>= xamarinios)) (&& (< net8.0) (>= xamarinmac)) (&& (>= netstandard2.0) (>= uap10.1))
       System.Security.Principal.Windows (>= 5.0) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
-    System.Security.Cryptography.Cng (5.0) - restriction: || (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (&& (< net472) (>= netstandard2.0)) (>= net5.0) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.1))
+    System.Security.Cryptography.Cng (5.0) - restriction: || (&& (< net462) (>= netstandard2.0) (< netstandard2.1)) (&& (< net6.0) (>= net8.0)) (&& (< net6.0) (>= netstandard2.1)) (&& (>= net8.0) (< netstandard2.1))
       Microsoft.NETCore.Platforms (>= 5.0) - restriction: && (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)
       System.Formats.Asn1 (>= 5.0) - restriction: && (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Pkcs (6.0.1) - restriction: || (&& (< net461) (>= netstandard2.0)) (&& (< net472) (>= netstandard2.0)) (>= net5.0)
-      System.Buffers (>= 4.5.1) - restriction: && (< net461) (>= netstandard2.0) (< netstandard2.1)
-      System.Formats.Asn1 (>= 6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= netstandard2.1)
-      System.Memory (>= 4.5.4) - restriction: && (< net461) (>= netstandard2.0) (< netstandard2.1)
-      System.Security.Cryptography.Cng (>= 5.0) - restriction: || (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.1))
-    System.Security.Cryptography.ProtectedData (6.0) - restriction: && (< net472) (>= netstandard2.0)
-      System.Memory (>= 4.5.4) - restriction: && (< net461) (< net6.0) (>= netstandard2.0)
-    System.Security.Cryptography.Xml (6.0.1) - restriction: && (< net472) (>= netstandard2.0)
-      System.Memory (>= 4.5.4) - restriction: && (< net461) (< net6.0) (>= netstandard2.0)
-      System.Security.AccessControl (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Security.Cryptography.Pkcs (>= 6.0.1) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= net6.0)
-    System.Security.Permissions (6.0) - restriction: && (< net472) (>= netstandard2.0)
-      System.Security.AccessControl (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Windows.Extensions (>= 6.0) - restriction: >= netcoreapp3.1
-    System.Security.Principal.Windows (5.0) - restriction: || (&& (>= net461) (< net472) (>= netstandard2.0)) (&& (< net472) (< net6.0) (>= netstandard2.0)) (>= netcoreapp2.1)
-      Microsoft.NETCore.Platforms (>= 5.0) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0))
-    System.Text.Encoding (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.5) (>= netstandard2.0)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (6.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= netcoreapp2.1)
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
-      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Text.Encodings.Web (6.0) - restriction: || (>= net472) (>= netcoreapp2.1)
-      System.Buffers (>= 4.5.1) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
-      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Text.Json (6.0.5) - restriction: || (>= net472) (>= netcoreapp2.1)
-      Microsoft.Bcl.AsyncInterfaces (>= 6.0) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
-      System.Buffers (>= 4.5.1) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
-      System.Numerics.Vectors (>= 4.5) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
-      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Text.Encodings.Web (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
-      System.ValueTuple (>= 4.5) - restriction: >= net461
-    System.Threading.Tasks (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp1.1) (< netstandard1.5) (>= netstandard2.0)) (&& (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Dataflow (6.0) - restriction: >= netstandard2.0
-    System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (>= net461) (>= netcoreapp2.1)) (>= net472) (&& (>= netcoreapp2.1) (< netcoreapp3.1)) (&& (>= netcoreapp2.1) (< netstandard2.1)) (&& (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1))
+    System.Security.Cryptography.Pkcs (8.0) - restriction: || (&& (< net462) (>= netstandard2.0)) (&& (< net472) (>= netstandard2.0)) (>= net6.0)
+      System.Buffers (>= 4.5.1) - restriction: && (< net462) (>= netstandard2.0) (< netstandard2.1)
+      System.Formats.Asn1 (>= 8.0) - restriction: || (&& (< net462) (>= netstandard2.0)) (>= netstandard2.1)
+      System.Memory (>= 4.5.5) - restriction: && (< net462) (>= netstandard2.0) (< netstandard2.1)
+      System.Security.Cryptography.Cng (>= 5.0) - restriction: || (&& (< net462) (>= netstandard2.0) (< netstandard2.1)) (&& (< net6.0) (>= netstandard2.1))
+    System.Security.Cryptography.ProtectedData (8.0) - restriction: || (&& (< net462) (>= net472)) (&& (>= net472) (>= net6.0)) (&& (< net472) (>= netstandard2.0)) (>= net8.0)
+    System.Security.Cryptography.Xml (8.0.1) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net8.0)
+      System.Memory (>= 4.5.5) - restriction: && (< net462) (< net6.0) (>= netstandard2.0)
+      System.Security.AccessControl (>= 6.0) - restriction: && (< net462) (< net6.0) (>= netstandard2.0)
+      System.Security.Cryptography.Pkcs (>= 8.0) - restriction: || (&& (< net462) (>= netstandard2.0)) (>= net6.0)
+    System.Security.Principal.Windows (5.0) - restriction: || (&& (>= net461) (< net462) (>= netstandard2.0)) (&& (>= net461) (>= net8.0)) (&& (< net462) (< net6.0) (>= netstandard2.0)) (>= net472) (&& (< net6.0) (>= net8.0)) (&& (< net8.0) (>= netstandard2.0))
+    System.Text.Encoding.CodePages (8.0) - restriction: && (< net472) (< net8.0) (>= netstandard2.0)
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net462) (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0))
+    System.Text.Encodings.Web (8.0) - restriction: >= net472
+      System.Buffers (>= 4.5.1) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net462) (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0))
+    System.Text.Json (8.0.4) - restriction: || (>= net472) (&& (< net5.0) (>= netstandard2.0))
+      Microsoft.Bcl.AsyncInterfaces (>= 8.0) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Buffers (>= 4.5.1) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net462) (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0))
+      System.Text.Encodings.Web (>= 8.0) - restriction: || (>= net462) (>= netstandard2.0)
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.ValueTuple (>= 4.5) - restriction: >= net462
+    System.Threading.Tasks.Dataflow (8.0.1) - restriction: || (>= net472) (&& (< net8.0) (>= netstandard2.0))
+    System.Threading.Tasks.Extensions (4.5.4) - restriction: || (>= net472) (&& (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1))
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.1)) (>= net472)
-    System.Windows.Extensions (6.0) - restriction: >= netcoreapp3.1
-      System.Drawing.Common (>= 6.0) - restriction: >= netcoreapp3.1
+    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (>= netstandard2.0)) (>= net472)
 
 GROUP Test
-RESTRICTION: == net6.0
+RESTRICTION: == net8.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
     FsCheck (2.15.1)
@@ -345,26 +324,24 @@ NUGET
       FSharp.Core (>= 4.3.4)
       NETStandard.Library (>= 2.0.3)
       NUnit (>= 3.13 < 4.0)
-    GitHubActionsTestLogger (2.0.1)
-      Microsoft.TestPlatform.ObjectModel (>= 17.2)
-    Microsoft.CodeCoverage (17.3)
-    Microsoft.NET.Test.Sdk (17.3)
-      Microsoft.CodeCoverage (>= 17.3)
-      Microsoft.TestPlatform.TestHost (>= 17.3)
+    GitHubActionsTestLogger (2.4.1)
+      Microsoft.TestPlatform.ObjectModel (>= 17.10)
+    Microsoft.CodeCoverage (17.11.1)
+    Microsoft.NET.Test.Sdk (17.11.1)
+      Microsoft.CodeCoverage (>= 17.11.1)
+      Microsoft.TestPlatform.TestHost (>= 17.11.1)
     Microsoft.NETCore.Platforms (6.0.5)
-    Microsoft.TestPlatform.ObjectModel (17.3)
-      NuGet.Frameworks (>= 5.11)
+    Microsoft.TestPlatform.ObjectModel (17.11.1)
       System.Reflection.Metadata (>= 1.6)
-    Microsoft.TestPlatform.TestHost (17.3)
-      Microsoft.TestPlatform.ObjectModel (>= 17.3)
-      Newtonsoft.Json (>= 9.0.1)
+    Microsoft.TestPlatform.TestHost (17.11.1)
+      Microsoft.TestPlatform.ObjectModel (>= 17.11.1)
+      Newtonsoft.Json (>= 13.0.1)
     NETStandard.Library (2.0.3)
       Microsoft.NETCore.Platforms (>= 1.1)
     Newtonsoft.Json (13.0.1)
-    NuGet.Frameworks (6.3)
     NUnit (3.13.1)
       NETStandard.Library (>= 2.0)
-    NUnit3TestAdapter (4.2.1)
+    NUnit3TestAdapter (4.6)
     System.Collections.Immutable (6.0)
       System.Runtime.CompilerServices.Unsafe (>= 6.0)
     System.Reflection.Metadata (6.0.1)

--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -9,6 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!-- always have tailcalls on for design time compiler add-in to allow repo to compile in DEBUG, see https://github.com/fsprojects/FSharp.Data/issues/1410 -->
     <Tailcalls>true</Tailcalls>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.SDK\src\ProvidedTypes.fsi">

--- a/src/FSharp.Data.DesignTime/WorldBank/WorldBankProvider.fs
+++ b/src/FSharp.Data.DesignTime/WorldBank/WorldBankProvider.fs
@@ -28,7 +28,7 @@ type public WorldBankProvider(cfg: TypeProviderConfig) as this =
     let asm = System.Reflection.Assembly.GetExecutingAssembly()
     let ns = "FSharp.Data"
 
-    let defaultServiceUrl = "http://api.worldbank.org/v2"
+    let defaultServiceUrl = "https://api.worldbank.org/v2"
     let cacheDuration = TimeSpan.FromDays 30.0
     let restCache = createInternetFileCache "WorldBankSchema" cacheDuration
 

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -11,6 +11,7 @@
     <PackagePath>typeproviders</PackagePath>
     <!-- always have tailcalls on for design time compiler add-in to allow repo to compile in DEBUG, see https://github.com/fsprojects/FSharp.Data/issues/1410 -->
     <Tailcalls>true</Tailcalls>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.fs" />

--- a/tests/FSharp.Data.Core.Tests.CSharp/FSharp.Data.Core.Tests.CSharp.csproj
+++ b/tests/FSharp.Data.Core.Tests.CSharp/FSharp.Data.Core.Tests.CSharp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- Tests won't run without this, at least on OSX, see https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/FSharp.Data.Core.Tests/FSharp.Data.Core.Tests.fsproj
+++ b/tests/FSharp.Data.Core.Tests/FSharp.Data.Core.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- Tests won't run without this, at least on OSX, see https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/FSharp.Data.DesignTime.Tests/FSharp.Data.DesignTime.Tests.fsproj
+++ b/tests/FSharp.Data.DesignTime.Tests/FSharp.Data.DesignTime.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Tests won't run without this, at least on OSX, see https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->

--- a/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
@@ -1,6 +1,6 @@
 class WorldBankDataProvider : obj
     static member GetDataContext: () -> WorldBankDataProvider+ServiceTypes+WorldBankDataService
-    (new WorldBankData("http://api.worldbank.org", "World Development Indicators;Global Financial Development"))
+    (new WorldBankData("https://api.worldbank.org", "World Development Indicators;Global Financial Development"))
 
 
 class WorldBankDataProvider+ServiceTypes : obj

--- a/tests/FSharp.Data.Reference.Tests/FSharp.Data.Reference.Tests.fsproj
+++ b/tests/FSharp.Data.Reference.Tests/FSharp.Data.Reference.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Tests won't run without this, at least on OSX, see https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- Tests won't run without this, at least on OSX, see https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
This updates:
- Fake and Paket to latest versions
- Globals.js to build on .NET 8
- Test projects from .NET 6 to .NET 8
- Also build-fixes included what are needed: 
   - WorldBank to https
   - Document generation fix on data source of F1 Season_Calendar
- CI-machine script updated (force-push over few trials)
  