### PR TITLE
Avoid ReadToEnd and use XDocument taking reader instead

### DIFF
--- a/src/FSharp.Data.Xml.Core/XmlRuntime.fs
+++ b/src/FSharp.Data.Xml.Core/XmlRuntime.fs
@@ -56,8 +56,7 @@ type XmlElement =
                                IsError = false)>]
     static member Create(reader: TextReader) =
         use reader = reader
-        let text = reader.ReadToEnd()
-        let element = XDocument.Parse(text, LoadOptions.PreserveWhitespace).Root
+        let element = XDocument.Load(reader, LoadOptions.PreserveWhitespace).Root
         { XElement = element }
 
     /// <exclude />


### PR DESCRIPTION
Avoid ReadToEnd and use XDocument taking reader instead.

Possible fix for #1501
